### PR TITLE
Fix missing date import after merge

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -1,4 +1,5 @@
 from flask import Flask, render_template, request, jsonify
+from datetime import date
 import json
 import os
 


### PR DESCRIPTION
## Summary
- import `date` in `app.py` to support history entry timestamps

## Testing
- `python -m py_compile app/app.py`
- `node --check app/static/script.js`


------
https://chatgpt.com/codex/tasks/task_e_688f73218564832aba0364761975cc36