### PR TITLE
Use solid sun and moon icons for theme toggle

### DIFF
--- a/app/static/script.js
+++ b/app/static/script.js
@@ -417,12 +417,13 @@ async function handleHistorySubmit(e) {
 
 // Theme toggle
 const themeToggle = document.getElementById('theme-toggle');
-if (themeToggle) {
+const themeIcon = document.getElementById('theme-icon');
+if (themeToggle && themeIcon) {
   themeToggle.addEventListener('click', () => {
     const html = document.documentElement;
     const current = html.getAttribute('data-theme');
     const next = current === 'dark' ? 'light' : 'dark';
     html.setAttribute('data-theme', next);
-    themeToggle.textContent = next === 'dark' ? '🌞' : '🌙';
+    themeIcon.className = next === 'dark' ? 'fa-solid fa-sun' : 'fa-solid fa-moon';
   });
 }

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -4,10 +4,11 @@
     <meta charset="utf-8">
     <title>Food App</title>
     <link href="https://cdn.jsdelivr.net/npm/daisyui@4.10.2/dist/full.min.css" rel="stylesheet" type="text/css" />
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css">
 </head>
 <body class="min-h-screen bg-base-100">
     <div class="flex justify-end max-w-screen-lg mx-auto p-4">
-        <button id="theme-toggle" class="text-xl p-2 bg-transparent border-0">🌞</button>
+        <button id="theme-toggle" class="text-xl p-2 bg-transparent border-0"><i id="theme-icon" class="fa-solid fa-sun"></i></button>
     </div>
     <div class="max-w-screen-lg mx-auto px-4 py-6">
         <h1 class="text-2xl font-bold mb-4">Produkty</h1>


### PR DESCRIPTION
## Summary
- load Font Awesome and display the solid sun icon in the theme toggle button
- switch the theme toggle script to swap between solid sun and moon icons for dark/light modes

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688fa629bef0832ab438f5d8032f0475