### PR TITLE
Enable header tap toggling on mobile

### DIFF
--- a/app/static/script.js
+++ b/app/static/script.js
@@ -844,6 +844,14 @@ function renderProducts(data) {
       toggleStorage();
     });
 
+    storageHeader.addEventListener('click', () => {
+      const isMobile =
+        document.documentElement.getAttribute('data-layout') === 'mobile';
+      if (isMobile) {
+        toggleStorage();
+      }
+    });
+
     const categories = storages[stor];
     Object.keys(categories)
       .sort((a, b) => categoryName(a).localeCompare(categoryName(b)))


### PR DESCRIPTION
## Summary
- allow tapping anywhere on a storage header to collapse or expand in mobile layout

## Testing
- `python -m py_compile app/app.py`
- `node --check app/static/script.js`


------
https://chatgpt.com/codex/tasks/task_e_689100cda5e0832a994d5554b5612fc7