### PR TITLE
Limit rating UI to history tab

### DIFF
--- a/app/static/script.js
+++ b/app/static/script.js
@@ -317,6 +317,12 @@ function checkLowStockToast() {
       const targetId = tab.dataset.tabTarget;
       const panel = document.getElementById(targetId);
       if (panel) panel.style.display = 'block';
+      if (targetId !== 'tab-history') {
+        const overlay = document.getElementById('cooking-overlay');
+        if (overlay) overlay.classList.add('hidden');
+        const modal = document.getElementById('rating-modal');
+        if (modal) modal.close();
+      }
       if (targetId === 'tab-products') {
         loadProducts();
       } else if (targetId === 'tab-recipes') {
@@ -1024,7 +1030,18 @@ async function loadHistory() {
   });
 }
 
+function activateTab(targetId) {
+  document.querySelectorAll('[data-tab-target]').forEach(t => t.classList.remove('tab-active', 'font-bold'));
+  const tab = document.querySelector(`[data-tab-target="${targetId}"]`);
+  if (tab) tab.classList.add('tab-active', 'font-bold');
+  document.querySelectorAll('.tab-panel').forEach(panel => (panel.style.display = 'none'));
+  const panel = document.getElementById(targetId);
+  if (panel) panel.style.display = 'block';
+}
+
 function openRatingModal(recipe) {
+  activateTab('tab-history');
+  loadHistory();
   currentRecipeName = recipe.name;
   const modal = document.getElementById('rating-modal');
   const title = document.getElementById('rating-title');
@@ -1078,6 +1095,8 @@ function showCookingStep() {
 }
 
 function openCookingMode(recipe) {
+  activateTab('tab-history');
+  loadHistory();
   cookingState.recipe = recipe;
   const saved = JSON.parse(localStorage.getItem('cookingProgress') || '{}');
   cookingState.step = saved.recipe === recipe.name ? saved.step || 0 : 0;

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -136,6 +136,11 @@
                 </select>
             </div>
             <ul id="recipe-list" class="list-disc pl-4 mb-8"></ul>
+        </div>
+
+        <div id="tab-history" class="tab-panel" style="display:none;">
+            <h1 class="text-2xl font-bold mb-4" data-i18n="heading_history">Historia dań</h1>
+            <ul id="history-list" class="list-disc pl-4"></ul>
 
             <dialog id="rating-modal" class="modal">
                 <form method="dialog" id="rating-form" class="modal-box">
@@ -171,11 +176,35 @@
                     </div>
                 </form>
             </dialog>
-        </div>
 
-        <div id="tab-history" class="tab-panel" style="display:none;">
-            <h1 class="text-2xl font-bold mb-4" data-i18n="heading_history">Historia dań</h1>
-            <ul id="history-list" class="list-disc pl-4"></ul>
+            <div id="cooking-overlay" class="fixed inset-0 bg-base-100 z-50 hidden flex flex-col items-center justify-center p-4">
+                <div id="cooking-step" class="text-xl text-center mb-6"></div>
+                <button id="cooking-next" class="btn btn-primary mb-4" data-i18n="next_step_button">Dalej</button>
+                <form id="cooking-form" class="w-full max-w-md space-y-4 hidden">
+                    <textarea name="comment" placeholder="Komentarz" data-i18n="comment_placeholder" class="textarea textarea-bordered w-full"></textarea>
+                    <div>
+                        <span data-i18n="label_taste" class="block mb-2">Smak:</span>
+                        <div class="rating">
+                            <input type="radio" name="taste" value="1" class="mask mask-star-2 bg-orange-400" required />
+                            <input type="radio" name="taste" value="2" class="mask mask-star-2 bg-orange-400" />
+                            <input type="radio" name="taste" value="3" class="mask mask-star-2 bg-orange-400" />
+                            <input type="radio" name="taste" value="4" class="mask mask-star-2 bg-orange-400" />
+                            <input type="radio" name="taste" value="5" class="mask mask-star-2 bg-orange-400" />
+                        </div>
+                    </div>
+                    <div>
+                        <span data-i18n="label_prep_time" class="block mb-2">Czas przygotowania:</span>
+                        <div class="rating">
+                            <input type="radio" name="time" value="1" class="mask mask-star-2 bg-orange-400" required />
+                            <input type="radio" name="time" value="2" class="mask mask-star-2 bg-orange-400" />
+                            <input type="radio" name="time" value="3" class="mask mask-star-2 bg-orange-400" />
+                            <input type="radio" name="time" value="4" class="mask mask-star-2 bg-orange-400" />
+                            <input type="radio" name="time" value="5" class="mask mask-star-2 bg-orange-400" />
+                        </div>
+                    </div>
+                    <button type="submit" class="btn btn-success" data-i18n="save_button">Zapisz</button>
+                </form>
+            </div>
         </div>
 
         <div id="tab-shopping" class="tab-panel" style="display:none;">
@@ -272,34 +301,6 @@
             <button id="units-save" class="btn btn-primary btn-sm mt-4" data-i18n="save_button">Zapisz</button>
         </div>
 
-    </div>
-    <div id="cooking-overlay" class="fixed inset-0 bg-base-100 z-50 hidden flex flex-col items-center justify-center p-4">
-        <div id="cooking-step" class="text-xl text-center mb-6"></div>
-        <button id="cooking-next" class="btn btn-primary mb-4" data-i18n="next_step_button">Dalej</button>
-        <form id="cooking-form" class="w-full max-w-md space-y-4 hidden">
-            <textarea name="comment" placeholder="Komentarz" data-i18n="comment_placeholder" class="textarea textarea-bordered w-full"></textarea>
-            <div>
-                <span data-i18n="label_taste" class="block mb-2">Smak:</span>
-                <div class="rating">
-                    <input type="radio" name="taste" value="1" class="mask mask-star-2 bg-orange-400" required />
-                    <input type="radio" name="taste" value="2" class="mask mask-star-2 bg-orange-400" />
-                    <input type="radio" name="taste" value="3" class="mask mask-star-2 bg-orange-400" />
-                    <input type="radio" name="taste" value="4" class="mask mask-star-2 bg-orange-400" />
-                    <input type="radio" name="taste" value="5" class="mask mask-star-2 bg-orange-400" />
-                </div>
-            </div>
-            <div>
-                <span data-i18n="label_prep_time" class="block mb-2">Czas przygotowania:</span>
-                <div class="rating">
-                    <input type="radio" name="time" value="1" class="mask mask-star-2 bg-orange-400" required />
-                    <input type="radio" name="time" value="2" class="mask mask-star-2 bg-orange-400" />
-                    <input type="radio" name="time" value="3" class="mask mask-star-2 bg-orange-400" />
-                    <input type="radio" name="time" value="4" class="mask mask-star-2 bg-orange-400" />
-                    <input type="radio" name="time" value="5" class="mask mask-star-2 bg-orange-400" />
-                </div>
-            </div>
-            <button type="submit" class="btn btn-success" data-i18n="save_button">Zapisz</button>
-        </form>
     </div>
     <script src="https://cdn.jsdelivr.net/npm/tesseract.js@2.1.5/dist/tesseract.min.js"></script>
     <script src="{{ url_for('static', filename='script.js') }}"></script>


### PR DESCRIPTION
## Summary
- Move rating modal and cooking overlay into the "Historia dań" tab.
- Add tab activation helper and redirect rating flows to the history tab.
- Hide rating UI when navigating to other tabs.

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_6890e28762bc832ab74032acd4655a80