### PR TITLE
Align grouped product tables

### DIFF
--- a/app/static/script.js
+++ b/app/static/script.js
@@ -977,7 +977,7 @@ function renderProducts(data) {
         categoryBlock.id = `category-${storIndex}-${catIndex}`;
 
         const catHeader = document.createElement('div');
-        catHeader.className = 'rounded px-2';
+        catHeader.className = 'rounded px-2 mb-1';
         const h4 = document.createElement('h4');
         h4.className = 'text-xl font-semibold flex items-center gap-2 m-0';
         const titleSpan = document.createElement('span');
@@ -999,10 +999,18 @@ function renderProducts(data) {
         categoryBlock.appendChild(catHeader);
 
         const catContent = document.createElement('div');
-        catContent.className = 'category-content';
+        catContent.className = 'category-content px-2';
 
         const table = document.createElement('table');
-        table.className = 'table table-zebra w-full';
+        table.className = 'table table-zebra w-full grouped-table';
+
+        const colgroup = document.createElement('colgroup');
+        ['name', 'qty', 'unit', 'status'].forEach(c => {
+          const col = document.createElement('col');
+          col.className = `grouped-col-${c}`;
+          colgroup.appendChild(col);
+        });
+        table.appendChild(colgroup);
         const thead = document.createElement('thead');
         const headRow = document.createElement('tr');
         [
@@ -1012,7 +1020,7 @@ function renderProducts(data) {
           t('table_header_status')
         ].forEach(text => {
           const th = document.createElement('th');
-          th.className = 'px-2 py-1 sm:px-4 sm:py-2';
+          th.className = 'px-1 py-1 sm:px-4 sm:py-2';
           th.textContent = text;
           headRow.appendChild(th);
         });
@@ -1029,12 +1037,12 @@ function renderProducts(data) {
               tr.classList.add(...LOW_STOCK_CLASS.split(' '));
             }
             const nameTd = document.createElement('td');
-            nameTd.className = 'px-2 py-1 sm:px-4 sm:py-2';
+            nameTd.className = 'px-1 py-1 sm:px-4 sm:py-2';
             nameTd.textContent = productName(p.name);
             tr.appendChild(nameTd);
 
             const qtyTd = document.createElement('td');
-            qtyTd.className = 'px-2 py-1 sm:px-4 sm:py-2';
+            qtyTd.className = 'px-1 py-1 sm:px-4 sm:py-2';
             qtyTd.textContent = formatPackQuantity(p);
             if (p.pack_size) {
               qtyTd.title = t('pack_title');
@@ -1042,12 +1050,12 @@ function renderProducts(data) {
             tr.appendChild(qtyTd);
 
             const unitTd = document.createElement('td');
-            unitTd.className = 'px-2 py-1 sm:px-4 sm:py-2';
+            unitTd.className = 'px-1 py-1 sm:px-4 sm:py-2';
             unitTd.textContent = unitName(p.unit);
             tr.appendChild(unitTd);
 
             const statusTd = document.createElement('td');
-            statusTd.className = 'px-2 py-1 sm:px-4 sm:py-2 text-center';
+            statusTd.className = 'px-1 py-1 sm:px-4 sm:py-2 text-center';
             const status = getStatusIcon(p);
             if (status) {
               statusTd.innerHTML = status.html;

--- a/app/static/styles.css
+++ b/app/static/styles.css
@@ -97,6 +97,44 @@ html[data-layout="mobile"] .btn {
   margin-bottom: 0;
 }
 
+#product-list .grouped-table {
+  table-layout: fixed;
+  width: 100%;
+}
+
+#product-list .grouped-table col.grouped-col-name {
+  width: 50%;
+}
+
+#product-list .grouped-table col.grouped-col-qty {
+  width: 20%;
+}
+
+#product-list .grouped-table col.grouped-col-unit {
+  width: 15%;
+}
+
+#product-list .grouped-table col.grouped-col-status {
+  width: 15%;
+}
+
+#product-list .grouped-table th,
+#product-list .grouped-table td {
+  padding: 0.25rem 0.25rem;
+}
+
+#product-list .grouped-table th:first-child,
+#product-list .grouped-table td:first-child {
+  padding-left: 0;
+}
+
+@media (min-width: 640px) {
+  #product-list .grouped-table th,
+  #product-list .grouped-table td {
+    padding: 0.5rem 1rem;
+  }
+}
+
 /* Navigation positioning for mobile view */
 .mobile-nav {
   display: none;


### PR DESCRIPTION
## Summary
- ensure grouped product tables share a fixed layout
- align headers and remove extra left padding in grouped view
- shrink mobile padding for columns and keep tables tight to headers

## Testing
- `node --check app/static/script.js`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6896498103f8832a87f13c2eb47cd62e