### PR TITLE
Refine storage/category collapse behavior for responsive views

### DIFF
--- a/app/static/script.js
+++ b/app/static/script.js
@@ -333,20 +333,23 @@ function renderProducts(data) {
   const storOrder = Object.keys(storages).sort((a, b) =>
     (STORAGE_NAMES[a] || a).localeCompare(STORAGE_NAMES[b] || b)
   );
-  storOrder.forEach(stor => {
+  storOrder.forEach((stor, storIndex) => {
     const storageBlock = document.createElement('div');
     storageBlock.className = 'storage-block border border-base-300 rounded-lg p-4 mb-6';
+    storageBlock.id = `storage-${storIndex}`;
 
     const storageHeader = document.createElement('div');
-    storageHeader.className = 'flex justify-between items-center mb-4 cursor-pointer md:cursor-default pl-4';
+    storageHeader.className = 'flex justify-between items-center mb-4 hover:bg-neutral/20 cursor-pointer md:cursor-default rounded px-2';
+    storageHeader.id = `storage-header-${storIndex}`;
 
     const h3 = document.createElement('h3');
-    h3.className = 'text-xl font-semibold';
+    h3.className = 'text-lg font-bold';
     h3.textContent = `${STORAGE_ICONS[stor] || ''} ${STORAGE_NAMES[stor] || stor}`;
 
     const storToggle = document.createElement('button');
     storToggle.className = 'text-xl cursor-pointer';
     storToggle.innerHTML = '<i class="fa-regular fa-caret-down"></i>';
+    storToggle.id = `storage-toggle-${storIndex}`;
 
     storageHeader.appendChild(h3);
     storageHeader.appendChild(storToggle);
@@ -359,7 +362,7 @@ function renderProducts(data) {
     let storOpen = true;
     const toggleStorage = () => {
       storOpen = !storOpen;
-      storageContent.style.display = storOpen ? 'block' : 'none';
+      storageContent.classList.toggle('hidden', !storOpen);
       storToggle.innerHTML = `<i class="fa-regular fa-caret-${storOpen ? 'down' : 'up'}"></i>`;
     };
     if (window.innerWidth < 768) {
@@ -371,20 +374,23 @@ function renderProducts(data) {
     const categories = storages[stor];
     Object.keys(categories)
       .sort((a, b) => (CATEGORY_NAMES[a] || a).localeCompare(CATEGORY_NAMES[b] || b))
-      .forEach(cat => {
+      .forEach((cat, catIndex) => {
         const categoryBlock = document.createElement('div');
         categoryBlock.className = 'category-block mb-4';
+        categoryBlock.id = `category-${storIndex}-${catIndex}`;
 
         const catHeader = document.createElement('div');
-        catHeader.className = 'flex justify-between items-center mb-2 cursor-pointer md:cursor-default pl-4';
+        catHeader.className = 'flex justify-between items-center mb-2 hover:bg-neutral/20 cursor-pointer md:cursor-default rounded px-2';
+        catHeader.id = `category-header-${storIndex}-${catIndex}`;
 
         const h4 = document.createElement('h4');
-        h4.className = 'text-lg font-medium';
+        h4.className = 'text-md font-semibold';
         h4.textContent = CATEGORY_NAMES[cat] || cat;
 
         const catToggle = document.createElement('button');
         catToggle.className = 'text-md cursor-pointer';
         catToggle.innerHTML = '<i class="fa-regular fa-caret-down"></i>';
+        catToggle.id = `category-toggle-${storIndex}-${catIndex}`;
 
         catHeader.appendChild(h4);
         catHeader.appendChild(catToggle);
@@ -451,7 +457,7 @@ function renderProducts(data) {
         let catOpen = true;
         const toggleCategory = () => {
           catOpen = !catOpen;
-          table.style.display = catOpen ? 'table' : 'none';
+          table.classList.toggle('hidden', !catOpen);
           catToggle.innerHTML = `<i class="fa-regular fa-caret-${catOpen ? 'down' : 'up'}"></i>`;
         };
         if (window.innerWidth < 768) {


### PR DESCRIPTION
## Summary
- Align caret icons to the right of storage and category headers with flex layout
- Toggle entire headers on mobile while limiting desktop toggling to caret icons
- Hide tables via `hidden` class and add unique IDs for storage/category blocks

## Testing
- `node --check app/static/script.js`
- `pytest -q`
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_688fb7c20a1c832aa6a602fc3c8601c9