### PR TITLE
Ensure product list renders in older browsers

### DIFF
--- a/app/static/script.js
+++ b/app/static/script.js
@@ -128,8 +128,12 @@ async function loadProducts() {
   data.forEach(p => {
     const storage = p.storage || 'pantry';
     const cat = p.category || 'uncategorized';
-    storages[storage] ??= {};
-    storages[storage][cat] ??= [];
+    if (!storages[storage]) {
+      storages[storage] = {};
+    }
+    if (!storages[storage][cat]) {
+      storages[storage][cat] = [];
+    }
     storages[storage][cat].push(p);
   });
 


### PR DESCRIPTION
## Summary
- avoid modern JavaScript operators when grouping products so lists show in more browsers

## Testing
- `node --check app/static/script.js`
- `python -m py_compile app/app.py`


------
https://chatgpt.com/codex/tasks/task_e_688f8a99e2c4832a9dd67e2a5f88c78d