### PR TITLE
feat: streamline mobile quantity input

### DIFF
--- a/app/static/script.js
+++ b/app/static/script.js
@@ -1470,44 +1470,33 @@ function renderShoppingList() {
 
     const qtyTd = document.createElement('td');
     const qtyWrap = document.createElement('div');
-    qtyWrap.className = 'flex items-center justify-center';
+    qtyWrap.className = 'flex items-center justify-center gap-2';
     const dec = document.createElement('button');
     dec.type = 'button';
-    dec.textContent = '−';
-    dec.className = 'btn btn-outline btn-xs';
+    dec.innerHTML = '<i class="fa-solid fa-minus"></i>';
+    dec.className = 'mx-2';
     dec.disabled = item.inCart;
-    const qtyInput = document.createElement('input');
-    qtyInput.type = 'number';
-    qtyInput.min = '1';
-    qtyInput.value = item.quantity;
-    qtyInput.className = 'input input-bordered w-16 text-center mx-2 no-spinner';
-    qtyInput.disabled = item.inCart;
+    const qtySpan = document.createElement('span');
+    qtySpan.textContent = item.quantity;
+    qtySpan.className = 'text-center w-8';
     const inc = document.createElement('button');
     inc.type = 'button';
-    inc.textContent = '+';
-    inc.className = 'btn btn-outline btn-xs';
+    inc.innerHTML = '<i class="fa-solid fa-plus"></i>';
+    inc.className = 'mx-2';
     inc.disabled = item.inCart;
     dec.addEventListener('click', () => {
-      const v = parseInt(qtyInput.value) || 1;
-      const newVal = Math.max(1, v - 1);
-      qtyInput.value = newVal;
+      const newVal = Math.max(1, item.quantity - 1);
       item.quantity = newVal;
+      qtySpan.textContent = newVal;
       saveShoppingList();
     });
     inc.addEventListener('click', () => {
-      const v = parseInt(qtyInput.value) || 1;
-      const newVal = v + 1;
-      qtyInput.value = newVal;
+      const newVal = item.quantity + 1;
       item.quantity = newVal;
+      qtySpan.textContent = newVal;
       saveShoppingList();
     });
-    qtyInput.addEventListener('change', () => {
-      const v = Math.max(1, parseInt(qtyInput.value) || 1);
-      qtyInput.value = v;
-      item.quantity = v;
-      saveShoppingList();
-    });
-    qtyWrap.append(dec, qtyInput, inc);
+    qtyWrap.append(dec, qtySpan, inc);
     qtyTd.appendChild(qtyWrap);
     tr.appendChild(qtyTd);
 

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -90,9 +90,9 @@
             <form id="add-form" class="grid grid-cols-1 sm:grid-cols-8 gap-2 mb-8">
                 <input name="name" placeholder="nazwa" data-i18n="add_form_name_placeholder" required class="input input-bordered w-full">
                 <input name="quantity" placeholder="ilość" data-i18n="add_form_quantity_placeholder" required class="input input-bordered w-full">
-                <input name="package_size" placeholder="w opak." data-i18n="add_form_package_size_placeholder" class="input input-bordered w-full" type="number" value="1">
-                <input name="pack_size" placeholder="paczka" data-i18n="add_form_pack_size_placeholder" class="input input-bordered w-full" type="number">
-                <input name="threshold" placeholder="próg" data-i18n="add_form_threshold_placeholder" class="input input-bordered w-full" type="number">
+                <input name="package_size" placeholder="w opak." data-i18n="add_form_package_size_placeholder" class="input input-bordered w-full no-spinner" type="number" value="1">
+                <input name="pack_size" placeholder="paczka" data-i18n="add_form_pack_size_placeholder" class="input input-bordered w-full no-spinner" type="number">
+                <input name="threshold" placeholder="próg" data-i18n="add_form_threshold_placeholder" class="input input-bordered w-full no-spinner" type="number">
                 <select name="category" required class="select select-bordered w-full">
                     <option value="uncategorized" data-i18n="category_uncategorized">brak kategorii</option>
                     <option value="fresh_veg" data-i18n="category_fresh_veg">Świeże warzywa</option>
@@ -248,10 +248,10 @@
                 <h2 class="text-xl font-semibold mb-4" data-i18n="heading_add_product">Dodaj produkt</h2>
                 <div class="flex flex-wrap items-center gap-2">
                     <input id="manual-name" list="product-datalist" class="input input-bordered flex-1" placeholder="nazwa" data-i18n="add_form_name_placeholder">
-                    <div class="flex items-center">
-                        <button id="manual-dec" type="button" class="btn btn-outline btn-xs">−</button>
-                        <input id="manual-qty" type="number" min="1" value="1" class="input input-bordered w-16 text-center mx-2 no-spinner" placeholder="1" data-i18n="add_form_quantity_placeholder">
-                        <button id="manual-inc" type="button" class="btn btn-outline btn-xs">+</button>
+                    <div class="flex items-center gap-2">
+                        <button id="manual-dec" type="button" class="mx-2"><i class="fa-solid fa-minus"></i></button>
+                        <input id="manual-qty" type="number" min="1" value="1" class="input input-bordered w-16 text-center no-spinner" placeholder="1" data-i18n="add_form_quantity_placeholder">
+                        <button id="manual-inc" type="button" class="mx-2"><i class="fa-solid fa-plus"></i></button>
                     </div>
                     <button id="manual-add-btn" class="btn btn-primary btn-sm" data-i18n="save_button">Zapisz</button>
                 </div>


### PR DESCRIPTION
## Summary
- streamline shopping-list quantity cell with minus/plus icons and centered value
- remove browser spinner arrows on numeric fields and update manual-add UI

## Testing
- `pytest`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_689116accb7c832a91c5899b608804e7