### PR TITLE
feat: enhance star rating with hover

### DIFF
--- a/app/static/script.js
+++ b/app/static/script.js
@@ -1063,27 +1063,42 @@ function setupStarRatings(form) {
   const groups = form.querySelectorAll('.rating');
   groups.forEach(group => {
     group.dataset.current = '0';
-    const inputs = group.querySelectorAll('input');
+    const stars = group.querySelectorAll('.star');
     const update = () => {
       const val = parseInt(group.dataset.current, 10);
-      inputs.forEach((input, idx) => {
+      stars.forEach((star, idx) => {
         const active = idx < val;
-        input.classList.toggle('bg-orange-400', active);
-        input.classList.toggle('bg-base-300', !active);
+        star.classList.toggle('fa-solid', active);
+        star.classList.toggle('fa-regular', !active);
+        star.classList.toggle('text-yellow-400', active);
+        star.classList.toggle('text-base-300', !active);
       });
     };
     update();
-    inputs.forEach(input => {
-      input.addEventListener('click', e => {
-        e.preventDefault();
-        if (group.dataset.current === input.value) {
+    stars.forEach((star, idx) => {
+      const val = idx + 1;
+      star.addEventListener('mouseenter', () => {
+        stars.forEach((s, i) => {
+          const active = i < val;
+          s.classList.toggle('fa-solid', active);
+          s.classList.toggle('fa-regular', !active);
+          s.classList.toggle('text-yellow-400', active);
+          s.classList.toggle('text-base-300', !active);
+        });
+      });
+      star.addEventListener('mouseleave', () => {
+        update();
+      });
+      star.addEventListener('click', () => {
+        if (group.dataset.current === String(val)) {
           group.dataset.current = '0';
         } else {
-          group.dataset.current = input.value;
+          group.dataset.current = String(val);
         }
         update();
       });
     });
+    group.addEventListener('mouseleave', () => update());
     form.addEventListener('reset', () => {
       group.dataset.current = '0';
       update();
@@ -1094,8 +1109,8 @@ function setupStarRatings(form) {
 async function handleRatingSubmit(e) {
   e.preventDefault();
   const form = e.target;
-  const tasteGroup = form.querySelector('input[name="taste"]').closest('.rating');
-  const timeGroup = form.querySelector('input[name="time"]').closest('.rating');
+  const tasteGroup = form.querySelector('.rating[data-name="taste"]');
+  const timeGroup = form.querySelector('.rating[data-name="time"]');
   const taste = Number(tasteGroup?.dataset.current || 0);
   const time = Number(timeGroup?.dataset.current || 0);
   const comment = form.comment ? form.comment.value.trim() : null;
@@ -1152,8 +1167,8 @@ function openCookingMode(recipe) {
 async function handleCookingSubmit(e) {
   e.preventDefault();
   const form = e.target;
-  const tasteGroup = form.querySelector('input[name="taste"]').closest('.rating');
-  const timeGroup = form.querySelector('input[name="time"]').closest('.rating');
+  const tasteGroup = form.querySelector('.rating[data-name="taste"]');
+  const timeGroup = form.querySelector('.rating[data-name="time"]');
   const taste = Number(tasteGroup?.dataset.current || 0);
   const time = Number(timeGroup?.dataset.current || 0);
   const comment = form.comment ? form.comment.value.trim() : null;

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -148,22 +148,22 @@
                     <div class="py-4 space-y-4">
                         <div>
                             <span data-i18n="label_taste" class="block mb-2">Smak:</span>
-                            <div class="rating">
-                                <input type="radio" name="taste" value="1" class="mask mask-star-2 bg-base-300" />
-                                <input type="radio" name="taste" value="2" class="mask mask-star-2 bg-base-300" />
-                                <input type="radio" name="taste" value="3" class="mask mask-star-2 bg-base-300" />
-                                <input type="radio" name="taste" value="4" class="mask mask-star-2 bg-base-300" />
-                                <input type="radio" name="taste" value="5" class="mask mask-star-2 bg-base-300" />
+                            <div class="rating flex gap-1 text-2xl" data-name="taste">
+                                <i class="fa-regular fa-star star cursor-pointer text-base-300"></i>
+                                <i class="fa-regular fa-star star cursor-pointer text-base-300"></i>
+                                <i class="fa-regular fa-star star cursor-pointer text-base-300"></i>
+                                <i class="fa-regular fa-star star cursor-pointer text-base-300"></i>
+                                <i class="fa-regular fa-star star cursor-pointer text-base-300"></i>
                             </div>
                         </div>
                         <div>
                             <span data-i18n="label_prep_time" class="block mb-2">Czas przygotowania:</span>
-                            <div class="rating">
-                                <input type="radio" name="time" value="1" class="mask mask-star-2 bg-base-300" />
-                                <input type="radio" name="time" value="2" class="mask mask-star-2 bg-base-300" />
-                                <input type="radio" name="time" value="3" class="mask mask-star-2 bg-base-300" />
-                                <input type="radio" name="time" value="4" class="mask mask-star-2 bg-base-300" />
-                                <input type="radio" name="time" value="5" class="mask mask-star-2 bg-base-300" />
+                            <div class="rating flex gap-1 text-2xl" data-name="time">
+                                <i class="fa-regular fa-star star cursor-pointer text-base-300"></i>
+                                <i class="fa-regular fa-star star cursor-pointer text-base-300"></i>
+                                <i class="fa-regular fa-star star cursor-pointer text-base-300"></i>
+                                <i class="fa-regular fa-star star cursor-pointer text-base-300"></i>
+                                <i class="fa-regular fa-star star cursor-pointer text-base-300"></i>
                             </div>
                         </div>
                         <div>
@@ -184,22 +184,22 @@
                     <textarea name="comment" placeholder="Komentarz" data-i18n="comment_placeholder" class="textarea textarea-bordered w-full"></textarea>
                     <div>
                         <span data-i18n="label_taste" class="block mb-2">Smak:</span>
-                        <div class="rating">
-                            <input type="radio" name="taste" value="1" class="mask mask-star-2 bg-base-300" />
-                            <input type="radio" name="taste" value="2" class="mask mask-star-2 bg-base-300" />
-                            <input type="radio" name="taste" value="3" class="mask mask-star-2 bg-base-300" />
-                            <input type="radio" name="taste" value="4" class="mask mask-star-2 bg-base-300" />
-                            <input type="radio" name="taste" value="5" class="mask mask-star-2 bg-base-300" />
+                        <div class="rating flex gap-1 text-2xl" data-name="taste">
+                            <i class="fa-regular fa-star star cursor-pointer text-base-300"></i>
+                            <i class="fa-regular fa-star star cursor-pointer text-base-300"></i>
+                            <i class="fa-regular fa-star star cursor-pointer text-base-300"></i>
+                            <i class="fa-regular fa-star star cursor-pointer text-base-300"></i>
+                            <i class="fa-regular fa-star star cursor-pointer text-base-300"></i>
                         </div>
                     </div>
                     <div>
                         <span data-i18n="label_prep_time" class="block mb-2">Czas przygotowania:</span>
-                        <div class="rating">
-                            <input type="radio" name="time" value="1" class="mask mask-star-2 bg-base-300" />
-                            <input type="radio" name="time" value="2" class="mask mask-star-2 bg-base-300" />
-                            <input type="radio" name="time" value="3" class="mask mask-star-2 bg-base-300" />
-                            <input type="radio" name="time" value="4" class="mask mask-star-2 bg-base-300" />
-                            <input type="radio" name="time" value="5" class="mask mask-star-2 bg-base-300" />
+                        <div class="rating flex gap-1 text-2xl" data-name="time">
+                            <i class="fa-regular fa-star star cursor-pointer text-base-300"></i>
+                            <i class="fa-regular fa-star star cursor-pointer text-base-300"></i>
+                            <i class="fa-regular fa-star star cursor-pointer text-base-300"></i>
+                            <i class="fa-regular fa-star star cursor-pointer text-base-300"></i>
+                            <i class="fa-regular fa-star star cursor-pointer text-base-300"></i>
                         </div>
                     </div>
                     <button type="submit" class="btn btn-success" data-i18n="save_button">Zapisz</button>


### PR DESCRIPTION
## Summary
- replace radio-based star ratings with FontAwesome icons for taste and prep time
- add hover and click interactions to highlight and select stars

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6890ebf45848832ab02ff981ab9f5acf