### PR TITLE
feat: merge duplicate products and add bulk edit

### DIFF
--- a/app/static/script.js
+++ b/app/static/script.js
@@ -1,4 +1,4 @@
-let editingName = null;
+let editing = false;
 let groupedView = false;
 
 const UNIT = 'szt.';
@@ -47,8 +47,8 @@ document.addEventListener('DOMContentLoaded', () => {
       storage: form.storage.value,
       unit: UNIT
     };
-    if (editingName) {
-      await fetch(`/api/products/${encodeURIComponent(editingName)}`, {
+    if (editing) {
+      await fetch('/api/products', {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(product)
@@ -60,7 +60,7 @@ document.addEventListener('DOMContentLoaded', () => {
         body: JSON.stringify(product)
       });
     }
-    editingName = null;
+    editing = false;
     form.reset();
     await loadProducts();
     await loadRecipes();
@@ -191,7 +191,7 @@ async function loadProducts() {
             form.quantity.value = p.quantity;
             form.category.value = p.category;
             form.storage.value = p.storage || 'pantry';
-            editingName = p.name;
+            editing = true;
           });
           const del = document.createElement('button');
           del.textContent = 'Usuń';


### PR DESCRIPTION
## Summary
- sum quantities when adding products with same name/category/storage
- allow bulk product updates via JSON payload
- adjust frontend to use unified product endpoint

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688f8e458d14832aa25c9396d6d479db