### PR TITLE
Add Polish translations for categories and storage

### DIFF
--- a/app/static/script.js
+++ b/app/static/script.js
@@ -3,6 +3,32 @@ let editingName = null;
 const UNIT = 'szt.';
 const LOW_STOCK_THRESHOLD = 1; // TODO: thresholds per category
 
+const CATEGORY_NAMES = {
+  fresh_veg: 'Świeże warzywa',
+  mushrooms: 'Grzyby',
+  dairy_eggs: 'Nabiał i jajka',
+  opened_preserves: 'Otwarte konserwy i przetwory',
+  ready_sauces: 'Gotowe sosy',
+  dry_veg: 'Warzywa suche',
+  bread: 'Pieczywo',
+  pasta: 'Makarony',
+  rice: 'Ryże',
+  grains: 'Kasze',
+  dried_legumes: 'Suche rośliny strączkowe',
+  sauces: 'Sosy i przyprawy płynne',
+  oils: 'Oleje',
+  spreads: 'Smarowidła i pasty',
+  frozen_veg: 'Mrożone warzywa',
+  frozen_sauces: 'Mrożone sosy',
+  frozen_meals: 'Mrożone dania / zupy'
+};
+
+const STORAGE_NAMES = {
+  fridge: 'Lodówka',
+  pantry: 'Szafka',
+  freezer: 'Zamrażarka'
+};
+
 document.addEventListener('DOMContentLoaded', () => {
   loadProducts();
   loadRecipes();
@@ -95,9 +121,9 @@ async function loadProducts() {
 
   const order = ['fridge', 'pantry', 'freezer'];
   const titles = {
-    fridge: '🧊 Lodówka',
-    pantry: '🏠 Spiżarnia',
-    freezer: '❄️ Zamrażarka'
+    fridge: `🧊 ${STORAGE_NAMES.fridge}`,
+    pantry: `🏠 ${STORAGE_NAMES.pantry}`,
+    freezer: `❄️ ${STORAGE_NAMES.freezer}`
   };
 
   order.forEach(stor => {
@@ -109,7 +135,8 @@ async function loadProducts() {
       groups[stor].sort((a, b) => a.category.localeCompare(b.category));
       groups[stor].forEach(p => {
         const li = document.createElement('li');
-        li.textContent = `${p.name} - ${p.quantity} (${p.category}) `;
+        const catName = CATEGORY_NAMES[p.category] || p.category;
+        li.textContent = `${p.name} - ${p.quantity} (${catName}) `;
         const edit = document.createElement('button');
         edit.textContent = 'Edytuj';
         edit.addEventListener('click', () => {

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -36,28 +36,28 @@
         <input name="quantity" placeholder="ilość" required>
         <select name="category" required>
             <option value="uncategorized">uncategorized</option>
-            <option value="fresh_veg">fresh_veg</option>
-            <option value="mushrooms">mushrooms</option>
-            <option value="dairy_eggs">dairy_eggs</option>
-            <option value="opened_preserves">opened_preserves</option>
-            <option value="ready_sauces">ready_sauces</option>
-            <option value="dry_veg">dry_veg</option>
-            <option value="bread">bread</option>
-            <option value="pasta">pasta</option>
-            <option value="rice">rice</option>
-            <option value="grains">grains</option>
-            <option value="dried_legumes">dried_legumes</option>
-            <option value="sauces">sauces</option>
-            <option value="oils">oils</option>
-            <option value="spreads">spreads</option>
-            <option value="frozen_veg">frozen_veg</option>
-            <option value="frozen_sauces">frozen_sauces</option>
-            <option value="frozen_meals">frozen_meals</option>
+            <option value="fresh_veg">Świeże warzywa</option>
+            <option value="mushrooms">Grzyby</option>
+            <option value="dairy_eggs">Nabiał i jajka</option>
+            <option value="opened_preserves">Otwarte konserwy i przetwory</option>
+            <option value="ready_sauces">Gotowe sosy</option>
+            <option value="dry_veg">Warzywa suche</option>
+            <option value="bread">Pieczywo</option>
+            <option value="pasta">Makarony</option>
+            <option value="rice">Ryże</option>
+            <option value="grains">Kasze</option>
+            <option value="dried_legumes">Suche rośliny strączkowe</option>
+            <option value="sauces">Sosy i przyprawy płynne</option>
+            <option value="oils">Oleje</option>
+            <option value="spreads">Smarowidła i pasty</option>
+            <option value="frozen_veg">Mrożone warzywa</option>
+            <option value="frozen_sauces">Mrożone sosy</option>
+            <option value="frozen_meals">Mrożone dania / zupy</option>
         </select>
         <select name="storage" required>
-            <option value="fridge">fridge</option>
-            <option value="pantry" selected>pantry</option>
-            <option value="freezer">freezer</option>
+            <option value="fridge">Lodówka</option>
+            <option value="pantry" selected>Szafka</option>
+            <option value="freezer">Zamrażarka</option>
         </select>
         <button type="submit">Zapisz</button>
     </form>


### PR DESCRIPTION
## Summary
- translate category and storage options into Polish
- show translated names when listing products

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688f7ab06510832a80361da1ecb66abc