### PR TITLE
refactor: adjust theme toggle and layout

### DIFF
--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -6,8 +6,8 @@
     <link href="https://cdn.jsdelivr.net/npm/daisyui@4.10.2/dist/full.min.css" rel="stylesheet" type="text/css" />
 </head>
 <body class="min-h-screen bg-base-100">
-    <div class="flex justify-end p-4">
-        <button id="theme-toggle" class="btn btn-circle btn-ghost">🌞</button>
+    <div class="flex justify-end max-w-screen-lg mx-auto p-4">
+        <button id="theme-toggle" class="text-xl p-2 bg-transparent border-0">🌞</button>
     </div>
     <div class="max-w-screen-lg mx-auto px-4 py-6">
         <h1 class="text-2xl font-bold mb-4">Produkty</h1>


### PR DESCRIPTION
## Summary
- show dark/light toggle as a plain icon without button colors
- align theme toggle with main content to keep right-side spacing

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_688fa4a6b308832a8b42d86880c406f2