### PR TITLE
Poprawa odstępów w widoku produktów

### DIFF
--- a/app/static/script.js
+++ b/app/static/script.js
@@ -439,15 +439,15 @@ function renderProducts(data) {
   );
   storOrder.forEach((stor, storIndex) => {
     const storageBlock = document.createElement('div');
-    storageBlock.className = 'storage-block border border-base-300 rounded-lg p-4 mb-6';
+    storageBlock.className = 'storage-block border border-base-300 rounded-lg p-4 mb-10';
     storageBlock.id = `storage-${storIndex}`;
 
     const storageHeader = document.createElement('div');
-    storageHeader.className = 'flex justify-between items-center mb-4 hover:bg-neutral/20 cursor-pointer md:cursor-default rounded px-2';
+    storageHeader.className = 'flex justify-between items-center mb-8 hover:bg-neutral/20 cursor-pointer md:cursor-default rounded px-2';
     storageHeader.id = `storage-header-${storIndex}`;
 
     const h3 = document.createElement('h3');
-    h3.className = 'text-lg font-bold';
+    h3.className = 'text-xl font-bold';
     h3.textContent = `${STORAGE_ICONS[stor] || ''} ${STORAGE_NAMES[stor] || stor}`;
 
     const storToggle = document.createElement('button');
@@ -460,7 +460,6 @@ function renderProducts(data) {
     storageBlock.appendChild(storageHeader);
 
     const storageContent = document.createElement('div');
-    storageContent.className = 'space-y-4';
     storageBlock.appendChild(storageContent);
 
     let storOpen = true;
@@ -480,7 +479,7 @@ function renderProducts(data) {
       .sort((a, b) => (CATEGORY_NAMES[a] || a).localeCompare(CATEGORY_NAMES[b] || b))
       .forEach((cat, catIndex) => {
         const categoryBlock = document.createElement('div');
-        categoryBlock.className = 'category-block mb-4';
+        categoryBlock.className = 'category-block mb-8';
         categoryBlock.id = `category-${storIndex}-${catIndex}`;
 
         const catHeader = document.createElement('div');
@@ -501,7 +500,7 @@ function renderProducts(data) {
         categoryBlock.appendChild(catHeader);
 
         const table = document.createElement('table');
-        table.className = 'table table-zebra w-full mb-4';
+        table.className = 'table table-zebra w-full mb-6';
         const thead = document.createElement('thead');
         const headRow = document.createElement('tr');
         ['Nazwa', 'Ilość', 'Jednostka', 'Status', 'Usuń'].forEach(text => {

--- a/app/static/styles.css
+++ b/app/static/styles.css
@@ -62,3 +62,22 @@ html[data-layout="mobile"] button {
   font-size: 1em;
   padding: 0.75rem 1rem;
 }
+
+/* Product view spacing adjustments */
+#product-list .storage-block h3 {
+  font-size: 1.25rem;
+  margin-bottom: 0.5rem;
+}
+
+#product-list .storage-block {
+  margin-bottom: 2.5rem;
+}
+
+#product-list .category-block {
+  margin-bottom: 2rem;
+}
+
+#product-list .category-block table {
+  margin-bottom: 1.5rem;
+  margin-top: 1rem;
+}


### PR DESCRIPTION
## Podsumowanie
- zwiększony odstęp między blokami magazynów i kategorii
- powiększony nagłówek sekcji storage z dodatkowym marginesem
- dodane większe przerwy po tabelach, aby sekcje się nie nachodziły

## Testy
- `python -m py_compile app/app.py`


------
https://chatgpt.com/codex/tasks/task_e_688fc1eb8a7c832aa83f4796033cea60