### PR TITLE
Improve shopping list layout

### DIFF
--- a/app/static/script.js
+++ b/app/static/script.js
@@ -1426,8 +1426,8 @@ function renderSuggestions() {
 
     const acceptTd = document.createElement('td');
     const acceptBtn = document.createElement('button');
-    acceptBtn.className = 'text-success';
-    acceptBtn.innerHTML = '<i class="fa-regular fa-circle-check"></i>';
+    acceptBtn.className = 'text-success text-xl';
+    acceptBtn.innerHTML = '<i class="fa-solid fa-check"></i>';
     acceptBtn.setAttribute('aria-label', t('accept'));
     acceptBtn.addEventListener('click', () => {
       addToShoppingList(p.name, parseInt(qtyInput.value) || 1);
@@ -1438,8 +1438,8 @@ function renderSuggestions() {
 
     const rejectTd = document.createElement('td');
     const rejectBtn = document.createElement('button');
-    rejectBtn.className = 'text-error';
-    rejectBtn.innerHTML = '<i class="fa-regular fa-circle-xmark"></i>';
+    rejectBtn.className = 'text-error text-xl';
+    rejectBtn.innerHTML = '<i class="fa-solid fa-xmark"></i>';
     rejectBtn.setAttribute('aria-label', t('reject'));
     rejectBtn.addEventListener('click', () => tr.remove());
     rejectTd.appendChild(rejectBtn);

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -244,7 +244,7 @@
                     </table>
                 </div>
             </div>
-            <div id="manual-add-section" class="mb-8 p-4 border rounded">
+            <div id="manual-add-section" class="mb-8 mt-4 p-4 border-t border-base-300">
                 <h2 class="text-xl font-semibold mb-4" data-i18n="heading_add_product">Dodaj produkt</h2>
                 <div class="flex flex-wrap items-center gap-2">
                     <input id="manual-name" list="product-datalist" class="input input-bordered flex-1" placeholder="nazwa" data-i18n="add_form_name_placeholder">


### PR DESCRIPTION
## Summary
- visually separate the Add Product section from the shopping list with top spacing and divider
- switch suggestion actions to solid check and x icons for better visibility

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689116aed61c832aa8a1bd3ef8c42827