### PR TITLE
Refactor units settings layout

### DIFF
--- a/app/static/script.js
+++ b/app/static/script.js
@@ -109,21 +109,28 @@ function renderUnitsAdmin() {
   Object.entries(units).forEach(([code, names]) => {
     const tr = document.createElement('tr');
     tr.dataset.code = code;
+
     const codeTd = document.createElement('td');
+    codeTd.className = 'w-1/3 align-middle text-center';
     codeTd.textContent = code;
     tr.appendChild(codeTd);
+
     const plTd = document.createElement('td');
+    plTd.className = 'w-1/3 align-middle text-center';
     const plInput = document.createElement('input');
     plInput.value = names.pl || '';
-    plInput.className = 'input input-bordered w-full';
+    plInput.className = 'input input-bordered w-full text-center';
     plTd.appendChild(plInput);
     tr.appendChild(plTd);
+
     const enTd = document.createElement('td');
+    enTd.className = 'w-1/3 align-middle text-center';
     const enInput = document.createElement('input');
     enInput.value = names.en || '';
-    enInput.className = 'input input-bordered w-full';
+    enInput.className = 'input input-bordered w-full text-center';
     enTd.appendChild(enInput);
     tr.appendChild(enTd);
+
     tbody.appendChild(tr);
   });
 }

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -258,18 +258,25 @@
             <h1 class="text-2xl font-bold mb-4" data-i18n="heading_settings">Ustawienia</h1>
             <h2 class="text-xl font-semibold mb-4" data-i18n="settings_units_header">Jednostki</h2>
             <div class="overflow-x-auto">
-                <table id="units-table" class="table w-full">
+                <table id="units-table" class="table table-zebra w-full">
+                    <colgroup>
+                        <col class="w-1/3" />
+                        <col class="w-1/3" />
+                        <col class="w-1/3" />
+                    </colgroup>
                     <thead>
-                        <tr>
-                            <th data-i18n="settings_unit_code">Kod</th>
-                            <th data-i18n="settings_unit_pl">Polski</th>
-                            <th data-i18n="settings_unit_en">Angielski</th>
+                        <tr class="text-center">
+                            <th class="w-1/3" data-i18n="settings_unit_code">Kod</th>
+                            <th class="w-1/3" data-i18n="settings_unit_pl">Polski</th>
+                            <th class="w-1/3" data-i18n="settings_unit_en">Angielski</th>
                         </tr>
                     </thead>
                     <tbody></tbody>
                 </table>
             </div>
-            <button id="units-save" class="btn btn-primary btn-sm mt-4" data-i18n="save_button">Zapisz</button>
+            <div class="mt-4">
+                <button id="units-save" class="btn btn-primary btn-sm" data-i18n="save_button">Zapisz</button>
+            </div>
         </div>
 
     </div>


### PR DESCRIPTION
## Summary
- restyle units settings table with equal-width zebra columns
- center inputs/headers and reposition save button

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6890e28bfd00832a8be2054c11a7b5ea