### PR TITLE
Add product status indicators and filtering

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -14,6 +14,8 @@ HISTORY_PATH = os.path.join(BASE_DIR, 'data', 'history.json')
 def apply_defaults(product):
     product.setdefault('category', 'uncategorized')
     product.setdefault('storage', 'pantry')
+    product.setdefault('main', False)
+    product.setdefault('threshold', None)
     return product
 
 def load_json(path):
@@ -43,6 +45,12 @@ def products():
             new_product['quantity'] = float(new_product.get('quantity', 0))
         except (TypeError, ValueError):
             new_product['quantity'] = 0
+        try:
+            thresh = new_product.get('threshold')
+            new_product['threshold'] = float(thresh) if thresh is not None else None
+        except (TypeError, ValueError):
+            new_product['threshold'] = None
+        new_product['main'] = bool(new_product.get('main', False))
         new_product = apply_defaults(new_product)
         products = load_json(PRODUCTS_PATH)
         found = False
@@ -74,6 +82,12 @@ def products():
                 item['quantity'] = float(item.get('quantity', 0))
             except (TypeError, ValueError):
                 item['quantity'] = 0
+            try:
+                thresh = item.get('threshold')
+                item['threshold'] = float(thresh) if thresh is not None else None
+            except (TypeError, ValueError):
+                item['threshold'] = None
+            item['main'] = bool(item.get('main', False))
             item = apply_defaults(item)
             found = False
             for p in products:
@@ -84,6 +98,8 @@ def products():
                 ):
                     p['quantity'] = item['quantity']
                     p['unit'] = item['unit']
+                    p['threshold'] = item['threshold']
+                    p['main'] = item['main']
                     found = True
                     break
             if not found:
@@ -107,6 +123,12 @@ def modify_product(name):
         updated['quantity'] = float(updated.get('quantity', 0))
     except (TypeError, ValueError):
         updated['quantity'] = 0
+    try:
+        thresh = updated.get('threshold')
+        updated['threshold'] = float(thresh) if thresh is not None else None
+    except (TypeError, ValueError):
+        updated['threshold'] = None
+    updated['main'] = bool(updated.get('main', False))
     updated = apply_defaults(updated)
     for p in products:
         if p.get('name') == name:

--- a/app/static/script.js
+++ b/app/static/script.js
@@ -1,5 +1,6 @@
 let groupedView = false;
 let editMode = false;
+let currentFilter = 'missing_low';
 
 const UNIT = 'szt.';
 const LOW_STOCK_CLASS = 'text-error bg-error/10';
@@ -38,6 +39,38 @@ const STORAGE_ICONS = {
   freezer: '❄️'
 };
 
