### PR TITLE
Add product categories and storage management

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -8,6 +8,11 @@ BASE_DIR = os.path.dirname(__file__)
 PRODUCTS_PATH = os.path.join(BASE_DIR, 'data', 'products.json')
 RECIPES_PATH = os.path.join(BASE_DIR, 'data', 'recipes.json')
 
+def apply_defaults(product):
+    product.setdefault('category', 'uncategorized')
+    product.setdefault('storage', 'pantry')
+    return product
+
 def load_json(path):
     with open(path, 'r', encoding='utf-8') as f:
         return json.load(f)
@@ -23,19 +28,29 @@ def index():
 @app.route('/api/products', methods=['GET', 'POST'])
 def products():
     if request.method == 'POST':
-        new_product = request.json
+        new_product = apply_defaults(request.json)
         products = load_json(PRODUCTS_PATH)
         products.append(new_product)
         save_json(PRODUCTS_PATH, products)
         return jsonify(products)
-    return jsonify(load_json(PRODUCTS_PATH))
-
-@app.route('/api/products/<string:name>', methods=['DELETE'])
-def delete_product(name):
     products = load_json(PRODUCTS_PATH)
-    products = [p for p in products if p['name'] != name]
+    products = [apply_defaults(p) for p in products]
+    return jsonify(products)
+
+@app.route('/api/products/<string:name>', methods=['DELETE', 'PUT'])
+def modify_product(name):
+    products = load_json(PRODUCTS_PATH)
+    if request.method == 'DELETE':
+        products = [p for p in products if p['name'] != name]
+        save_json(PRODUCTS_PATH, products)
+        return '', 204
+    updated = apply_defaults(request.json)
+    for i, p in enumerate(products):
+        if p['name'] == name:
+            products[i] = updated
+            break
     save_json(PRODUCTS_PATH, products)
-    return '', 204
+    return jsonify(updated)
 
 @app.route('/api/recipes')
 def recipes():

--- a/app/data/products.json
+++ b/app/data/products.json
@@ -1,5 +1,20 @@
 [
-  {"name": "tofu", "quantity": "2 opakowania", "category": "nabiał"},
-  {"name": "cebula czerwona", "quantity": "1 sztuka", "category": "warzywa"},
-  {"name": "feta", "quantity": "1/2 opakowania", "category": "nabiał"}
+  {
+    "name": "tofu",
+    "quantity": "2 opakowania",
+    "category": "dairy_eggs",
+    "storage": "fridge"
+  },
+  {
+    "name": "cebula czerwona",
+    "quantity": "1 sztuka",
+    "category": "fresh_veg",
+    "storage": "pantry"
+  },
+  {
+    "name": "feta",
+    "quantity": "1/2 opakowania",
+    "category": "dairy_eggs",
+    "storage": "fridge"
+  }
 ]

