### PR TITLE
feat: separate manual add from shopping list

### DIFF
--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -253,8 +253,9 @@
                     </table>
                 </div>
             </div>
-            <div id="manual-add-section" class="mb-8 mt-4 p-4 border-t border-base-300">
-                <h2 class="text-xl font-semibold mb-4" data-i18n="heading_add_product">Dodaj produkt</h2>
+            <hr class="border-t border-base-300 mt-6 mb-4">
+            <div id="manual-add-section" class="mb-8 p-4 shadow rounded bg-base-100">
+                <h2 class="text-xl font-bold mb-4" data-i18n="heading_add_product">Dodaj produkt</h2>
                 <div class="flex flex-wrap items-center gap-2">
                     <input id="manual-name" list="product-datalist" class="input input-bordered flex-1" placeholder="nazwa" data-i18n="add_form_name_placeholder">
                     <div class="flex items-center gap-2">


### PR DESCRIPTION
## Summary
- add a horizontal rule and styled card to clearly separate the manual 'Add product' form from the shopping list

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689125bd8fd8832aba0066165ab78f8e