### PR TITLE
Add global edit action for products

### DIFF
--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -19,6 +19,7 @@
 <body>
     <h1>Produkty</h1>
     <button id="view-toggle">Widok z podziałem</button>
+    <button id="edit-any">Edytuj</button>
     <table id="product-table">
         <thead>
             <tr>


### PR DESCRIPTION
## Summary
- add global edit button for product lists to update any product's quantity
- simplify product form to update existing entries automatically
- remove per-item edit buttons in grouped view

## Testing
- `python -m py_compile app/app.py`


------
https://chatgpt.com/codex/tasks/task_e_688f8d0a56c8832aae9b25e00500e478