### PR TITLE
Add product search bar

### DIFF
--- a/app/static/script.js
+++ b/app/static/script.js
@@ -86,13 +86,25 @@ document.addEventListener('DOMContentLoaded', () => {
     document.getElementById('product-list').style.display = groupedView ? 'block' : 'none';
     document.getElementById('view-toggle').textContent = groupedView ? 'Płaska lista' : 'Widok z podziałem';
   });
+  document.getElementById('product-search').addEventListener('input', () => {
+    renderProducts(getFilteredProducts());
+  });
 });
 
 async function loadProducts() {
   const res = await fetch('/api/products');
-  const data = await res.json();
-  window.currentProducts = data;
+  window.currentProducts = await res.json();
+  renderProducts(getFilteredProducts());
+}
 
+function getFilteredProducts() {
+  const query = document.getElementById('product-search').value.toLowerCase();
+  return (window.currentProducts || []).filter(p =>
+    p.name.toLowerCase().includes(query)
+  );
+}
+
+function renderProducts(data) {
   const tbody = document.querySelector('#product-table tbody');
   tbody.innerHTML = '';
   data.forEach(p => {

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -18,6 +18,7 @@
 </head>
 <body>
     <h1>Produkty</h1>
+    <input id="product-search" placeholder="Szukaj produktu">
     <button id="view-toggle">Widok z podziałem</button>
     <table id="product-table">
         <thead>


### PR DESCRIPTION
## Summary
- Add product search input under the products header.
- Filter product list on the client-side as the user types.

## Testing
- `node --check app/static/script.js`
- `python -m py_compile app/app.py`
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_688f8d39b4f0832aa4708328c61625e2