### PR TITLE
Scope rating UI to history tab

### DIFF
--- a/app/static/script.js
+++ b/app/static/script.js
@@ -318,18 +318,8 @@ function checkLowStockToast() {
 
   document.querySelectorAll('[data-tab-target]').forEach(tab => {
     tab.addEventListener('click', () => {
-      document.querySelectorAll('[data-tab-target]').forEach(t => t.classList.remove('tab-active', 'font-bold'));
-      tab.classList.add('tab-active', 'font-bold');
-      document.querySelectorAll('.tab-panel').forEach(panel => (panel.style.display = 'none'));
       const targetId = tab.dataset.tabTarget;
-      const panel = document.getElementById(targetId);
-      if (panel) panel.style.display = 'block';
-      if (targetId !== 'tab-history') {
-        const overlay = document.getElementById('cooking-overlay');
-        if (overlay) overlay.classList.add('hidden');
-        const modal = document.getElementById('rating-modal');
-        if (modal) modal.close();
-      }
+      activateTab(targetId);
       if (targetId === 'tab-products') {
         loadProducts();
       } else if (targetId === 'tab-recipes') {
@@ -1052,6 +1042,12 @@ function activateTab(targetId) {
   document.querySelectorAll('.tab-panel').forEach(panel => (panel.style.display = 'none'));
   const panel = document.getElementById(targetId);
   if (panel) panel.style.display = 'block';
+  if (targetId !== 'tab-history') {
+    const overlay = document.getElementById('cooking-overlay');
+    if (overlay) overlay.classList.add('hidden');
+    const modal = document.getElementById('rating-modal');
+    if (modal) modal.close();
+  }
 }
 
 function openRatingModal(recipe) {

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -307,34 +307,6 @@
         </div>
 
     </div>
-    <div id="cooking-overlay" class="fixed inset-0 bg-base-100 z-50 hidden flex flex-col items-center justify-center p-4">
-        <div id="cooking-step" class="text-xl text-center mb-6"></div>
-        <button id="cooking-next" class="btn btn-primary mb-4" data-i18n="next_step_button">Dalej</button>
-        <form id="cooking-form" class="w-full max-w-md space-y-4 hidden">
-            <textarea name="comment" placeholder="Komentarz" data-i18n="comment_placeholder" class="textarea textarea-bordered w-full"></textarea>
-            <div>
-                <span data-i18n="label_taste" class="block mb-2">Smak:</span>
-                <div class="rating">
-                    <input type="radio" name="taste" value="1" class="mask mask-star-2 bg-orange-400" />
-                    <input type="radio" name="taste" value="2" class="mask mask-star-2 bg-orange-400" />
-                    <input type="radio" name="taste" value="3" class="mask mask-star-2 bg-orange-400" />
-                    <input type="radio" name="taste" value="4" class="mask mask-star-2 bg-orange-400" />
-                    <input type="radio" name="taste" value="5" class="mask mask-star-2 bg-orange-400" />
-                </div>
-            </div>
-            <div>
-                <span data-i18n="label_prep_time" class="block mb-2">Czas przygotowania:</span>
-                <div class="rating">
-                    <input type="radio" name="time" value="1" class="mask mask-star-2 bg-orange-400" />
-                    <input type="radio" name="time" value="2" class="mask mask-star-2 bg-orange-400" />
-                    <input type="radio" name="time" value="3" class="mask mask-star-2 bg-orange-400" />
-                    <input type="radio" name="time" value="4" class="mask mask-star-2 bg-orange-400" />
-                    <input type="radio" name="time" value="5" class="mask mask-star-2 bg-orange-400" />
-                </div>
-            </div>
-            <button type="submit" class="btn btn-success" data-i18n="save_button">Zapisz</button>
-        </form>
-    </div>
     <script src="https://cdn.jsdelivr.net/npm/tesseract.js@2.1.5/dist/tesseract.min.js"></script>
     <script src="{{ url_for('static', filename='script.js') }}"></script>
 </body>


### PR DESCRIPTION
## Summary
- Remove duplicate cooking overlay so rating controls live only in the history tab
- Centralize tab activation logic to hide rating UI when not on the history tab

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6890e6e49dc0832a966a3892e20243d8