### PR TITLE
Replace low-stock SweetAlert with toast notification

### DIFF
--- a/app/static/script.js
+++ b/app/static/script.js
@@ -336,7 +336,6 @@ function showLowStockToast() {
     renderSuggestions();
     renderShoppingList();
     alert.remove();
-    lowStockToastShown = false;
   });
   const close = document.createElement('button');
   close.className = 'btn btn-xs btn-circle btn-ghost absolute top-1 right-1';
@@ -345,7 +344,6 @@ function showLowStockToast() {
   close.innerHTML = '<i class="fa-regular fa-xmark"></i>';
   close.addEventListener('click', () => {
     alert.remove();
-    lowStockToastShown = false;
   });
   alert.appendChild(span);
   alert.appendChild(btn);
@@ -368,8 +366,8 @@ function checkLowStockToast() {
       const close = toast.querySelector('button[data-action="close"]');
       if (close) close.setAttribute('title', t('toast_close'));
     }
-  } else if (toast) {
-    toast.remove();
+  } else {
+    if (toast) toast.remove();
     lowStockToastShown = false;
   }
 }

--- a/app/static/translations/en.json
+++ b/app/static/translations/en.json
@@ -105,7 +105,7 @@
   "ingredient_placeholder": "ingredient",
   "quantity_placeholder_ing": "quantity",
   "toast_low_stock": "Some products are running low! Check the shopping list.",
-  "toast_go_shopping": "Go",
+  "toast_go_shopping": "Go to shopping list",
   "toast_close": "Close",
   "notify_success_title": "Success",
   "notify_error_title": "Error",

--- a/app/static/translations/pl.json
+++ b/app/static/translations/pl.json
@@ -105,7 +105,7 @@
   "ingredient_placeholder": "składnik",
   "quantity_placeholder_ing": "ilość",
   "toast_low_stock": "Niektóre produkty się kończą! Przejrzyj listę zakupów.",
-  "toast_go_shopping": "Przejdź",
+  "toast_go_shopping": "Przejdź do listy zakupów",
   "toast_close": "Zamknij",
   "notify_success_title": "Sukces",
   "notify_error_title": "Błąd",


### PR DESCRIPTION
## Summary
- Replace low-stock SweetAlert with toast notification including close button and CTA redirecting to shopping list
- Persist dismissal state so toast doesn't reappear until stock changes or page reload
- Update Polish and English translations for the CTA text

## Testing
- `pip install -r requirements.txt`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68964985ba7c832aa0d1607d64605eef