### PR TITLE
Fix mobile tab bar and label toggle

### DIFF
--- a/app/static/script.js
+++ b/app/static/script.js
@@ -1669,7 +1669,7 @@ async function handleReceiptUpload(file) {
   });
 }
 
-// Toggle mobile tab labels based on scroll direction
+// Hide labels on scroll down, show them on scroll up
 const mobileNav = document.querySelector('.mobile-nav');
 let lastScroll = 0;
 window.addEventListener(
@@ -1678,9 +1678,9 @@ window.addEventListener(
     if (!mobileNav || html.getAttribute('data-layout') !== 'mobile') return;
     const current = window.pageYOffset || document.documentElement.scrollTop;
     if (current > lastScroll) {
-      mobileNav.classList.remove('labels-hidden');
-    } else if (current < lastScroll) {
       mobileNav.classList.add('labels-hidden');
+    } else if (current < lastScroll) {
+      mobileNav.classList.remove('labels-hidden');
     }
     lastScroll = current <= 0 ? 0 : current;
   },

--- a/app/static/styles.css
+++ b/app/static/styles.css
@@ -99,6 +99,7 @@ html[data-layout="mobile"] .desktop-nav {
 html[data-layout="mobile"] .mobile-nav {
   display: flex;
   box-shadow: 0 -2px 5px rgba(0, 0, 0, 0.1);
+  border-top: 1px solid hsl(var(--b3));
 }
 html[data-layout="mobile"] .mobile-nav a {
   transition: padding 0.2s ease;

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -324,7 +324,7 @@
         </div>
 
     </div>
-    <nav class="mobile-nav fixed bottom-0 left-0 w-full z-50 bg-base-100 border-t border-base-300 flex">
+    <nav class="mobile-nav fixed bottom-0 left-0 w-full z-50 bg-base-100 flex">
         <a class="tab tab-active font-bold flex flex-col items-center justify-center flex-1 py-3 px-2 border-r border-base-300" data-tab-target="tab-products">
             <i class="fa-solid fa-box text-xl"></i>
             <span class="text-xs" data-i18n="tab_products">Produkty</span>


### PR DESCRIPTION
## Summary
- keep mobile navigation fixed at bottom and visually separated with a top border
- adjust scroll handling to hide tab labels on downward scroll and reveal them on upward scroll

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68913ab649a0832ab4ed56331b793a25