### PR TITLE
Align corner icons with header on mobile layout

### DIFF
--- a/app/static/styles.css
+++ b/app/static/styles.css
@@ -21,6 +21,7 @@ html[data-layout="desktop"] .main-container {
 }
 
 html[data-layout="mobile"] .corner-icons {
+  top: 0.5rem;
   left: auto;
   right: 1rem;
 }


### PR DESCRIPTION
## Summary
- Adjust mobile CSS so corner icons sit above the search bar at the same height as the "Produkty" header

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_688fae4eaee8832a9186e5b7f1c530b7