+function getStatusIcon(p) {
+  if (p.main) {
+    if (p.quantity === 0) {
+      return { html: '<i class="fa-regular fa-circle-exclamation text-red-600"></i>', title: 'Brak produktu' };
+    }
+    if (p.threshold !== null && p.quantity <= p.threshold) {
+      return { html: '<i class="fa-regular fa-triangle-exclamation text-yellow-500"></i>', title: 'Produkt się kończy' };
+    }
+  } else {
+    if (p.quantity === 0) {
+      return { html: '<i class="fa-regular fa-circle-exclamation text-red-600"></i>', title: 'Brak produktu' };
+    }
+    if (p.threshold !== null && p.quantity <= p.threshold) {
+      return { html: '<i class="fa-regular fa-triangle-exclamation text-yellow-300"></i>', title: 'Produkt się kończy' };
+    }
+  }
+  return null;
+}
+
+function updateFilterVisibility() {
+  const layout = document.documentElement.getAttribute('data-layout');
+  const radios = document.getElementById('filter-radios');
+  const selectWrapper = document.getElementById('filter-select-wrapper');
+  if (layout === 'mobile') {
+    if (radios) radios.style.display = 'none';
+    if (selectWrapper) selectWrapper.style.display = 'block';
+  } else {
+    if (radios) radios.style.display = 'flex';
+    if (selectWrapper) selectWrapper.style.display = 'none';
+  }
+}
+
 function sortProducts(list) {
   return list.sort((a, b) => {
     const storA = STORAGE_NAMES[a.storage] || a.storage;
@@ -59,6 +92,7 @@ document.addEventListener('DOMContentLoaded', () => {
     html.setAttribute('data-layout', 'mobile');
     if (icon) icon.className = 'fa-solid fa-desktop';
   }
+  updateFilterVisibility();
 
   loadProducts();
   loadRecipes();
@@ -72,6 +106,8 @@ document.addEventListener('DOMContentLoaded', () => {
       quantity: parseFloat(form.quantity.value),
       category: form.category.value,
       storage: form.storage.value,
+      threshold: form.threshold.value ? parseFloat(form.threshold.value) : null,
+      main: form.main.checked,
       unit: UNIT
     };
     await fetch('/api/products', {
@@ -148,6 +184,20 @@ document.addEventListener('DOMContentLoaded', () => {
   document.getElementById('product-search').addEventListener('input', () => {
     renderProducts(getFilteredProducts());
   });
+  document.querySelectorAll('#filter-radios input[name="product-filter"]').forEach(r => {
+    r.addEventListener('change', (e) => {
+      currentFilter = e.target.value;
+      const select = document.getElementById('filter-select');
+      if (select) select.value = currentFilter;
+      renderProducts(getFilteredProducts());
+    });
+  });
+  document.getElementById('filter-select').addEventListener('change', (e) => {
+    currentFilter = e.target.value;
+    const radio = document.querySelector(`#filter-radios input[value="${currentFilter}"]`);
+    if (radio) radio.checked = true;
+    renderProducts(getFilteredProducts());
+  });
   document.getElementById('edit-json-btn').addEventListener('click', async () => {
     const textarea = document.getElementById('edit-json');
     try {
@@ -168,15 +218,35 @@ document.addEventListener('DOMContentLoaded', () => {
 
 async function loadProducts() {
   const res = await fetch('/api/products');
-  window.currentProducts = sortProducts(await res.json());
+  const data = await res.json();
+  window.currentProducts = sortProducts(data.map(p => {
+    p.low_stock = p.threshold !== null && p.quantity <= p.threshold;
+    return p;
+  }));
   renderProducts(getFilteredProducts());
 }
 
 function getFilteredProducts() {
   const query = document.getElementById('product-search').value.toLowerCase();
-  return sortProducts((window.currentProducts || []).filter(p =>
-    p.name.toLowerCase().includes(query)
-  ));
+  return sortProducts((window.currentProducts || []).filter(p => {
+    switch (currentFilter) {
+      case 'missing':
+        if (!(p.main && p.quantity === 0)) return false;
+        break;
+      case 'missing_low':
+        if (!(p.main && (p.quantity === 0 || (p.threshold !== null && p.quantity <= p.threshold)))) return false;
+        break;
+      case 'all_zero':
+        if (p.quantity !== 0) return false;
+        break;
+      case 'all':
+        break;
+    }
+    if (currentFilter !== 'all' && currentFilter !== 'all_zero') {
+      if (!p.main && p.quantity === 0) return false;
+    }
+    return p.name.toLowerCase().includes(query);
+  }));
 }
 
   function addRowActions(tr, product) {
@@ -233,6 +303,14 @@ function renderProducts(data) {
       storTd.className = 'px-4 py-2';
       storTd.textContent = STORAGE_NAMES[p.storage] || p.storage;
       tr.appendChild(storTd);
+      const statusTd = document.createElement('td');
+      statusTd.className = 'px-4 py-2 text-center';
+      const status = getStatusIcon(p);
+      if (status) {
+        statusTd.innerHTML = status.html;
+        statusTd.title = status.title;
+      }
+      tr.appendChild(statusTd);
       addRowActions(tr, p);
       tbody.appendChild(tr);
     });
@@ -315,7 +393,7 @@ function renderProducts(data) {
         table.className = 'table table-zebra w-full';
         const thead = document.createElement('thead');
         const headRow = document.createElement('tr');
-        ['Nazwa', 'Ilość', 'Jednostka', 'Usuń'].forEach(text => {
+        ['Nazwa', 'Ilość', 'Jednostka', 'Status', 'Usuń'].forEach(text => {
           const th = document.createElement('th');
           th.className = 'px-4 py-2';
           th.textContent = text;
@@ -354,6 +432,14 @@ function renderProducts(data) {
           unitTd.className = 'px-4 py-2';
           unitTd.textContent = p.unit;
           tr.appendChild(unitTd);
+          const statusTd = document.createElement('td');
+          statusTd.className = 'px-4 py-2 text-center';
+          const status = getStatusIcon(p);
+          if (status) {
+            statusTd.innerHTML = status.html;
+            statusTd.title = status.title;
+          }
+          tr.appendChild(statusTd);
           addRowActions(tr, p);
           tbodyCat.appendChild(tr);
         });
@@ -504,5 +590,6 @@ if (layoutToggle && layoutIcon) {
     const next = current === 'desktop' ? 'mobile' : 'desktop';
     html.setAttribute('data-layout', next);
     layoutIcon.className = next === 'desktop' ? 'fa-regular fa-mobile' : 'fa-solid fa-desktop';
+    updateFilterVisibility();
   });
 }

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -21,6 +21,20 @@
             <button id="edit-toggle" class="btn btn-warning">Edytuj</button>
             <button id="save-btn" style="display:none;" class="btn btn-success">Zapisz</button>
         </div>
+        <div id="filter-radios" class="mb-4 gap-4">
+            <label class="flex items-center gap-2"><input type="radio" name="product-filter" value="missing" class="radio"><span>Tylko braki</span></label>
+            <label class="flex items-center gap-2"><input type="radio" name="product-filter" value="missing_low" class="radio" checked><span>Braki + końcówki</span></label>
+            <label class="flex items-center gap-2"><input type="radio" name="product-filter" value="all_zero" class="radio"><span>Wszystkie 0</span></label>
+            <label class="flex items-center gap-2"><input type="radio" name="product-filter" value="all" class="radio"><span>Wszystkie</span></label>
+        </div>
+        <div id="filter-select-wrapper" class="mb-4">
+            <select id="filter-select" class="select select-bordered w-full">
+                <option value="missing">Tylko braki</option>
+                <option value="missing_low" selected>Braki + końcówki</option>
+                <option value="all_zero">Wszystkie 0</option>
+                <option value="all">Wszystkie</option>
+            </select>
+        </div>
         <div class="overflow-x-auto">
             <table id="product-table" class="table table-zebra w-full">
                 <thead>
@@ -30,6 +44,7 @@
                         <th>Jednostka</th>
                         <th>Kategoria</th>
                         <th>Miejsce</th>
+                        <th>Status</th>
                         <th></th>
                     </tr>
                 </thead>
@@ -39,9 +54,10 @@
         </div>
 
         <h2 class="text-xl font-semibold mt-8 mb-4">Dodaj / edytuj produkt</h2>
-        <form id="add-form" class="grid grid-cols-1 sm:grid-cols-5 gap-2 mb-6">
+        <form id="add-form" class="grid grid-cols-1 sm:grid-cols-7 gap-2 mb-6">
             <input name="name" placeholder="nazwa" required class="input input-bordered">
             <input name="quantity" placeholder="ilość" required class="input input-bordered">
+            <input name="threshold" placeholder="próg" class="input input-bordered" type="number">
             <select name="category" required class="select select-bordered">
                 <option value="uncategorized">brak kategorii</option>
                 <option value="fresh_veg">Świeże warzywa</option>
@@ -67,6 +83,7 @@
                 <option value="pantry" selected>Szafka</option>
                 <option value="freezer">Zamrażarka</option>
             </select>
+            <label class="flex items-center gap-2"><input type="checkbox" name="main" class="checkbox"> Podstawowy</label>
             <button type="submit" class="btn btn-success">Zapisz</button>
         </form>
 


### PR DESCRIPTION
## Summary
- Support `threshold` and `main` fields for products with sensible defaults on the backend.
- Display stock status icons and responsive filters in the UI; hide non-main zero stock items and allow viewing with new filter options.
- Allow specifying `threshold` and `main` when adding products.

## Testing
- `python -m py_compile app/app.py`
- `node --check app/static/script.js`


------
https://chatgpt.com/codex/tasks/task_e_688fb2e1f198832a829aa79a43d13f41