### PR TITLE
Improve mobile layout

### DIFF
--- a/app/static/script.js
+++ b/app/static/script.js
@@ -53,6 +53,13 @@ function sortProducts(list) {
 }
 
 document.addEventListener('DOMContentLoaded', () => {
+  const html = document.documentElement;
+  const icon = document.getElementById('layout-icon');
+  if (window.innerWidth < 768) {
+    html.setAttribute('data-layout', 'mobile');
+    if (icon) icon.className = 'fa-solid fa-desktop';
+  }
+
   loadProducts();
   loadRecipes();
   loadHistory();

--- a/app/static/styles.css
+++ b/app/static/styles.css
@@ -38,3 +38,26 @@ html[data-layout="mobile"] #product-table th:nth-child(n+4),
 html[data-layout="mobile"] #product-table td:nth-child(n+4) {
   display: none;
 }
+
+html[data-layout="mobile"] {
+  font-size: 150%;
+}
+
+html[data-layout="mobile"] #product-table th,
+html[data-layout="mobile"] #product-table td,
+html[data-layout="mobile"] #product-list,
+html[data-layout="mobile"] #recipe-list,
+html[data-layout="mobile"] #history-list {
+  font-size: 1em;
+}
+
+html[data-layout="mobile"] #product-table th,
+html[data-layout="mobile"] #product-table td {
+  padding-top: 1rem;
+  padding-bottom: 1rem;
+}
+
+html[data-layout="mobile"] button {
+  font-size: 1em;
+  padding: 0.75rem 1rem;
+}

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -2,6 +2,7 @@
 <html lang="pl" data-theme="dark" data-layout="desktop">
 <head>
     <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Food App</title>
     <link href="https://cdn.jsdelivr.net/npm/daisyui@4.10.2/dist/full.min.css" rel="stylesheet" type="text/css" />
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css">


### PR DESCRIPTION
## Summary
- support mobile scaling with viewport metadata
- auto-enable mobile layout on small screens
- enlarge typography and controls for better touch ergonomics

## Testing
- `pytest`
- `python -m py_compile app/app.py`


------
https://chatgpt.com/codex/tasks/task_e_688fac9bebe4832a8c29ad8ead856ec6