### PR TITLE
Align main product checkbox under category selection

### DIFF
--- a/app/static/translations/pl.json
+++ b/app/static/translations/pl.json
@@ -55,7 +55,7 @@
   "storage_fridge": "Lodówka",
   "storage_pantry": "Szafka",
   "storage_freezer": "Zamrażarka",
-  "checkbox_main_label": "Główny produkt",
+  "checkbox_main_label": "Produkt podstawowy",
   "heading_edit_json": "Edytuj produkty (JSON)",
   "edit_json_placeholder": "JSON",
   "edit_json_submit_button": "Wyślij JSON",

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -117,11 +117,11 @@
                             <option value="frozen_sauces" data-i18n="category_frozen_sauces">Mrożone sosy</option>
                             <option value="frozen_meals" data-i18n="category_frozen_meals">Mrożone dania / zupy</option>
                         </select>
+                        <label class="flex items-center gap-2 w-full">
+                            <input type="checkbox" name="main" class="checkbox">
+                            <span data-i18n="checkbox_main_label">Produkt podstawowy</span>
+                        </label>
                     </div>
-                    <label class="flex items-center gap-2 w-full">
-                        <input type="checkbox" name="main" class="checkbox">
-                        <span data-i18n="checkbox_main_label">Główny produkt</span>
-                    </label>
                 </div>
                 <select name="storage" required class="select select-bordered w-full">
                     <option value="fridge" data-i18n="storage_fridge">Lodówka</option>


### PR DESCRIPTION
## Summary
- Move "Main product" checkbox directly under category selector for consistent add/edit layout
- Update Polish translation for "Main product" to "Produkt podstawowy"

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6896376afd24832a8899db14e8a2b411