--- a/app/static/script.js
+++ b/app/static/script.js
@@ -1,3 +1,5 @@
+let editingName = null;
+
 document.addEventListener('DOMContentLoaded', () => {
   loadProducts();
   loadRecipes();
@@ -8,13 +10,23 @@ document.addEventListener('DOMContentLoaded', () => {
     const product = {
       name: form.name.value,
       quantity: form.quantity.value,
-      category: form.category.value
+      category: form.category.value,
+      storage: form.storage.value
     };
-    await fetch('/api/products', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(product)
-    });
+    if (editingName) {
+      await fetch(`/api/products/${encodeURIComponent(editingName)}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(product)
+      });
+    } else {
+      await fetch('/api/products', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(product)
+      });
+    }
+    editingName = null;
     form.reset();
     await loadProducts();
     await loadRecipes();
@@ -33,20 +45,56 @@ async function loadProducts() {
   const res = await fetch('/api/products');
   const data = await res.json();
   window.currentProducts = data;
-  const list = document.getElementById('product-list');
-  list.innerHTML = '';
+  const container = document.getElementById('product-list');
+  container.innerHTML = '';
+
+  const groups = {};
   data.forEach(p => {
-    const li = document.createElement('li');
-    li.textContent = `${p.name} - ${p.quantity} (${p.category}) `;
-    const btn = document.createElement('button');
-    btn.textContent = 'Usuń';
-    btn.addEventListener('click', async () => {
-      await fetch(`/api/products/${encodeURIComponent(p.name)}`, { method: 'DELETE' });
-      await loadProducts();
-      await loadRecipes();
-    });
-    li.appendChild(btn);
-    list.appendChild(li);
+    const storage = p.storage || 'pantry';
+    if (!groups[storage]) groups[storage] = [];
+    groups[storage].push(p);
+  });
+
+  const order = ['fridge', 'pantry', 'freezer'];
+  const titles = {
+    fridge: '🧊 Lodówka',
+    pantry: '🏠 Spiżarnia',
+    freezer: '❄️ Zamrażarka'
+  };
+
+  order.forEach(stor => {
+    if (groups[stor] && groups[stor].length) {
+      const h = document.createElement('h3');
+      h.textContent = titles[stor] || stor;
+      container.appendChild(h);
+      const ul = document.createElement('ul');
+      groups[stor].sort((a, b) => a.category.localeCompare(b.category));
+      groups[stor].forEach(p => {
+        const li = document.createElement('li');
+        li.textContent = `${p.name} - ${p.quantity} (${p.category}) `;
+        const edit = document.createElement('button');
+        edit.textContent = 'Edytuj';
+        edit.addEventListener('click', () => {
+          const form = document.getElementById('add-form');
+          form.name.value = p.name;
+          form.quantity.value = p.quantity;
+          form.category.value = p.category;
+          form.storage.value = p.storage || 'pantry';
+          editingName = p.name;
+        });
+        const del = document.createElement('button');
+        del.textContent = 'Usuń';
+        del.addEventListener('click', async () => {
+          await fetch(`/api/products/${encodeURIComponent(p.name)}`, { method: 'DELETE' });
+          await loadProducts();
+          await loadRecipes();
+        });
+        li.appendChild(edit);
+        li.appendChild(del);
+        ul.appendChild(li);
+      });
+      container.appendChild(ul);
+    }
   });
 }
 

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -6,14 +6,38 @@
 </head>
 <body>
     <h1>Produkty</h1>
-    <ul id="product-list"></ul>
+    <div id="product-list"></div>
 
-    <h2>Dodaj produkt</h2>
+    <h2>Dodaj / edytuj produkt</h2>
     <form id="add-form">
         <input name="name" placeholder="nazwa" required>
         <input name="quantity" placeholder="ilość" required>
-        <input name="category" placeholder="kategoria" required>
-        <button type="submit">Dodaj</button>
+        <select name="category" required>
+            <option value="uncategorized">uncategorized</option>
+            <option value="fresh_veg">fresh_veg</option>
+            <option value="mushrooms">mushrooms</option>
+            <option value="dairy_eggs">dairy_eggs</option>
+            <option value="opened_preserves">opened_preserves</option>
+            <option value="ready_sauces">ready_sauces</option>
+            <option value="dry_veg">dry_veg</option>
+            <option value="bread">bread</option>
+            <option value="pasta">pasta</option>
+            <option value="rice">rice</option>
+            <option value="grains">grains</option>
+            <option value="dried_legumes">dried_legumes</option>
+            <option value="sauces">sauces</option>
+            <option value="oils">oils</option>
+            <option value="spreads">spreads</option>
+            <option value="frozen_veg">frozen_veg</option>
+            <option value="frozen_sauces">frozen_sauces</option>
+            <option value="frozen_meals">frozen_meals</option>
+        </select>
+        <select name="storage" required>
+            <option value="fridge">fridge</option>
+            <option value="pantry" selected>pantry</option>
+            <option value="freezer">freezer</option>
+        </select>
+        <button type="submit">Zapisz</button>
     </form>
 
     <button id="copy-btn">Kopiuj jako prompt</button>


### PR DESCRIPTION
## Summary
- extend products with category and storage defaults
- support editing and grouping products by storage in UI
- add select inputs for category and storage in forms

## Testing
- `python -m py_compile app/app.py`


------
https://chatgpt.com/codex/tasks/task_e_688f706f816c832a9e94a9e628e8ca81