### PR TITLE
Allow clearing 5-star ratings

### DIFF
--- a/app/static/script.js
+++ b/app/static/script.js
@@ -382,6 +382,7 @@ function checkLowStockToast() {
   const ratingForm = document.getElementById('rating-form');
   const ratingModal = document.getElementById('rating-modal');
   if (ratingForm && ratingModal) {
+    setupStarRatings(ratingForm);
     ratingForm.addEventListener('submit', handleRatingSubmit);
     document.getElementById('rating-cancel').addEventListener('click', () => ratingModal.close());
   }
@@ -958,8 +959,8 @@ async function loadRecipes() {
       if (!ratingMap[h.name]) {
         ratingMap[h.name] = { taste: [], prep_time: [] };
       }
-      if (h.rating.taste) ratingMap[h.name].taste.push(h.rating.taste);
-      if (h.rating.prep_time) ratingMap[h.name].prep_time.push(h.rating.prep_time);
+      if (h.rating.taste != null) ratingMap[h.name].taste.push(h.rating.taste);
+      if (h.rating.prep_time != null) ratingMap[h.name].prep_time.push(h.rating.prep_time);
     }
   });
   data.forEach(r => {
@@ -1034,19 +1035,44 @@ function openRatingModal(recipe) {
   if (modal) modal.showModal();
 }
 
+function setupStarRatings(form) {
+  const groups = form.querySelectorAll('.rating');
+  groups.forEach(group => {
+    group.dataset.current = '0';
+    const inputs = group.querySelectorAll('input');
+    inputs.forEach(input => {
+      input.addEventListener('click', () => {
+        if (group.dataset.current === input.value) {
+          inputs.forEach(i => (i.checked = false));
+          group.dataset.current = '0';
+        } else {
+          group.dataset.current = input.value;
+        }
+      });
+    });
+  });
+  form.addEventListener('reset', () => {
+    groups.forEach(g => {
+      g.dataset.current = '0';
+    });
+  });
+}
+
 async function handleRatingSubmit(e) {
   e.preventDefault();
   const form = e.target;
   const taste = parseInt(form.taste.value, 10);
   const time = parseInt(form.time.value, 10);
-  if (!taste || !time) return;
   const comment = form.comment ? form.comment.value.trim() : null;
   const entry = {
     name: currentRecipeName,
     used_ingredients: {},
     followed_recipe_exactly: true,
     comment: comment || null,
-    rating: { taste, prep_time: time },
+    rating: {
+      taste: Number.isNaN(taste) ? 0 : taste,
+      prep_time: Number.isNaN(time) ? 0 : time
+    },
     favorite: false
   };
   await fetch('/api/history', {
@@ -1091,14 +1117,16 @@ async function handleCookingSubmit(e) {
   const form = e.target;
   const taste = parseInt(form.taste.value, 10);
   const time = parseInt(form.time.value, 10);
-  if (!taste || !time) return;
   const comment = form.comment ? form.comment.value.trim() : null;
   const entry = {
     name: cookingState.recipe.name,
     used_ingredients: {},
     followed_recipe_exactly: true,
     comment: comment || null,
-    rating: { taste, prep_time: time },
+    rating: {
+      taste: Number.isNaN(taste) ? 0 : taste,
+      prep_time: Number.isNaN(time) ? 0 : time
+    },
     favorite: false
   };
   await fetch('/api/history', {
@@ -1122,6 +1150,7 @@ if (cookingNext) {
 }
 const cookingForm = document.getElementById('cooking-form');
 if (cookingForm) {
+  setupStarRatings(cookingForm);
   cookingForm.addEventListener('submit', handleCookingSubmit);
 }
 const cookingOverlay = document.getElementById('cooking-overlay');

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -144,7 +144,7 @@
                         <div>
                             <span data-i18n="label_taste" class="block mb-2">Smak:</span>
                             <div class="rating">
-                                <input type="radio" name="taste" value="1" class="mask mask-star-2 bg-orange-400" required />
+                                <input type="radio" name="taste" value="1" class="mask mask-star-2 bg-orange-400" />
                                 <input type="radio" name="taste" value="2" class="mask mask-star-2 bg-orange-400" />
                                 <input type="radio" name="taste" value="3" class="mask mask-star-2 bg-orange-400" />
                                 <input type="radio" name="taste" value="4" class="mask mask-star-2 bg-orange-400" />
@@ -154,7 +154,7 @@
                         <div>
                             <span data-i18n="label_prep_time" class="block mb-2">Czas przygotowania:</span>
                             <div class="rating">
-                                <input type="radio" name="time" value="1" class="mask mask-star-2 bg-orange-400" required />
+                                <input type="radio" name="time" value="1" class="mask mask-star-2 bg-orange-400" />
                                 <input type="radio" name="time" value="2" class="mask mask-star-2 bg-orange-400" />
                                 <input type="radio" name="time" value="3" class="mask mask-star-2 bg-orange-400" />
                                 <input type="radio" name="time" value="4" class="mask mask-star-2 bg-orange-400" />
@@ -281,7 +281,7 @@
             <div>
                 <span data-i18n="label_taste" class="block mb-2">Smak:</span>
                 <div class="rating">
-                    <input type="radio" name="taste" value="1" class="mask mask-star-2 bg-orange-400" required />
+                    <input type="radio" name="taste" value="1" class="mask mask-star-2 bg-orange-400" />
                     <input type="radio" name="taste" value="2" class="mask mask-star-2 bg-orange-400" />
                     <input type="radio" name="taste" value="3" class="mask mask-star-2 bg-orange-400" />
                     <input type="radio" name="taste" value="4" class="mask mask-star-2 bg-orange-400" />
@@ -291,7 +291,7 @@
             <div>
                 <span data-i18n="label_prep_time" class="block mb-2">Czas przygotowania:</span>
                 <div class="rating">
-                    <input type="radio" name="time" value="1" class="mask mask-star-2 bg-orange-400" required />
+                    <input type="radio" name="time" value="1" class="mask mask-star-2 bg-orange-400" />
                     <input type="radio" name="time" value="2" class="mask mask-star-2 bg-orange-400" />
                     <input type="radio" name="time" value="3" class="mask mask-star-2 bg-orange-400" />
                     <input type="radio" name="time" value="4" class="mask mask-star-2 bg-orange-400" />


### PR DESCRIPTION
## Summary
- allow users to clear selected stars and start from 0 when rating dishes
- handle zero ratings across the app and include them in averages

## Testing
- `python -m py_compile app/app.py`
- `node --check app/static/script.js`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6890e29102f0832a82310e2a7c513c95