### PR TITLE
Add responsive product state filters

### DIFF
--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -26,11 +26,27 @@
             <div id="controls" class="flex flex-wrap items-center gap-4 mb-4">
                 <div class="flex flex-col md:flex-row gap-2 items-start flex-1">
                     <input id="product-search" placeholder="Szukaj produktu" class="input input-bordered flex-1 min-w-[200px]" />
-                    <div id="product-filter" class="flex gap-2">
-                        <button data-filter="missing" class="btn btn-sm btn-outline btn-neutral">Braki (main, ilość = 0)</button>
-                        <button data-filter="missing_low" class="btn btn-sm btn-outline btn-neutral">Braki + końcówki (main, ilość ≤ próg)</button>
-                        <button data-filter="all_zero" class="btn btn-sm btn-outline btn-neutral">Braki wszystkich (ilość = 0)</button>
-                        <button data-filter="all" class="btn btn-sm btn-outline btn-neutral btn-active">Wszystko</button>
+                    <div class="hidden md:block">
+                        <select id="state-filter" class="select select-bordered">
+                            <option value="available">Dostępne</option>
+                            <option value="missing">Brakujące</option>
+                            <option value="low">Kończące się</option>
+                            <option value="all">Wszystkie</option>
+                        </select>
+                    </div>
+                    <div class="md:hidden w-full">
+                        <div tabindex="0" class="collapse collapse-arrow border border-base-300 bg-base-100 rounded-box w-full">
+                            <input type="checkbox" />
+                            <div class="collapse-title text-md font-medium">Filtr</div>
+                            <div class="collapse-content">
+                                <select id="state-filter-mobile" class="select select-bordered w-full mt-2">
+                                    <option value="available">Dostępne</option>
+                                    <option value="missing">Brakujące</option>
+                                    <option value="low">Kończące się</option>
+                                    <option value="all">Wszystkie</option>
+                                </select>
+                            </div>
+                        </div>
                     </div>
                 </div>
                 <button id="view-toggle" class="btn btn-primary">Widok z podziałem</button>


### PR DESCRIPTION
## Summary
- Add desktop dropdown and mobile collapsible menu to filter products by availability state
- Show available items by default and support missing, low stock, and all filters

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688fc52cbd28832a913a43bb30778645