### PR TITLE
style: improve mobile action icon spacing

### DIFF
--- a/app/static/styles.css
+++ b/app/static/styles.css
@@ -16,14 +16,12 @@ html[data-layout="desktop"] .main-container {
   position: fixed;
   top: 1rem;
   right: 1rem;
-  display: flex;
-  gap: 1rem;
+  padding: 0.5rem;
 }
 
 html[data-layout="mobile"] .corner-icons {
   top: 0.5rem;
-  left: auto;
-  right: 1rem;
+  right: 0.5rem;
 }
 
 html[data-layout="mobile"] #controls {

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -16,11 +16,17 @@
 </head>
 <body class="min-h-screen bg-base-100">
 <div id="toast-container" class="toast toast-end toast-top"></div>
-<div class="corner-icons">
-    <button id="layout-toggle" class="text-xl p-2 bg-transparent border-0"><i id="layout-icon" class="fa-solid fa-mobile-screen-button"></i></button>
-    <button id="lang-toggle" class="text-xl p-2 bg-transparent border-0">PL</button>
-    <button id="theme-toggle" class="text-xl p-2 bg-transparent border-0"><i id="theme-icon" class="fa-solid fa-circle-half-stroke"></i></button>
-    <button id="install-btn" class="text-xl p-2 bg-transparent border-0" style="display:none;"><i class="fa-solid fa-download"></i></button>
+<div class="corner-icons flex justify-end gap-3 p-2">
+    <button id="layout-toggle" aria-label="Toggle layout" class="text-xl p-2 bg-transparent border-0">
+        <i id="layout-icon" class="fa-solid fa-mobile-screen-button"></i>
+    </button>
+    <button id="lang-toggle" aria-label="Toggle language" class="text-xl p-2 bg-transparent border-0">PL</button>
+    <button id="theme-toggle" aria-label="Toggle theme" class="text-xl p-2 bg-transparent border-0">
+        <i id="theme-icon" class="fa-solid fa-circle-half-stroke"></i>
+    </button>
+    <button id="install-btn" aria-label="Install app" class="text-xl p-2 bg-transparent border-0" style="display:none;">
+        <i class="fa-solid fa-download"></i>
+    </button>
 </div>
 <div class="max-w-screen-lg mx-auto px-4 py-6 main-container">
     <div class="tabs tabs-bordered flex-nowrap overflow-x-auto whitespace-nowrap mb-6">


### PR DESCRIPTION
## Summary
- space out mobile action icons with flex layout
- add ARIA labels for better accessibility

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_689100cab4a0832a8eb8173cda25a5ed