### PR TITLE
Fix main product checkbox placement

### DIFF
--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -95,8 +95,8 @@
                 <input name="package_size" placeholder="w opak." data-i18n="add_form_package_size_placeholder" class="input input-bordered w-full" type="number" value="1">
                 <input name="pack_size" placeholder="paczka" data-i18n="add_form_pack_size_placeholder" class="input input-bordered w-full" type="number">
                 <input name="threshold" placeholder="próg" data-i18n="add_form_threshold_placeholder" class="input input-bordered w-full" type="number">
-                <div class="flex flex-col gap-2 w-full">
-                    <div id="category-checkboxes" class="flex flex-wrap gap-2">
+                <div class="mb-4">
+                    <div id="category-checkboxes" class="flex flex-wrap gap-2 mb-2">
                         <select name="category" required class="select select-bordered w-full">
                             <option value="uncategorized" data-i18n="category_uncategorized">brak kategorii</option>
                             <option value="fresh_veg" data-i18n="category_fresh_veg">Świeże warzywa</option>


### PR DESCRIPTION
## Summary
- Place the "Main product" checkbox below the category list for products

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68912c13ee18832a891add9e46c46b84