### PR TITLE
Ensure consistent mobile tab bar behaviour

### DIFF
--- a/app/static/script.js
+++ b/app/static/script.js
@@ -1660,7 +1660,7 @@ async function handleReceiptUpload(file) {
   });
 }
 
-// Hide labels on scroll down, show them on scroll up
+// Show labels when scrolling down, hide them on scroll up
 const mobileNav = document.querySelector('.mobile-nav');
 let lastScroll = 0;
 window.addEventListener(
@@ -1669,9 +1669,9 @@ window.addEventListener(
     if (!mobileNav || html.getAttribute('data-layout') !== 'mobile') return;
     const current = window.pageYOffset || document.documentElement.scrollTop;
     if (current > lastScroll) {
-      mobileNav.classList.add('labels-hidden');
-    } else if (current < lastScroll) {
       mobileNav.classList.remove('labels-hidden');
+    } else if (current < lastScroll) {
+      mobileNav.classList.add('labels-hidden');
     }
     lastScroll = current <= 0 ? 0 : current;
   },

--- a/app/static/styles.css
+++ b/app/static/styles.css
@@ -100,13 +100,14 @@ html[data-layout="mobile"] .mobile-nav {
   display: flex;
   box-shadow: 0 -2px 5px rgba(0, 0, 0, 0.1);
   border-top: 1px solid hsl(var(--b3));
+  height: 4.5rem;
 }
 html[data-layout="mobile"] .mobile-nav a {
-  transition: padding 0.2s ease;
-}
-html[data-layout="mobile"] .mobile-nav.labels-hidden a {
-  padding-top: 0.5rem;
-  padding-bottom: 0.5rem;
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
 }
 html[data-layout="mobile"] .mobile-nav.labels-hidden span {
   display: none;


### PR DESCRIPTION
## Summary
- Keep mobile bottom navigation fixed with constant height and clearer separation
- Reverse scroll logic so tab labels show when scrolling down and hide when scrolling up

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68962c6bdef0832ab34d2735b1b694f5