### PR TITLE
Improve spacing between top-right config icons

### DIFF
--- a/app/static/styles.css
+++ b/app/static/styles.css
@@ -18,10 +18,16 @@ html[data-layout="desktop"] .main-container {
   right: 0.5rem;
   display: flex;
   padding: 0.5rem;
+  gap: 0.5rem;
+  align-items: center;
   z-index: 50;
   background-color: hsl(var(--b1) / 0.8);
   backdrop-filter: blur(4px);
   border-radius: 0.5rem;
+}
+
+html[data-layout="desktop"] .corner-icons {
+  gap: 1rem;
 }
 
 #top-sentinel {

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -16,7 +16,7 @@
 </head>
 <body class="min-h-screen bg-base-100">
 <div id="top-sentinel"></div>
-<div class="corner-icons flex justify-end gap-3 p-2 bg-base-100">
+<div class="corner-icons flex justify-end bg-base-100">
     <button id="layout-toggle" aria-label="Toggle layout" class="text-xl p-2 bg-transparent border-0">
         <i id="layout-icon" class="fa-solid fa-mobile-screen-button"></i>
     </button>


### PR DESCRIPTION
## Summary
- increase gap and align corner configuration icons for clarity on desktop
- clean up icon container classes

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6896376b768c832ab6ef7c6d894122b8