### PR TITLE
Improve JSON editor layout on mobile

### DIFF
--- a/app/static/styles.css
+++ b/app/static/styles.css
@@ -121,3 +121,13 @@ input[type="number"] {
 .shopping-table {
   border-radius: 0.5rem;
 }
+
+/* JSON editor adjustments */
+#edit-json {
+  box-sizing: border-box;
+}
+
+html[data-layout="mobile"] #edit-json {
+  width: 100%;
+  max-width: 100%;
+}

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -127,7 +127,8 @@
             <hr class="border-t border-base-300 my-6">
 
             <h3 class="text-lg font-semibold mt-6 mb-2" data-i18n="heading_edit_json">Edytuj produkty (JSON)</h3>
-            <textarea id="edit-json" rows="10" placeholder='JSON' data-i18n="edit_json_placeholder" class="textarea textarea-bordered w-full mb-4 h-60 overflow-y-scroll resize-y p-2"></textarea>            <div class="flex flex-col sm:flex-row gap-2 mb-8">
+            <textarea id="edit-json" rows="10" placeholder='JSON' data-i18n="edit_json_placeholder" class="textarea textarea-bordered w-full max-w-full mb-4 h-60 overflow-y-auto overflow-x-hidden resize-none p-4"></textarea>
+            <div class="flex flex-col sm:flex-row gap-2 mb-8">
                 <button id="edit-json-btn" class="btn btn-outline btn-primary btn-sm w-full sm:w-auto" data-i18n="edit_json_submit_button">Wyślij JSON</button>
                 <button id="copy-btn" class="btn btn-outline btn-sm w-full sm:w-auto" data-i18n="copy_structure_button">Pobierz strukturę</button>
             </div>


### PR DESCRIPTION
## Summary
- keep JSON editor within the mobile viewport and prevent horizontal overflow
- add padding and vertical scrolling for the JSON editor
- ensure mobile-specific styles for the JSON editor

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68911de03af8832abcfab8886aec1194