### PR TITLE
Enable inline editing for products

### DIFF
--- a/app/static/script.js
+++ b/app/static/script.js
@@ -73,30 +73,6 @@ document.addEventListener('DOMContentLoaded', () => {
     form.style.display = 'none';
   });
   document.getElementById('add-ingredient').addEventListener('click', () => addIngredientRow());
-  document.getElementById('edit-any').addEventListener('click', async () => {
-    const name = prompt('Nazwa produktu:');
-    if (!name) return;
-    const product = (window.currentProducts || []).find(p => p.name === name);
-    if (!product) {
-      alert('Nie znaleziono produktu');
-      return;
-    }
-    const qtyStr = prompt('Nowa ilość:', product.quantity);
-    if (qtyStr === null) return;
-    const quantity = parseFloat(qtyStr);
-    if (isNaN(quantity)) {
-      alert('Nieprawidłowa ilość');
-      return;
-    }
-    const updated = { ...product, quantity };
-    await fetch(`/api/products/${encodeURIComponent(name)}`, {
-      method: 'PUT',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(updated)
-    });
-    await loadProducts();
-    await loadRecipes();
-  });
   document.getElementById('view-toggle').addEventListener('click', () => {
     groupedView = !groupedView;
     document.getElementById('product-table').style.display = groupedView ? 'none' : 'table';
@@ -121,6 +97,64 @@ function getFilteredProducts() {
   );
 }
 
+function enableEdit(tr, product) {
+  const nameTd = tr.children[0];
+  const qtyTd = tr.children[1];
+  const actionTd = tr.children[3];
+
+  const nameInput = document.createElement('input');
+  nameInput.value = product.name;
+  nameTd.innerHTML = '';
+  nameTd.appendChild(nameInput);
+
+  const qtyInput = document.createElement('input');
+  qtyInput.type = 'number';
+  qtyInput.value = product.quantity;
+  qtyTd.innerHTML = '';
+  qtyTd.appendChild(qtyInput);
+
+  actionTd.innerHTML = '';
+  const save = document.createElement('button');
+  save.textContent = 'Zapisz';
+  save.addEventListener('click', async () => {
+    const updated = { ...product, name: nameInput.value.trim(), quantity: parseFloat(qtyInput.value) };
+    await fetch(`/api/products/${encodeURIComponent(product.name)}`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(updated)
+    });
+    await loadProducts();
+    await loadRecipes();
+  });
+
+  const cancel = document.createElement('button');
+  cancel.textContent = 'Anuluj';
+  cancel.addEventListener('click', () => {
+    renderProducts(getFilteredProducts());
+  });
+
+  actionTd.appendChild(save);
+  actionTd.appendChild(cancel);
+}
+
+function addRowActions(tr, product) {
+  const actionTd = document.createElement('td');
+  const edit = document.createElement('button');
+  edit.textContent = 'Edytuj';
+  edit.addEventListener('click', () => enableEdit(tr, product));
+  actionTd.appendChild(edit);
+
+  const del = document.createElement('button');
+  del.textContent = 'Usuń';
+  del.addEventListener('click', async () => {
+    await fetch(`/api/products/${encodeURIComponent(product.name)}`, { method: 'DELETE' });
+    await loadProducts();
+    await loadRecipes();
+  });
+  actionTd.appendChild(del);
+  tr.appendChild(actionTd);
+}
+
 function renderProducts(data) {
   const tbody = document.querySelector('#product-table tbody');
   tbody.innerHTML = '';
@@ -138,16 +172,7 @@ function renderProducts(data) {
     const unitTd = document.createElement('td');
     unitTd.textContent = p.unit;
     tr.appendChild(unitTd);
-    const actionTd = document.createElement('td');
-    const btn = document.createElement('button');
-    btn.textContent = 'Usuń';
-    btn.addEventListener('click', async () => {
-      await fetch(`/api/products/${encodeURIComponent(p.name)}`, { method: 'DELETE' });
-      await loadProducts();
-      await loadRecipes();
-    });
-    actionTd.appendChild(btn);
-    tr.appendChild(actionTd);
+    addRowActions(tr, p);
     tbody.appendChild(tr);
   });
 
@@ -211,16 +236,7 @@ function renderProducts(data) {
           const unitTd = document.createElement('td');
           unitTd.textContent = p.unit;
           tr.appendChild(unitTd);
-          const actionTd = document.createElement('td');
-          const del = document.createElement('button');
-          del.textContent = 'Usuń';
-          del.addEventListener('click', async () => {
-            await fetch(`/api/products/${encodeURIComponent(p.name)}`, { method: 'DELETE' });
-            await loadProducts();
-            await loadRecipes();
-          });
-          actionTd.appendChild(del);
-          tr.appendChild(actionTd);
+          addRowActions(tr, p);
           tbodyCat.appendChild(tr);
         });
         table.appendChild(tbodyCat);

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -20,7 +20,6 @@
     <h1>Produkty</h1>
     <input id="product-search" placeholder="Szukaj produktu">
     <button id="view-toggle">Widok z podziałem</button>
-    <button id="edit-any">Edytuj</button>
     <table id="product-table">
         <thead>
             <tr>


### PR DESCRIPTION
## Summary
- allow editing product name and quantity directly in table rows
- remove global edit button that relied on pop-up prompts

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688f8eb17ae4832a9d73aae0f40d3f7a