### PR TITLE
Reposition product visibility filter near search

### DIFF
--- a/app/static/script.js
+++ b/app/static/script.js
@@ -208,19 +208,14 @@ document.addEventListener('DOMContentLoaded', () => {
   document.getElementById('product-search').addEventListener('input', () => {
     renderProducts(getFilteredProducts());
   });
-  const desktopFilter = document.getElementById('state-filter');
-  const mobileFilter = document.getElementById('state-filter-mobile');
+  const stateFilter = document.getElementById('state-filter');
   function setFilter(value) {
     currentFilter = value;
-    if (desktopFilter) desktopFilter.value = value;
-    if (mobileFilter) mobileFilter.value = value;
+    if (stateFilter) stateFilter.value = value;
     renderProducts(getFilteredProducts());
   }
-  if (desktopFilter) {
-    desktopFilter.addEventListener('change', e => setFilter(e.target.value));
-  }
-  if (mobileFilter) {
-    mobileFilter.addEventListener('change', e => setFilter(e.target.value));
+  if (stateFilter) {
+    stateFilter.addEventListener('change', e => setFilter(e.target.value));
   }
   document.getElementById('edit-json-btn').addEventListener('click', async () => {
     const textarea = document.getElementById('edit-json');

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -24,30 +24,14 @@
         <div id="tab-products" class="tab-panel">
             <h1 class="text-2xl font-bold mb-4">Produkty</h1>
             <div id="controls" class="flex flex-wrap items-center gap-4 mb-4">
-                <div class="flex flex-col md:flex-row gap-2 items-start flex-1">
+                <div class="flex flex-col md:flex-row gap-2 items-start md:items-center flex-1">
                     <input id="product-search" placeholder="Szukaj produktu" class="input input-bordered flex-1 min-w-[200px]" />
-                    <div class="hidden md:block">
-                        <select id="state-filter" class="select select-bordered">
-                            <option value="available">Dostępne</option>
-                            <option value="missing">Brakujące</option>
-                            <option value="low">Kończące się</option>
-                            <option value="all">Wszystkie</option>
-                        </select>
-                    </div>
-                    <div class="md:hidden w-full">
-                        <div tabindex="0" class="collapse collapse-arrow border border-base-300 bg-base-100 rounded-box w-full">
-                            <input type="checkbox" />
-                            <div class="collapse-title text-md font-medium">Filtr</div>
-                            <div class="collapse-content">
-                                <select id="state-filter-mobile" class="select select-bordered w-full mt-2">
-                                    <option value="available">Dostępne</option>
-                                    <option value="missing">Brakujące</option>
-                                    <option value="low">Kończące się</option>
-                                    <option value="all">Wszystkie</option>
-                                </select>
-                            </div>
-                        </div>
-                    </div>
+                    <select id="state-filter" class="select select-bordered w-full md:w-auto">
+                        <option value="available">Dostępne</option>
+                        <option value="missing">Brakujące</option>
+                        <option value="low">Kończące się</option>
+                        <option value="all">Wszystkie</option>
+                    </select>
                 </div>
                 <button id="view-toggle" class="btn btn-primary">Widok z podziałem</button>
                 <button id="edit-toggle" class="btn btn-warning">Edytuj</button>


### PR DESCRIPTION
## Summary
- Place product visibility dropdown next to search bar on desktop and directly below it on mobile.
- Remove old collapsible filter container and use a single `state-filter` element.
- Update scripts to handle unified filter element.

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_688fc9ea49e8832aa68357ee5cd65ac7