### PR TITLE
Refine mobile bottom navigation and settings access

### DIFF
--- a/app/static/script.js
+++ b/app/static/script.js
@@ -405,6 +405,15 @@ function checkLowStockToast() {
     });
   });
 
+  const settingsBtn = document.getElementById('settings-btn');
+  if (settingsBtn) {
+    settingsBtn.addEventListener('click', () => {
+      activateTab('tab-settings');
+      localStorage.setItem('activeTab', 'tab-settings');
+      renderUnitsAdmin();
+    });
+  }
+
   const saveUnitsBtn = document.getElementById('units-save');
   if (saveUnitsBtn) {
     saveUnitsBtn.addEventListener('click', async (e) => {

--- a/app/static/translations/en.json
+++ b/app/static/translations/en.json
@@ -1,7 +1,7 @@
 {
   "tab_products": "Products",
   "tab_recipes": "Recipes",
-  "tab_history": "Meal History",
+  "tab_history": "Dishes History",
   "tab_shopping": "Shopping List",
   "tab_settings": "Settings",
   "heading_products": "Products",
@@ -69,7 +69,7 @@
   "yes": "Yes",
   "no": "No",
   "checkbox_favorite_label": "Favorite",
-  "heading_history": "Meal History",
+  "heading_history": "Dishes History",
   "heading_shopping": "Shopping List",
   "heading_settings": "Settings",
   "receipt_import": "Import from receipt",

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -28,6 +28,9 @@
     <button id="install-btn" aria-label="Install app" class="text-xl p-2 bg-transparent border-0" style="display:none;">
         <i class="fa-solid fa-download"></i>
     </button>
+    <button id="settings-btn" aria-label="Settings" class="text-xl p-2 bg-transparent border-0">
+        <i class="fa-solid fa-gear"></i>
+    </button>
 </div>
 <div class="max-w-screen-lg mx-auto px-4 py-6 main-container">
     <div class="tabs tabs-bordered flex-nowrap overflow-x-auto whitespace-nowrap mb-6 desktop-nav">
@@ -35,7 +38,6 @@
         <a class="tab" data-tab-target="tab-recipes" data-i18n="tab_recipes">Przepisy</a>
         <a class="tab" data-tab-target="tab-history" data-i18n="tab_history">Historia dań</a>
         <a class="tab" data-tab-target="tab-shopping" data-i18n="tab_shopping">Lista zakupów</a>
-        <a class="tab" data-tab-target="tab-settings" data-i18n="tab_settings">Ustawienia</a>
     </div>
         <div id="tab-products" class="tab-panel">
             <h1 class="text-2xl font-bold mb-4" data-i18n="heading_products">Produkty</h1>
@@ -317,16 +319,16 @@
         </div>
 
     </div>
-    <nav class="mobile-nav bottom-0 fixed w-full z-50 bg-base-100 border-t border-base-300 flex divide-x divide-base-300">
-        <a class="tab tab-active font-bold flex flex-col items-center justify-center flex-1 py-3 px-2" data-tab-target="tab-products">
+    <nav class="mobile-nav fixed bottom-0 left-0 w-full z-50 bg-base-100 border-t border-base-300 flex">
+        <a class="tab tab-active font-bold flex flex-col items-center justify-center flex-1 py-3 px-2 border-r border-base-300" data-tab-target="tab-products">
             <i class="fa-solid fa-box text-xl"></i>
             <span class="text-xs" data-i18n="tab_products">Produkty</span>
         </a>
-        <a class="tab flex flex-col items-center justify-center flex-1 py-3 px-2" data-tab-target="tab-recipes">
+        <a class="tab flex flex-col items-center justify-center flex-1 py-3 px-2 border-r border-base-300" data-tab-target="tab-recipes">
             <i class="fa-solid fa-utensils text-xl"></i>
             <span class="text-xs" data-i18n="tab_recipes">Przepisy</span>
         </a>
-        <a class="tab flex flex-col items-center justify-center flex-1 py-3 px-2" data-tab-target="tab-history">
+        <a class="tab flex flex-col items-center justify-center flex-1 py-3 px-2 border-r border-base-300" data-tab-target="tab-history">
             <i class="fa-solid fa-clock-rotate-left text-xl"></i>
             <span class="text-xs" data-i18n="tab_history">Historia dań</span>
         </a>


### PR DESCRIPTION
## Summary
- Fix mobile navigation bar to bottom with clearer vertical dividers and equal-width tabs
- Remove settings tab and expose settings via a new gear icon in the header
- Update English translation for history section to "Dishes History"

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68911dda3ef4832a8223aeaba010c370