### PR TITLE
feat: enhance mobile bottom navigation

### DIFF
--- a/app/static/script.js
+++ b/app/static/script.js
@@ -1674,3 +1674,21 @@ async function handleReceiptUpload(file) {
   });
 }
 
+// Toggle mobile tab labels based on scroll direction
+const mobileNav = document.querySelector('.mobile-nav');
+let lastScroll = 0;
+window.addEventListener(
+  'scroll',
+  () => {
+    if (!mobileNav || html.getAttribute('data-layout') !== 'mobile') return;
+    const current = window.pageYOffset || document.documentElement.scrollTop;
+    if (current > lastScroll) {
+      mobileNav.classList.remove('labels-hidden');
+    } else if (current < lastScroll) {
+      mobileNav.classList.add('labels-hidden');
+    }
+    lastScroll = current <= 0 ? 0 : current;
+  },
+  { passive: true }
+);
+

--- a/app/static/styles.css
+++ b/app/static/styles.css
@@ -95,6 +95,17 @@ html[data-layout="mobile"] .desktop-nav {
 }
 html[data-layout="mobile"] .mobile-nav {
   display: flex;
+  box-shadow: 0 -2px 5px rgba(0, 0, 0, 0.1);
+}
+html[data-layout="mobile"] .mobile-nav a {
+  transition: padding 0.2s ease;
+}
+html[data-layout="mobile"] .mobile-nav.labels-hidden a {
+  padding-top: 0.5rem;
+  padding-bottom: 0.5rem;
+}
+html[data-layout="mobile"] .mobile-nav.labels-hidden span {
+  display: none;
 }
 html[data-layout="mobile"] body {
   padding-bottom: 4.5rem;


### PR DESCRIPTION
## Summary
- add scroll-aware bottom navigation bar for mobile layout
- visually separate nav with top shadow and animated padding when labels hide

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68912e37ee04832aa9a501f41cd54bd3