### PR TITLE
Refine mobile shopping list UI

### DIFF
--- a/app/static/script.js
+++ b/app/static/script.js
@@ -1475,6 +1475,7 @@ function renderShoppingList() {
   });
   shoppingList.forEach((item, idx) => {
     const tr = document.createElement('tr');
+    tr.className = 'shopping-row';
     if (item.inCart) tr.classList.add('opacity-50', 'italic');
 
     const nameTd = document.createElement('td');
@@ -1514,13 +1515,9 @@ function renderShoppingList() {
     qtyTd.appendChild(qtyWrap);
     tr.appendChild(qtyTd);
 
-    const ownedTd = document.createElement('td');
-    const product = (window.currentProducts || []).find(p => p.name === item.name && p.quantity > 0);
-    ownedTd.textContent = product ? `${formatQuantity(product)} ${t('owned')}` : '';
-    tr.appendChild(ownedTd);
+    const actionsTd = document.createElement('td');
+    actionsTd.className = 'flex items-center justify-end gap-2';
 
-    const cartTd = document.createElement('td');
-    cartTd.className = 'text-center';
     const cartBtn = document.createElement('button');
     cartBtn.type = 'button';
     cartBtn.innerHTML = '<i class="fa-solid fa-cart-shopping"></i>';
@@ -1536,23 +1533,21 @@ function renderShoppingList() {
       saveShoppingList();
       renderShoppingList();
     });
-    cartTd.appendChild(cartBtn);
-    tr.appendChild(cartTd);
+    actionsTd.appendChild(cartBtn);
 
-    const removeTd = document.createElement('td');
-    removeTd.className = 'text-center';
     const removeBtn = document.createElement('button');
     removeBtn.type = 'button';
     removeBtn.className = 'text-error touch-btn';
-    removeBtn.innerHTML = '<i class="fa-regular fa-circle-minus"></i>';
+    removeBtn.innerHTML = '<i class="fa-regular fa-trash-can"></i>';
     removeBtn.setAttribute('aria-label', t('remove'));
     removeBtn.addEventListener('click', () => {
       pendingRemoveIndex = idx;
       const modal = document.getElementById('shopping-delete-modal');
       if (modal) modal.showModal();
     });
-    removeTd.appendChild(removeBtn);
-    tr.appendChild(removeTd);
+    actionsTd.appendChild(removeBtn);
+
+    tr.appendChild(actionsTd);
 
     tbody.appendChild(tr);
   });

--- a/app/static/styles.css
+++ b/app/static/styles.css
@@ -148,6 +148,44 @@ input[type="number"] {
   margin: 0 0.25rem;
 }
 
+/* Shopping list mobile card layout */
+html[data-layout="mobile"] #shopping-list thead {
+  display: none;
+}
+
+html[data-layout="mobile"] #shopping-list tbody tr {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.5rem;
+  border-bottom: 1px solid hsl(var(--b3));
+}
+
+html[data-layout="mobile"] #shopping-list tbody td {
+  border: none;
+  padding: 0;
+}
+
+html[data-layout="mobile"] #shopping-list tbody td:nth-child(1) {
+  flex: 1;
+}
+
+html[data-layout="mobile"] #shopping-list tbody td:nth-child(2) {
+  flex: 0 0 auto;
+}
+
+html[data-layout="mobile"] #shopping-list tbody td:nth-child(3) {
+  flex: 0 0 auto;
+  display: flex;
+  gap: 0.5rem;
+}
+
+html[data-layout="mobile"] .touch-btn {
+  width: 3rem;
+  height: 3rem;
+  font-size: 1.5rem;
+}
+
 /* JSON editor adjustments */
 #edit-json {
   box-sizing: border-box;

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -244,9 +244,7 @@
                             <tr>
                                 <th data-i18n="table_header_name">Nazwa</th>
                                 <th data-i18n="table_header_quantity">Ilość</th>
-                                <th data-i18n="owned_units">szt Posiadane</th>
-                                <th data-i18n="in_cart">w koszyku</th>
-                                <th data-i18n="remove"></th>
+                                <th></th>
                             </tr>
                         </thead>
                         <tbody></tbody>


### PR DESCRIPTION
## Summary
- simplify shopping list table to product, quantity and action icons
- render shopping items as touch-friendly rows with cart toggle and delete confirmation
- add responsive styles for mobile card layout and larger buttons

## Testing
- `python -m pytest`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68912fa44dc0832a85d3d6177dc04ee9