### PR TITLE
feat: add toggleable star ratings

### DIFF
--- a/app/static/script.js
+++ b/app/static/script.js
@@ -1067,20 +1067,29 @@ function setupStarRatings(form) {
   groups.forEach(group => {
     group.dataset.current = '0';
     const inputs = group.querySelectorAll('input');
+    const update = () => {
+      const val = parseInt(group.dataset.current, 10);
+      inputs.forEach((input, idx) => {
+        const active = idx < val;
+        input.classList.toggle('bg-orange-400', active);
+        input.classList.toggle('bg-base-300', !active);
+      });
+    };
+    update();
     inputs.forEach(input => {
-      input.addEventListener('click', () => {
+      input.addEventListener('click', e => {
+        e.preventDefault();
         if (group.dataset.current === input.value) {
-          inputs.forEach(i => (i.checked = false));
           group.dataset.current = '0';
         } else {
           group.dataset.current = input.value;
         }
+        update();
       });
     });
-  });
-  form.addEventListener('reset', () => {
-    groups.forEach(g => {
-      g.dataset.current = '0';
+    form.addEventListener('reset', () => {
+      group.dataset.current = '0';
+      update();
     });
   });
 }
@@ -1088,8 +1097,10 @@ function setupStarRatings(form) {
 async function handleRatingSubmit(e) {
   e.preventDefault();
   const form = e.target;
-  const taste = parseInt(form.taste.value, 10);
-  const time = parseInt(form.time.value, 10);
+  const tasteGroup = form.querySelector('input[name="taste"]').closest('.rating');
+  const timeGroup = form.querySelector('input[name="time"]').closest('.rating');
+  const taste = Number(tasteGroup?.dataset.current || 0);
+  const time = Number(timeGroup?.dataset.current || 0);
   const comment = form.comment ? form.comment.value.trim() : null;
   const entry = {
     name: currentRecipeName,
@@ -1097,8 +1108,8 @@ async function handleRatingSubmit(e) {
     followed_recipe_exactly: true,
     comment: comment || null,
     rating: {
-      taste: Number.isNaN(taste) ? 0 : taste,
-      prep_time: Number.isNaN(time) ? 0 : time
+      taste: taste,
+      prep_time: time
     },
     favorite: false
   };
@@ -1144,8 +1155,10 @@ function openCookingMode(recipe) {
 async function handleCookingSubmit(e) {
   e.preventDefault();
   const form = e.target;
-  const taste = parseInt(form.taste.value, 10);
-  const time = parseInt(form.time.value, 10);
+  const tasteGroup = form.querySelector('input[name="taste"]').closest('.rating');
+  const timeGroup = form.querySelector('input[name="time"]').closest('.rating');
+  const taste = Number(tasteGroup?.dataset.current || 0);
+  const time = Number(timeGroup?.dataset.current || 0);
   const comment = form.comment ? form.comment.value.trim() : null;
   const entry = {
     name: cookingState.recipe.name,
@@ -1153,8 +1166,8 @@ async function handleCookingSubmit(e) {
     followed_recipe_exactly: true,
     comment: comment || null,
     rating: {
-      taste: Number.isNaN(taste) ? 0 : taste,
-      prep_time: Number.isNaN(time) ? 0 : time
+      taste: taste,
+      prep_time: time
     },
     favorite: false
   };

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -149,21 +149,21 @@
                         <div>
                             <span data-i18n="label_taste" class="block mb-2">Smak:</span>
                             <div class="rating">
-                                <input type="radio" name="taste" value="1" class="mask mask-star-2 bg-orange-400" />
-                                <input type="radio" name="taste" value="2" class="mask mask-star-2 bg-orange-400" />
-                                <input type="radio" name="taste" value="3" class="mask mask-star-2 bg-orange-400" />
-                                <input type="radio" name="taste" value="4" class="mask mask-star-2 bg-orange-400" />
-                                <input type="radio" name="taste" value="5" class="mask mask-star-2 bg-orange-400" />
+                                <input type="radio" name="taste" value="1" class="mask mask-star-2 bg-base-300" />
+                                <input type="radio" name="taste" value="2" class="mask mask-star-2 bg-base-300" />
+                                <input type="radio" name="taste" value="3" class="mask mask-star-2 bg-base-300" />
+                                <input type="radio" name="taste" value="4" class="mask mask-star-2 bg-base-300" />
+                                <input type="radio" name="taste" value="5" class="mask mask-star-2 bg-base-300" />
                             </div>
                         </div>
                         <div>
                             <span data-i18n="label_prep_time" class="block mb-2">Czas przygotowania:</span>
                             <div class="rating">
-                                <input type="radio" name="time" value="1" class="mask mask-star-2 bg-orange-400" />
-                                <input type="radio" name="time" value="2" class="mask mask-star-2 bg-orange-400" />
-                                <input type="radio" name="time" value="3" class="mask mask-star-2 bg-orange-400" />
-                                <input type="radio" name="time" value="4" class="mask mask-star-2 bg-orange-400" />
-                                <input type="radio" name="time" value="5" class="mask mask-star-2 bg-orange-400" />
+                                <input type="radio" name="time" value="1" class="mask mask-star-2 bg-base-300" />
+                                <input type="radio" name="time" value="2" class="mask mask-star-2 bg-base-300" />
+                                <input type="radio" name="time" value="3" class="mask mask-star-2 bg-base-300" />
+                                <input type="radio" name="time" value="4" class="mask mask-star-2 bg-base-300" />
+                                <input type="radio" name="time" value="5" class="mask mask-star-2 bg-base-300" />
                             </div>
                         </div>
                         <div>
@@ -185,21 +185,21 @@
                     <div>
                         <span data-i18n="label_taste" class="block mb-2">Smak:</span>
                         <div class="rating">
-                            <input type="radio" name="taste" value="1" class="mask mask-star-2 bg-orange-400" required />
-                            <input type="radio" name="taste" value="2" class="mask mask-star-2 bg-orange-400" />
-                            <input type="radio" name="taste" value="3" class="mask mask-star-2 bg-orange-400" />
-                            <input type="radio" name="taste" value="4" class="mask mask-star-2 bg-orange-400" />
-                            <input type="radio" name="taste" value="5" class="mask mask-star-2 bg-orange-400" />
+                            <input type="radio" name="taste" value="1" class="mask mask-star-2 bg-base-300" />
+                            <input type="radio" name="taste" value="2" class="mask mask-star-2 bg-base-300" />
+                            <input type="radio" name="taste" value="3" class="mask mask-star-2 bg-base-300" />
+                            <input type="radio" name="taste" value="4" class="mask mask-star-2 bg-base-300" />
+                            <input type="radio" name="taste" value="5" class="mask mask-star-2 bg-base-300" />
                         </div>
                     </div>
                     <div>
                         <span data-i18n="label_prep_time" class="block mb-2">Czas przygotowania:</span>
                         <div class="rating">
-                            <input type="radio" name="time" value="1" class="mask mask-star-2 bg-orange-400" required />
-                            <input type="radio" name="time" value="2" class="mask mask-star-2 bg-orange-400" />
-                            <input type="radio" name="time" value="3" class="mask mask-star-2 bg-orange-400" />
-                            <input type="radio" name="time" value="4" class="mask mask-star-2 bg-orange-400" />
-                            <input type="radio" name="time" value="5" class="mask mask-star-2 bg-orange-400" />
+                            <input type="radio" name="time" value="1" class="mask mask-star-2 bg-base-300" />
+                            <input type="radio" name="time" value="2" class="mask mask-star-2 bg-base-300" />
+                            <input type="radio" name="time" value="3" class="mask mask-star-2 bg-base-300" />
+                            <input type="radio" name="time" value="4" class="mask mask-star-2 bg-base-300" />
+                            <input type="radio" name="time" value="5" class="mask mask-star-2 bg-base-300" />
                         </div>
                     </div>
                     <button type="submit" class="btn btn-success" data-i18n="save_button">Zapisz</button>


### PR DESCRIPTION
## Summary
- allow star ratings in history to be toggled off by clicking the active star
- record numeric ratings from 0–5 for taste and prep time

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_6890e8941128832ab07c5f7563c62fc2