### PR TITLE
feat: adjust quantity inline

### DIFF
--- a/app/static/script.js
+++ b/app/static/script.js
@@ -258,7 +258,7 @@ function getFilteredProducts() {
   }));
 }
 
-async function changeQuantity(product, delta) {
+async function changeQuantity(product, delta, { qtySpan, decBtn, tr, statusTd }) {
   const newQty = Math.max(0, (product.quantity || 0) + delta);
   if (newQty === product.quantity) return;
   const updated = { ...product, quantity: newQty };
@@ -267,8 +267,27 @@ async function changeQuantity(product, delta) {
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(updated)
   });
-  await loadProducts();
-  await loadRecipes();
+  product.quantity = newQty;
+  product.low_stock = product.threshold !== null && product.quantity <= product.threshold;
+  if (qtySpan) qtySpan.textContent = newQty;
+  if (decBtn) decBtn.disabled = newQty <= 0;
+  if (tr) {
+    if (product.low_stock) {
+      tr.classList.add(...LOW_STOCK_CLASS.split(' '));
+    } else {
+      tr.classList.remove(...LOW_STOCK_CLASS.split(' '));
+    }
+  }
+  if (statusTd) {
+    const status = getStatusIcon(product);
+    if (status) {
+      statusTd.innerHTML = status.html;
+      statusTd.title = status.title;
+    } else {
+      statusTd.innerHTML = '';
+      statusTd.removeAttribute('title');
+    }
+  }
 }
 
   function addRowActions(tr, product) {
@@ -299,6 +318,7 @@ function renderProducts(data) {
       nameTd.className = 'px-4 py-2';
       const qtyTd = document.createElement('td');
       qtyTd.className = 'px-4 py-2';
+      let decBtn, qtySpan, incBtn;
       if (editMode) {
         const nameInput = document.createElement('input');
         nameInput.value = p.name;
@@ -309,18 +329,16 @@ function renderProducts(data) {
         qtyTd.appendChild(qtyInput);
       } else {
         nameTd.textContent = p.name;
-        const decBtn = document.createElement('button');
+        decBtn = document.createElement('button');
         decBtn.textContent = '−';
         decBtn.className = 'btn btn-xs';
         decBtn.disabled = p.quantity <= 0;
-        decBtn.addEventListener('click', () => changeQuantity(p, -1));
-        const qtySpan = document.createElement('span');
+        qtySpan = document.createElement('span');
         qtySpan.className = 'mx-2';
         qtySpan.textContent = p.quantity;
-        const incBtn = document.createElement('button');
+        incBtn = document.createElement('button');
         incBtn.textContent = '+';
         incBtn.className = 'btn btn-xs';
-        incBtn.addEventListener('click', () => changeQuantity(p, 1));
         qtyTd.appendChild(decBtn);
         qtyTd.appendChild(qtySpan);
         qtyTd.appendChild(incBtn);
@@ -347,6 +365,14 @@ function renderProducts(data) {
         statusTd.title = status.title;
       }
       tr.appendChild(statusTd);
+      if (!editMode) {
+        decBtn.addEventListener('click', () =>
+          changeQuantity(p, -1, { qtySpan, decBtn, tr, statusTd })
+        );
+        incBtn.addEventListener('click', () =>
+          changeQuantity(p, 1, { qtySpan, decBtn, tr, statusTd })
+        );
+      }
       addRowActions(tr, p);
       tbody.appendChild(tr);
     });
@@ -457,6 +483,7 @@ function renderProducts(data) {
           nameTd.className = 'px-4 py-2';
           const qtyTd = document.createElement('td');
           qtyTd.className = 'px-4 py-2';
+          let decBtn, qtySpan, incBtn;
           if (editMode) {
             const nameInput = document.createElement('input');
             nameInput.value = p.name;
@@ -467,18 +494,16 @@ function renderProducts(data) {
             qtyTd.appendChild(qtyInput);
           } else {
             nameTd.textContent = p.name;
-            const decBtn = document.createElement('button');
+            decBtn = document.createElement('button');
             decBtn.textContent = '−';
             decBtn.className = 'btn btn-xs';
             decBtn.disabled = p.quantity <= 0;
-            decBtn.addEventListener('click', () => changeQuantity(p, -1));
-            const qtySpan = document.createElement('span');
+            qtySpan = document.createElement('span');
             qtySpan.className = 'mx-2';
             qtySpan.textContent = p.quantity;
-            const incBtn = document.createElement('button');
+            incBtn = document.createElement('button');
             incBtn.textContent = '+';
             incBtn.className = 'btn btn-xs';
-            incBtn.addEventListener('click', () => changeQuantity(p, 1));
             qtyTd.appendChild(decBtn);
             qtyTd.appendChild(qtySpan);
             qtyTd.appendChild(incBtn);
@@ -497,6 +522,14 @@ function renderProducts(data) {
             statusTd.title = status.title;
           }
           tr.appendChild(statusTd);
+          if (!editMode) {
+            decBtn.addEventListener('click', () =>
+              changeQuantity(p, -1, { qtySpan, decBtn, tr, statusTd })
+            );
+            incBtn.addEventListener('click', () =>
+              changeQuantity(p, 1, { qtySpan, decBtn, tr, statusTd })
+            );
+          }
           addRowActions(tr, p);
           tbodyCat.appendChild(tr);
         });


### PR DESCRIPTION
## Summary
- add inline +/- controls for product quantity
- send quantity changes via API and update values without reloading

## Testing
- `node --check app/static/script.js`
- `python -m py_compile app/app.py`


------
https://chatgpt.com/codex/tasks/task_e_688fc5b02a70832a921dc68f58b04eba