### PR TITLE
Unify receipt import entry point

### DIFF
--- a/app/static/translations/en.json
+++ b/app/static/translations/en.json
@@ -74,7 +74,7 @@
   "heading_settings": "Settings",
   "receipt_import": "Add from receipt",
   "camera": "Camera",
-  "upload_file": "Upload file",
+  "choose_file": "Choose file",
   "heading_suggestions": "Suggestions",
   "heading_add_product": "Add product",
   "heading_shopping_list": "Shopping List",

--- a/app/static/translations/pl.json
+++ b/app/static/translations/pl.json
@@ -74,7 +74,7 @@
   "heading_settings": "Ustawienia",
   "receipt_import": "Dodaj z paragonu",
   "camera": "Aparat",
-  "upload_file": "Wgraj plik",
+  "choose_file": "Wybierz plik",
   "heading_suggestions": "Propozycje",
   "heading_add_product": "Dodaj produkt",
   "heading_shopping_list": "Lista zakupów",

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -230,13 +230,13 @@
             <dialog id="receipt-sheet" class="modal modal-bottom sm:modal-middle">
                 <form method="dialog" class="modal-box">
                     <button id="receipt-camera" class="btn w-full mb-2" data-i18n="camera">Aparat</button>
-                    <button id="receipt-upload" class="btn w-full" data-i18n="upload_file">Wgraj plik</button>
+                    <button id="receipt-upload" class="btn w-full" data-i18n="choose_file">Wybierz plik</button>
                 </form>
             </dialog>
             <dialog id="receipt-upload-modal" class="modal">
                 <form method="dialog" class="modal-box">
                     <div id="receipt-drop-area" class="border-2 border-dashed rounded p-8 text-center">
-                        <button id="receipt-choose" class="btn" data-i18n="upload_file">Wgraj plik</button>
+                        <button id="receipt-choose" class="btn" data-i18n="choose_file">Wybierz plik</button>
                     </div>
                 </form>
             </dialog>


### PR DESCRIPTION
## Summary
- Show "Wybierz plik" for both mobile and desktop receipt uploads
- Remove legacy "Upload file" label for receipt import

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python -m json.tool app/static/translations/pl.json`
- `python -m json.tool app/static/translations/en.json`


------
https://chatgpt.com/codex/tasks/task_e_6896498e8fa0832a89f8ea3b0ba6896f