### PR TITLE
Style shopping list quantity controls for mobile

### DIFF
--- a/app/static/script.js
+++ b/app/static/script.js
@@ -609,10 +609,12 @@ function checkLowStockToast() {
   const manualInc = document.getElementById('manual-inc');
   if (manualDec && manualInc && manualQty) {
     manualDec.addEventListener('click', () => {
-      manualQty.value = Math.max(1, (parseInt(manualQty.value) || 1) - 1);
+      const current = parseInt(manualQty.textContent) || 1;
+      manualQty.textContent = Math.max(1, current - 1);
     });
     manualInc.addEventListener('click', () => {
-      manualQty.value = (parseInt(manualQty.value) || 1) + 1;
+      const current = parseInt(manualQty.textContent) || 1;
+      manualQty.textContent = current + 1;
     });
   }
   const manualAddBtn = document.getElementById('manual-add-btn');
@@ -1371,15 +1373,15 @@ function addToShoppingList(name, quantity = 1) {
 
 function handleManualAdd() {
   const nameInput = document.getElementById('manual-name');
-  const qtyInput = document.getElementById('manual-qty');
+  const qtyDisplay = document.getElementById('manual-qty');
   let name = nameInput.value.trim();
-  const qty = parseInt(qtyInput.value) || 1;
+  const qty = parseInt(qtyDisplay.textContent) || 1;
   if (!name) return;
   const opt = Array.from(document.querySelectorAll('#product-datalist option')).find(o => o.value.toLowerCase() === name.toLowerCase());
   if (opt) name = opt.dataset.key;
   addToShoppingList(name, qty);
   nameInput.value = '';
-  qtyInput.value = '1';
+  qtyDisplay.textContent = '1';
   renderSuggestions();
   renderShoppingList();
 }
@@ -1409,7 +1411,7 @@ function renderSuggestions() {
     qtyInput.type = 'number';
     qtyInput.min = '1';
     qtyInput.value = '1';
-    qtyInput.className = 'input input-bordered w-16 text-center mx-2 no-spinner';
+    qtyInput.className = 'input input-bordered w-16 text-center mx-2';
     const inc = document.createElement('button');
     inc.type = 'button';
     inc.textContent = '+';
@@ -1470,44 +1472,33 @@ function renderShoppingList() {
 
     const qtyTd = document.createElement('td');
     const qtyWrap = document.createElement('div');
-    qtyWrap.className = 'flex items-center justify-center';
+    qtyWrap.className = 'flex items-center justify-center gap-2 mx-2';
     const dec = document.createElement('button');
     dec.type = 'button';
-    dec.textContent = '−';
-    dec.className = 'btn btn-outline btn-xs';
+    dec.innerHTML = '<i class="fa-solid fa-minus"></i>';
+    dec.className = 'text-xl';
     dec.disabled = item.inCart;
-    const qtyInput = document.createElement('input');
-    qtyInput.type = 'number';
-    qtyInput.min = '1';
-    qtyInput.value = item.quantity;
-    qtyInput.className = 'input input-bordered w-16 text-center mx-2 no-spinner';
-    qtyInput.disabled = item.inCart;
+    const qtyDisplay = document.createElement('span');
+    qtyDisplay.textContent = item.quantity;
+    qtyDisplay.className = 'w-8 text-center';
     const inc = document.createElement('button');
     inc.type = 'button';
-    inc.textContent = '+';
-    inc.className = 'btn btn-outline btn-xs';
+    inc.innerHTML = '<i class="fa-solid fa-plus"></i>';
+    inc.className = 'text-xl';
     inc.disabled = item.inCart;
     dec.addEventListener('click', () => {
-      const v = parseInt(qtyInput.value) || 1;
-      const newVal = Math.max(1, v - 1);
-      qtyInput.value = newVal;
+      const newVal = Math.max(1, item.quantity - 1);
       item.quantity = newVal;
+      qtyDisplay.textContent = newVal;
       saveShoppingList();
     });
     inc.addEventListener('click', () => {
-      const v = parseInt(qtyInput.value) || 1;
-      const newVal = v + 1;
-      qtyInput.value = newVal;
+      const newVal = item.quantity + 1;
       item.quantity = newVal;
+      qtyDisplay.textContent = newVal;
       saveShoppingList();
     });
-    qtyInput.addEventListener('change', () => {
-      const v = Math.max(1, parseInt(qtyInput.value) || 1);
-      qtyInput.value = v;
-      item.quantity = v;
-      saveShoppingList();
-    });
-    qtyWrap.append(dec, qtyInput, inc);
+    qtyWrap.append(dec, qtyDisplay, inc);
     qtyTd.appendChild(qtyWrap);
     tr.appendChild(qtyTd);
 

--- a/app/static/styles.css
+++ b/app/static/styles.css
@@ -100,12 +100,12 @@ html[data-layout="mobile"] body {
 }
 
 /* Remove number input arrows */
-.no-spinner::-webkit-outer-spin-button,
-.no-spinner::-webkit-inner-spin-button {
+input[type="number"]::-webkit-outer-spin-button,
+input[type="number"]::-webkit-inner-spin-button {
   -webkit-appearance: none;
   margin: 0;
 }
-.no-spinner {
+input[type="number"] {
   -moz-appearance: textfield;
 }
 

--- a/app/static/translations/en.json
+++ b/app/static/translations/en.json
@@ -30,7 +30,7 @@
   "delete_cancel_button": "Cancel",
   "heading_add_edit_product": "Add / edit product",
   "add_form_name_placeholder": "name",
-  "add_form_quantity_placeholder": "quantity",
+  "add_form_quantity_placeholder": "Quantity",
   "add_form_package_size_placeholder": "in package",
   "add_form_pack_size_placeholder": "pack",
   "add_form_threshold_placeholder": "threshold",

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -249,10 +249,10 @@
                 <h2 class="text-xl font-semibold mb-4" data-i18n="heading_add_product">Dodaj produkt</h2>
                 <div class="flex flex-wrap items-center gap-2">
                     <input id="manual-name" list="product-datalist" class="input input-bordered flex-1" placeholder="nazwa" data-i18n="add_form_name_placeholder">
-                    <div class="flex items-center">
-                        <button id="manual-dec" type="button" class="btn btn-outline btn-xs">−</button>
-                        <input id="manual-qty" type="number" min="1" value="1" class="input input-bordered w-16 text-center mx-2 no-spinner" placeholder="1" data-i18n="add_form_quantity_placeholder">
-                        <button id="manual-inc" type="button" class="btn btn-outline btn-xs">+</button>
+                    <div class="flex items-center gap-2">
+                        <button id="manual-dec" type="button" class="text-xl"><i class="fa-solid fa-minus"></i></button>
+                        <span id="manual-qty" class="w-8 text-center mx-2">1</span>
+                        <button id="manual-inc" type="button" class="text-xl"><i class="fa-solid fa-plus"></i></button>
                     </div>
                     <button id="manual-add-btn" class="btn btn-primary btn-sm" data-i18n="save_button">Zapisz</button>
                 </div>


### PR DESCRIPTION
## Summary
- Replace shopping list quantity inputs with compact plus/minus icon controls for mobile
- Drop native number spinners and tweak translation for "Quantity"

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689118d767a4832a95cc1826a2539057