### PR TITLE
Exit edit mode after saving products

### DIFF
--- a/app/static/script.js
+++ b/app/static/script.js
@@ -130,8 +130,11 @@ document.addEventListener('DOMContentLoaded', () => {
         body: JSON.stringify(u.updated)
       });
     }
+    editMode = false;
+    document.getElementById('edit-toggle').textContent = 'Edytuj';
+    document.getElementById('save-btn').style.display = 'none';
+    await loadProducts();
     if (updates.length) {
-      await loadProducts();
       await loadRecipes();
     }
   });


### PR DESCRIPTION
## Summary
- reset edit mode after saving edited products
- refresh product and recipe lists when changes are saved

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688fa4e69794832a8d3792911382cffb