### PR TITLE
fix: adjust top-right config icons

### DIFF
--- a/app/static/script.js
+++ b/app/static/script.js
@@ -60,10 +60,13 @@ detectInitialDisplayMode();
 updateCornerIconsVisibility();
 
 if (topSentinel && cornerIcons) {
-  const observer = new IntersectionObserver(entries => {
-    cornerIconsTop = entries[0].isIntersecting;
-    updateCornerIconsVisibility();
-  });
+  const observer = new IntersectionObserver(
+    entries => {
+      cornerIconsTop = entries[0].intersectionRatio === 1;
+      updateCornerIconsVisibility();
+    },
+    { threshold: [0, 1] }
+  );
   observer.observe(topSentinel);
 }
 

--- a/app/static/styles.css
+++ b/app/static/styles.css
@@ -13,18 +13,19 @@ html[data-layout="desktop"] .main-container {
 }
 
 .corner-icons {
-  position: sticky;
-  top: 0;
-  right: 0;
-  width: 100%;
+  position: fixed;
+  top: 0.5rem;
+  right: 0.5rem;
   display: flex;
-  justify-content: flex-end;
   padding: 0.5rem;
-  z-index: 10;
+  z-index: 50;
+  background-color: hsl(var(--b1) / 0.8);
+  backdrop-filter: blur(4px);
+  border-radius: 0.5rem;
 }
 
-html[data-layout="mobile"] .corner-icons {
-  top: 0;
+#top-sentinel {
+  height: 3rem;
 }
 
 html[data-layout="mobile"] #controls {


### PR DESCRIPTION
## Summary
- hide config icons unless page is scrolled to top on mobile
- fix config icon position with soft blurred background

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68911ddbeac4832aa765fec5b32b4f94