### PR TITLE
Simplify mobile receipt import

### DIFF
--- a/app/static/script.js
+++ b/app/static/script.js
@@ -1555,30 +1555,21 @@ function renderShoppingList() {
 
 function initReceiptImport() {
   const btn = document.getElementById('receipt-btn');
+  const input = document.getElementById('receipt-input');
   const modal = document.getElementById('receipt-modal');
-  const fileInput = document.getElementById('receipt-file');
-  const scanInput = document.getElementById('receipt-scan');
   const tableBody = document.querySelector('#receipt-table tbody');
   const confirm = document.getElementById('receipt-confirm');
-  if (!btn || !modal || !fileInput || !tableBody || !confirm) return;
+  if (!btn || !modal || !input || !tableBody || !confirm) return;
 
   btn.addEventListener('click', () => {
-    tableBody.innerHTML = '';
-    fileInput.value = '';
-    modal.showModal();
+    input.click();
   });
 
-  fileInput.addEventListener('change', () => {
-    const file = fileInput.files[0];
+  input.addEventListener('change', () => {
+    const file = input.files[0];
     if (file) handleReceiptUpload(file);
+    input.value = '';
   });
-
-  if (scanInput) {
-    scanInput.addEventListener('change', () => {
-      const file = scanInput.files[0];
-      if (file) handleReceiptUpload(file);
-    });
-  }
 
   confirm.addEventListener('click', () => {
     const rows = Array.from(tableBody.querySelectorAll('tr'));
@@ -1593,7 +1584,7 @@ function initReceiptImport() {
     renderShoppingList();
     modal.close();
     tableBody.innerHTML = '';
-    fileInput.value = '';
+    input.value = '';
   });
 }
 

--- a/app/static/translations/en.json
+++ b/app/static/translations/en.json
@@ -80,7 +80,6 @@
   "settings_unit_code": "Code",
   "settings_unit_pl": "Polish",
   "settings_unit_en": "English",
-  "scan_receipt": "Scan receipt",
   "ocr_not_recognized": "Not recognized",
   "confirm_import": "Confirm import",
   "accept_action": "Accept",

--- a/app/static/translations/pl.json
+++ b/app/static/translations/pl.json
@@ -80,7 +80,6 @@
   "settings_unit_code": "Kod",
   "settings_unit_pl": "Polski",
   "settings_unit_en": "Angielski",
-  "scan_receipt": "Zeskanuj paragon",
   "ocr_not_recognized": "Nie rozpoznano",
   "confirm_import": "Zatwierdź import",
   "accept_action": "Akceptuj",

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -226,8 +226,7 @@
         <div id="tab-shopping" class="tab-panel" style="display:none;">
             <h1 class="text-2xl font-bold mb-6" data-i18n="heading_shopping">Lista zakupów</h1>
             <button id="receipt-btn" class="btn btn-secondary btn-sm mb-4" data-i18n="receipt_import">Dodaj z paragonu</button>
-            <input id="receipt-scan" type="file" accept="image/*" capture="environment" class="hidden" />
-            <label for="receipt-scan" class="btn btn-primary btn-sm mb-4" data-i18n="scan_receipt">Zeskanuj paragon</label>
+            <input id="receipt-input" type="file" accept="image/*" class="hidden" />
             <div id="suggestions-section" class="mb-8">
                 <h2 class="text-xl font-semibold mb-4" data-i18n="heading_suggestions">Propozycje</h2>
                 <div class="overflow-x-auto">
@@ -268,7 +267,6 @@
             <dialog id="receipt-modal" class="modal">
                 <form method="dialog" class="modal-box w-11/12 max-w-3xl">
                     <h3 class="font-bold text-lg" data-i18n="receipt_import">Dodaj z paragonu</h3>
-                    <input id="receipt-file" type="file" accept="image/png,image/jpeg" class="file-input file-input-bordered w-full my-4">
                     <div class="overflow-x-auto">
                         <table id="receipt-table" class="table w-full">
                             <thead>


### PR DESCRIPTION
## Summary
- replace separate scan/upload options on the shopping list with single "Dodaj z paragonu" button
- trigger native camera/gallery chooser and populate receipt modal from selected image
- clean up unused "scan receipt" translations

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689130ca8248832a92b0a8ec7312ad06