### PR TITLE
Align mobile corner icons to top-right

### DIFF
--- a/app/static/styles.css
+++ b/app/static/styles.css
@@ -21,8 +21,8 @@ html[data-layout="desktop"] .main-container {
 }
 
 html[data-layout="mobile"] .corner-icons {
-  left: 1rem;
-  right: auto;
+  left: auto;
+  right: 1rem;
 }
 
 html[data-layout="mobile"] #controls {


### PR DESCRIPTION
## Summary
- Ensure corner icons stay on the right side in mobile layout

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688fabc5f64c832ab98c822659679d63