### PR TITLE
Add grouped product display by storage and category

### DIFF
--- a/app/static/script.js
+++ b/app/static/script.js
@@ -1,4 +1,5 @@
 let editingName = null;
+let groupedView = false;
 
 const UNIT = 'szt.';
 const LOW_STOCK_THRESHOLD = 1; // TODO: thresholds per category
@@ -78,18 +79,19 @@ document.addEventListener('DOMContentLoaded', () => {
     form.style.display = 'none';
   });
   document.getElementById('add-ingredient').addEventListener('click', () => addIngredientRow());
+  document.getElementById('view-toggle').addEventListener('click', () => {
+    groupedView = !groupedView;
+    document.getElementById('product-table').style.display = groupedView ? 'none' : 'table';
+    document.getElementById('product-list').style.display = groupedView ? 'block' : 'none';
+    document.getElementById('view-toggle').textContent = groupedView ? 'Płaska lista' : 'Widok z podziałem';
+  });
 });
 
 async function loadProducts() {
   const res = await fetch('/api/products');
   const data = await res.json();
   window.currentProducts = data;
-  const container = document.getElementById('product-list');
-  if (container) {
-    container.innerHTML = '';
-  }
 
-  const groups = {};
   const tbody = document.querySelector('#product-table tbody');
   tbody.innerHTML = '';
   data.forEach(p => {
@@ -117,57 +119,89 @@ async function loadProducts() {
     actionTd.appendChild(btn);
     tr.appendChild(actionTd);
     tbody.appendChild(tr);
-    if (container) {
-      const storage = p.storage || 'pantry';
-      if (!groups[storage]) groups[storage] = [];
-      groups[storage].push(p);
-    }
   });
 
-  if (container) {
-    const order = ['fridge', 'pantry', 'freezer'];
-    const titles = {
-      fridge: `🧊 ${STORAGE_NAMES.fridge}`,
-      pantry: `🏠 ${STORAGE_NAMES.pantry}`,
-      freezer: `❄️ ${STORAGE_NAMES.freezer}`
-    };
+  const container = document.getElementById('product-list');
+  container.innerHTML = '';
+  const storages = {};
+  data.forEach(p => {
+    const storage = p.storage || 'pantry';
+    const cat = p.category || 'uncategorized';
+    storages[storage] ??= {};
+    storages[storage][cat] ??= [];
+    storages[storage][cat].push(p);
+  });
 
-    order.forEach(stor => {
-      if (groups[stor] && groups[stor].length) {
-        const h = document.createElement('h3');
-        h.textContent = titles[stor] || stor;
-        container.appendChild(h);
-        const ul = document.createElement('ul');
-        groups[stor].sort((a, b) => a.category.localeCompare(b.category));
-        groups[stor].forEach(p => {
-          const li = document.createElement('li');
-            const catName = CATEGORY_NAMES[p.category] || p.category;
-            li.textContent = `${p.name} - ${p.quantity} (${catName}) `;
-          const edit = document.createElement('button');
-          edit.textContent = 'Edytuj';
-          edit.addEventListener('click', () => {
-            const form = document.getElementById('add-form');
-            form.name.value = p.name;
-            form.quantity.value = p.quantity;
-            form.category.value = p.category;
-            form.storage.value = p.storage || 'pantry';
-            editingName = p.name;
-          });
-          const del = document.createElement('button');
-          del.textContent = 'Usuń';
-          del.addEventListener('click', async () => {
-            await fetch(`/api/products/${encodeURIComponent(p.name)}`, { method: 'DELETE' });
-            await loadProducts();
-            await loadRecipes();
-          });
-          li.appendChild(edit);
-          li.appendChild(del);
-          ul.appendChild(li);
+  const order = ['fridge', 'pantry', 'freezer'];
+  const titles = {
+    fridge: `🧊 ${STORAGE_NAMES.fridge}`,
+    pantry: `🏠 ${STORAGE_NAMES.pantry}`,
+    freezer: `❄️ ${STORAGE_NAMES.freezer}`
+  };
+
+  order.forEach(stor => {
+    if (!storages[stor]) return;
+    const h3 = document.createElement('h3');
+    h3.textContent = titles[stor] || stor;
+    container.appendChild(h3);
+    const categories = storages[stor];
+    Object.keys(categories).sort().forEach(cat => {
+      const h4 = document.createElement('h4');
+      h4.textContent = CATEGORY_NAMES[cat] || cat;
+      container.appendChild(h4);
+      const table = document.createElement('table');
+      const thead = document.createElement('thead');
+      const headRow = document.createElement('tr');
+      ['Nazwa', 'Ilość', 'Jednostka', ''].forEach(text => {
+        const th = document.createElement('th');
+        th.textContent = text;
+        headRow.appendChild(th);
+      });
+      thead.appendChild(headRow);
+      table.appendChild(thead);
+      const tbodyCat = document.createElement('tbody');
+      categories[cat].sort((a, b) => a.name.localeCompare(b.name));
+      categories[cat].forEach(p => {
+        const tr = document.createElement('tr');
+        if (p.quantity <= LOW_STOCK_THRESHOLD) {
+          tr.classList.add('low-stock');
+        }
+        const nameTd = document.createElement('td');
+        nameTd.textContent = p.name;
+        tr.appendChild(nameTd);
+        const qtyTd = document.createElement('td');
+        qtyTd.textContent = p.quantity;
+        tr.appendChild(qtyTd);
+        const unitTd = document.createElement('td');
+        unitTd.textContent = p.unit;
+        tr.appendChild(unitTd);
+        const actionTd = document.createElement('td');
+        const edit = document.createElement('button');
+        edit.textContent = 'Edytuj';
+        edit.addEventListener('click', () => {
+          const form = document.getElementById('add-form');
+          form.name.value = p.name;
+          form.quantity.value = p.quantity;
+          form.category.value = p.category;
+          form.storage.value = p.storage || 'pantry';
+          editingName = p.name;
         });
-        container.appendChild(ul);
-      }
+        const del = document.createElement('button');
+        del.textContent = 'Usuń';
+        del.addEventListener('click', async () => {
+          await fetch(`/api/products/${encodeURIComponent(p.name)}`, { method: 'DELETE' });
+          await loadProducts();
+          await loadRecipes();
+        });
+        actionTd.appendChild(edit);
+        actionTd.appendChild(del);
+        tr.appendChild(actionTd);
+        tbodyCat.appendChild(tr);
+      });
+      table.appendChild(tbodyCat);
+      container.appendChild(table);
     });
-  }
+  });
 }
 
 async function loadRecipes() {

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -18,6 +18,7 @@
 </head>
 <body>
     <h1>Produkty</h1>
+    <button id="view-toggle">Widok z podziałem</button>
     <table id="product-table">
         <thead>
             <tr>
@@ -29,6 +30,7 @@
         </thead>
         <tbody></tbody>
     </table>
+    <div id="product-list" style="display:none;"></div>
 
     <h2>Dodaj / edytuj produkt</h2>
     <form id="add-form">


### PR DESCRIPTION
## Summary
- add view-toggle button and grouped product container
- group products by storage and category using table displays
- enable switching between flat and grouped views

## Testing
- `python -m py_compile app/app.py`


------
https://chatgpt.com/codex/tasks/task_e_688f7dee426c832a87cd724c02625f64