### PR TITLE
Add mobile receipt scan input

### DIFF
--- a/app/static/translations/en.json
+++ b/app/static/translations/en.json
@@ -78,6 +78,7 @@
   "settings_unit_code": "Code",
   "settings_unit_pl": "Polish",
   "settings_unit_en": "English",
+  "scan_receipt": "Scan receipt",
   "ocr_not_recognized": "Not recognized",
   "confirm_import": "Confirm import",
   "accept_action": "Accept",

--- a/app/static/translations/pl.json
+++ b/app/static/translations/pl.json
@@ -78,6 +78,7 @@
   "settings_unit_code": "Kod",
   "settings_unit_pl": "Polski",
   "settings_unit_en": "Angielski",
+  "scan_receipt": "Zeskanuj paragon",
   "ocr_not_recognized": "Nie rozpoznano",
   "confirm_import": "Zatwierdź import",
   "accept_action": "Akceptuj",

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -216,6 +216,8 @@
         <div id="tab-shopping" class="tab-panel" style="display:none;">
             <h1 class="text-2xl font-bold mb-6" data-i18n="heading_shopping">Lista zakupów</h1>
             <button id="receipt-btn" class="btn btn-secondary btn-sm mb-4" data-i18n="receipt_import">Dodaj z paragonu</button>
+            <input id="receipt-scan" type="file" accept="image/*" capture="environment" class="hidden" />
+            <label for="receipt-scan" class="btn btn-primary btn-sm mb-4" data-i18n="scan_receipt">Zeskanuj paragon</label>
             <div id="suggestions-section" class="mb-8">
                 <h2 class="text-xl font-semibold mb-4" data-i18n="heading_suggestions">Propozycje</h2>
                 <div class="overflow-x-auto">


### PR DESCRIPTION
## Summary
- Add hidden mobile-friendly file input and label for scanning receipts
- Translate new "Scan receipt" label into Polish and English
- Refactor receipt import to use a reusable `handleReceiptUpload` and hook up new input

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68910fbdfb90832a823ee0335270363e