### PR TITLE
Add package size handling for products

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -16,6 +16,7 @@ def apply_defaults(product):
     product.setdefault('storage', 'pantry')
     product.setdefault('main', False)
     product.setdefault('threshold', None)
+    product.setdefault('package_size', 1)
     return product
 
 def load_json(path):
@@ -45,6 +46,10 @@ def products():
             new_product['quantity'] = float(new_product.get('quantity', 0))
         except (TypeError, ValueError):
             new_product['quantity'] = 0
+        try:
+            new_product['package_size'] = float(new_product.get('package_size', 1)) or 1
+        except (TypeError, ValueError):
+            new_product['package_size'] = 1
         try:
             thresh = new_product.get('threshold')
             new_product['threshold'] = float(thresh) if thresh is not None else None
@@ -83,6 +88,10 @@ def products():
             except (TypeError, ValueError):
                 item['quantity'] = 0
             try:
+                item['package_size'] = float(item.get('package_size', 1)) or 1
+            except (TypeError, ValueError):
+                item['package_size'] = 1
+            try:
                 thresh = item.get('threshold')
                 item['threshold'] = float(thresh) if thresh is not None else None
             except (TypeError, ValueError):
@@ -100,6 +109,7 @@ def products():
                     p['unit'] = item['unit']
                     p['threshold'] = item['threshold']
                     p['main'] = item['main']
+                    p['package_size'] = item['package_size']
                     found = True
                     break
             if not found:
@@ -123,6 +133,10 @@ def modify_product(name):
         updated['quantity'] = float(updated.get('quantity', 0))
     except (TypeError, ValueError):
         updated['quantity'] = 0
+    try:
+        updated['package_size'] = float(updated.get('package_size', 1)) or 1
+    except (TypeError, ValueError):
+        updated['package_size'] = 1
     try:
         thresh = updated.get('threshold')
         updated['threshold'] = float(thresh) if thresh is not None else None

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -48,9 +48,10 @@
         </div>
 
         <h2 class="text-xl font-semibold mt-8 mb-4">Dodaj / edytuj produkt</h2>
-        <form id="add-form" class="grid grid-cols-1 sm:grid-cols-7 gap-2 mb-6">
+        <form id="add-form" class="grid grid-cols-1 sm:grid-cols-8 gap-2 mb-6">
             <input name="name" placeholder="nazwa" required class="input input-bordered">
             <input name="quantity" placeholder="ilość" required class="input input-bordered">
+            <input name="package_size" placeholder="w opak." class="input input-bordered" type="number" value="1">
             <input name="threshold" placeholder="próg" class="input input-bordered" type="number">
             <select name="category" required class="select select-bordered">
                 <option value="uncategorized">brak kategorii</option>


### PR DESCRIPTION
## Summary
- allow defining `package_size` for products and persist it through API
- show package and unit counts together, e.g. `1 op. (4 szt.)`
- convert user-edited unit counts to package quantities before saving

## Testing
- `python -m py_compile app/app.py`


------
https://chatgpt.com/codex/tasks/task_e_688fba23a1dc832aa7e1c9b72f68eac5