### PR TITLE
Hide corner icons when not at top

### DIFF
--- a/app/static/script.js
+++ b/app/static/script.js
@@ -13,6 +13,7 @@ let currentRecipeName = null;
 let currentRecipeSort = 'name';
 let cookingState = { recipe: null, step: 0 };
 let touchStartX = 0;
+let cornerIconsTop = true;
 
 let uiTranslations = { pl: {}, en: {} };
 let translations = { products: {} };
@@ -20,6 +21,17 @@ let units = {};
 
 const html = document.documentElement;
 const layoutIcon = document.getElementById('layout-icon');
+const cornerIcons = document.querySelector('.corner-icons');
+const topSentinel = document.getElementById('top-sentinel');
+
+function updateCornerIconsVisibility() {
+  if (!cornerIcons) return;
+  if (html.getAttribute('data-layout') === 'mobile') {
+    cornerIcons.style.display = cornerIconsTop ? 'flex' : 'none';
+  } else {
+    cornerIcons.style.display = 'flex';
+  }
+}
 let state = {
   displayMode: html.getAttribute('data-layout') || 'desktop',
   expandedStorages: {},
@@ -32,6 +44,7 @@ function setDisplayMode(mode) {
   if (layoutIcon) {
     layoutIcon.className = mode === 'desktop' ? 'fa-regular fa-mobile' : 'fa-solid fa-desktop';
   }
+  updateCornerIconsVisibility();
 }
 
 function detectInitialDisplayMode() {
@@ -44,6 +57,15 @@ function detectInitialDisplayMode() {
 }
 
 detectInitialDisplayMode();
+updateCornerIconsVisibility();
+
+if (topSentinel && cornerIcons) {
+  const observer = new IntersectionObserver(entries => {
+    cornerIconsTop = entries[0].isIntersecting;
+    updateCornerIconsVisibility();
+  });
+  observer.observe(topSentinel);
+}
 
 async function loadTranslations() {
   try {
@@ -310,6 +332,7 @@ function checkLowStockToast() {
     document.documentElement.setAttribute('lang', currentLang);
     UNIT = 'szt';
     applyTranslations();
+    updateThemeToggleLabel();
     if ('serviceWorker' in navigator) {
       navigator.serviceWorker.register('/service-worker.js');
     }
@@ -335,6 +358,7 @@ function checkLowStockToast() {
         document.documentElement.setAttribute('lang', currentLang);
         UNIT = 'szt';
         applyTranslations();
+        updateThemeToggleLabel();
         renderUnitsAdmin();
         if (activeTarget) {
           document.querySelectorAll('.tab-panel').forEach(panel => (panel.style.display = 'none'));
@@ -1295,6 +1319,13 @@ if (cookingOverlay) {
 // Theme toggle
 const themeToggle = document.getElementById('theme-toggle');
 const themeIcon = document.getElementById('theme-icon');
+function updateThemeToggleLabel() {
+  if (!themeToggle) return;
+  const key = document.documentElement.getAttribute('data-theme') === 'dark' ? 'theme_light' : 'theme_dark';
+  const label = t(key);
+  themeToggle.setAttribute('aria-label', label);
+  themeToggle.setAttribute('title', label);
+}
 if (themeToggle && themeIcon) {
   themeToggle.addEventListener('click', () => {
     const html = document.documentElement;
@@ -1302,6 +1333,7 @@ if (themeToggle && themeIcon) {
     const next = current === 'dark' ? 'light' : 'dark';
     html.setAttribute('data-theme', next);
     themeIcon.className = 'fa-solid fa-circle-half-stroke';
+    updateThemeToggleLabel();
   });
 }
 

--- a/app/static/styles.css
+++ b/app/static/styles.css
@@ -13,15 +13,18 @@ html[data-layout="desktop"] .main-container {
 }
 
 .corner-icons {
-  position: fixed;
-  top: 1rem;
-  right: 1rem;
+  position: sticky;
+  top: 0;
+  right: 0;
+  width: 100%;
+  display: flex;
+  justify-content: flex-end;
   padding: 0.5rem;
+  z-index: 10;
 }
 
 html[data-layout="mobile"] .corner-icons {
-  top: 0.5rem;
-  right: 0.5rem;
+  top: 0;
 }
 
 html[data-layout="mobile"] #controls {

--- a/app/static/translations/en.json
+++ b/app/static/translations/en.json
@@ -12,6 +12,8 @@
   "state_filter_all": "All",
   "change_view_toggle_grouped": "Categories view",
   "change_view_toggle_flat": "Flat list",
+  "theme_light": "Light mode",
+  "theme_dark": "Dark mode",
   "edit_mode_button_on": "Edit",
   "edit_mode_button_off": "Finish editing",
   "save_button": "Save",

--- a/app/static/translations/pl.json
+++ b/app/static/translations/pl.json
@@ -12,6 +12,8 @@
   "state_filter_all": "Wszystkie",
   "change_view_toggle_grouped": "Widok z podziałem",
   "change_view_toggle_flat": "Płaska lista",
+  "theme_light": "Tryb jasny",
+  "theme_dark": "Tryb ciemny",
   "edit_mode_button_on": "Edytuj",
   "edit_mode_button_off": "Zakończ edycję",
   "save_button": "Zapisz",

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -16,7 +16,8 @@
 </head>
 <body class="min-h-screen bg-base-100">
 <div id="toast-container" class="toast toast-end top-[4.5rem]"></div>
-<div class="corner-icons flex justify-end gap-3 p-2">
+<div id="top-sentinel"></div>
+<div class="corner-icons flex justify-end gap-3 p-2 bg-base-100">
     <button id="layout-toggle" aria-label="Toggle layout" class="text-xl p-2 bg-transparent border-0">
         <i id="layout-icon" class="fa-solid fa-mobile-screen-button"></i>
     </button>


### PR DESCRIPTION
## Summary
- Move corner icon bar into a sticky container that only displays when scrolled to the page top.
- Attach intersection observer to toggle visibility in mobile layout.
- Add translations and accessible labels for theme toggle.

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6891148d0e4c832a8a3ff4e2972a7fec