### PR TITLE
Add grouped product display by storage and category

### DIFF
--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -18,6 +18,7 @@
 </head>
 <body>
     <h1>Produkty</h1>
+    <button id="view-toggle">Widok z podziałem</button>
     <table id="product-table">
         <thead>
             <tr>
@@ -29,6 +30,7 @@
         </thead>
         <tbody></tbody>
     </table>
+    <div id="product-list" style="display:none;"></div>
 
     <h2>Dodaj / edytuj produkt</h2>
     <form id="add-form">


### PR DESCRIPTION
## Summary
- add view-toggle button and grouped product container
- group products by storage, category and subcategory with translated headers
- enable switching between flat and grouped views

## Testing
- `python -m py_compile app/app.py`


------
https://chatgpt.com/codex/tasks/task_e_688f7dee426c832a87cd724c02625f64