### PR TITLE
Fix desktop layout and icon placement

### DIFF
--- a/app/static/styles.css
+++ b/app/static/styles.css
@@ -4,6 +4,27 @@ html[data-layout="mobile"] .main-container {
   padding-right: 1rem;
 }
 
+html[data-layout="desktop"] .main-container {
+  max-width: 1024px;
+  margin-left: auto;
+  margin-right: auto;
+  padding-left: 1rem;
+  padding-right: 1rem;
+}
+
+.corner-icons {
+  position: fixed;
+  top: 1rem;
+  right: 1rem;
+  display: flex;
+  gap: 1rem;
+}
+
+html[data-layout="mobile"] .corner-icons {
+  left: 1rem;
+  right: auto;
+}
+
 html[data-layout="mobile"] #controls {
   flex-direction: column;
   align-items: stretch;

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -7,8 +7,8 @@
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css">
     <link rel="stylesheet" href="{{ url_for('static', filename='styles.css') }}">
 </head>
-<body class="min-h-screen bg-base-100 pr-4">
-    <div class="fixed top-4 right-4 flex gap-4">
+<body class="min-h-screen bg-base-100">
+    <div class="corner-icons">
         <button id="layout-toggle" class="text-xl p-2 bg-transparent border-0"><i id="layout-icon" class="fa-solid fa-mobile-screen-button"></i></button>
         <button id="theme-toggle" class="text-xl p-2 bg-transparent border-0"><i id="theme-icon" class="fa-solid fa-circle-half-stroke"></i></button>
     </div>


### PR DESCRIPTION
## Summary
- Ensure main content is properly centered on desktop layout
- Anchor layout/theme toggle icons in the top-right corner with CSS

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688faa6fc070832ab1566da195bec2d4