### PR TITLE
Revamp mobile shopping list layout

### DIFF
--- a/app/static/script.js
+++ b/app/static/script.js
@@ -1718,18 +1718,14 @@ function renderShoppingList() {
   });
   shoppingList.forEach((item, idx) => {
     const row = document.createElement('div');
-    row.className = 'shopping-item flex items-center justify-between gap-2 p-2 min-h-12 hover:bg-base-200 transition-colors';
+    row.className = 'shopping-item flex items-center justify-between gap-2 p-2 min-h-10 hover:bg-base-200 transition-colors';
     if (item.inCart) row.classList.add('opacity-50', 'italic');
 
     const nameWrap = document.createElement('div');
-    nameWrap.className = 'flex-1';
-    let displayName = productName(item.name);
-    if (displayName === '(no translation)') {
-      const tName = t(item.name);
-      displayName = tName !== '(no translation)' ? tName : item.name;
-    }
+    nameWrap.className = 'flex-1 overflow-hidden';
     const nameEl = document.createElement('div');
-    nameEl.textContent = displayName;
+    nameEl.textContent = t(item.name);
+    nameEl.className = 'truncate';
     if (item.inCart) nameEl.classList.add('line-through');
     nameWrap.appendChild(nameEl);
 
@@ -1753,7 +1749,7 @@ function renderShoppingList() {
     qtyInput.type = 'number';
     qtyInput.min = '1';
     qtyInput.value = item.quantity;
-    qtyInput.className = 'input input-bordered w-12 text-center';
+    qtyInput.className = 'input input-bordered w-12 h-10 text-center no-spinner';
     qtyInput.disabled = item.inCart;
     const inc = document.createElement('button');
     inc.type = 'button';
@@ -1784,12 +1780,12 @@ function renderShoppingList() {
     const actions = document.createElement('div');
     actions.className = 'flex items-center gap-2';
 
-    const cartBtn = document.createElement('button');
-    cartBtn.type = 'button';
-    cartBtn.innerHTML = `<i class="fa-${item.inCart ? 'solid' : 'regular'} fa-cart-shopping"></i>`;
-    cartBtn.className = 'touch-btn';
-    cartBtn.setAttribute('aria-label', t('in_cart'));
-    cartBtn.addEventListener('click', () => {
+    const acceptBtn = document.createElement('button');
+    acceptBtn.type = 'button';
+    acceptBtn.innerHTML = '<i class="fa-solid fa-check"></i>';
+    acceptBtn.className = 'touch-btn' + (item.inCart ? ' text-success' : '');
+    acceptBtn.setAttribute('aria-label', t('in_cart'));
+    acceptBtn.addEventListener('click', () => {
       item.inCart = !item.inCart;
       if (item.inCart) {
         item.cartTime = Date.now();
@@ -1799,7 +1795,7 @@ function renderShoppingList() {
       saveShoppingList();
       renderShoppingList();
     });
-    actions.appendChild(cartBtn);
+    actions.appendChild(acceptBtn);
 
     const delBtn = document.createElement('button');
     delBtn.type = 'button';

--- a/app/static/styles.css
+++ b/app/static/styles.css
@@ -193,6 +193,17 @@ input[type="number"] {
   margin: 0 0.25rem;
 }
 
+/* Hide native number input spinners */
+.no-spinner::-webkit-outer-spin-button,
+.no-spinner::-webkit-inner-spin-button {
+  -webkit-appearance: none;
+  margin: 0;
+}
+
+.no-spinner {
+  -moz-appearance: textfield;
+}
+
 /* Suggestion table mobile card layout */
 html[data-layout="mobile"] #suggestion-table thead {
   display: none;

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -300,9 +300,9 @@
                 <div class="flex flex-wrap items-center gap-2">
                     <input id="manual-name" list="product-datalist" class="input input-bordered flex-1" placeholder="nazwa" data-i18n="add_form_name_placeholder">
                     <div class="flex items-center gap-2">
-                        <button id="manual-dec" type="button" class="text-xl"><i class="fa-solid fa-minus"></i></button>
-                        <span id="manual-qty" class="w-8 text-center mx-2">1</span>
-                        <button id="manual-inc" type="button" class="text-xl"><i class="fa-solid fa-plus"></i></button>
+                        <button id="manual-dec" type="button" class="text-xl touch-btn"><i class="fa-solid fa-minus"></i></button>
+                        <span id="manual-qty" class="w-10 h-10 inline-flex items-center justify-center text-center mx-2">1</span>
+                        <button id="manual-inc" type="button" class="text-xl touch-btn"><i class="fa-solid fa-plus"></i></button>
                     </div>
                     <button id="manual-add-btn" class="btn btn-primary btn-sm" data-i18n="save_button">Zapisz</button>
                 </div>


### PR DESCRIPTION
## Summary
- Streamline shopping list rows with translated names, quantity controls, check-to-cart and delete actions
- Hide native number spinners and ensure 40x40 touch targets for all interactive elements
- Keep add-product section separated with its own header and touch-friendly buttons

## Testing
- `python -m py_compile app/app.py app/utils.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689658407298832aa58f0ad5097e87da