### PR TITLE
Add recipe ingredients to shopping list

### DIFF
--- a/app/static/translations/en.json
+++ b/app/static/translations/en.json
@@ -98,6 +98,8 @@
   "recipe_done_mod_button": "Done (modified)",
   "recipe_ingredients_header": "Ingredients",
   "recipe_steps_header": "Steps",
+  "recipe_add_to_shopping": "Add ingredients to shopping list",
+  "recipe_added_to_shopping": "Added to shopping list",
   "label_time": "Time",
   "label_portions": "Portions",
   "recipe_sort_label": "Sort by:",

--- a/app/static/translations/pl.json
+++ b/app/static/translations/pl.json
@@ -98,6 +98,8 @@
   "recipe_done_mod_button": "Zrobione (ze zmianami)",
   "recipe_ingredients_header": "Składniki",
   "recipe_steps_header": "Kroki",
+  "recipe_add_to_shopping": "Dodaj składniki do listy zakupów",
+  "recipe_added_to_shopping": "Dodano do listy zakupów",
   "label_time": "Czas",
   "label_portions": "Porcje",
   "recipe_sort_label": "Sortuj według:",

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -212,6 +212,7 @@
                     <h4 class="font-semibold mb-2" data-i18n="recipe_steps_header">Kroki</h4>
                     <ol id="recipe-steps" class="recipe-steps list-decimal pl-5 space-y-2"></ol>
                     <div class="modal-action">
+                        <button id="recipe-add-to-shopping" class="btn btn-primary btn-sm" data-i18n="recipe_add_to_shopping">Dodaj składniki do listy zakupów</button>
                         <button id="recipe-detail-close" class="btn btn-sm">OK</button>
                     </div>
                 </div>


### PR DESCRIPTION
## Summary
- Add "Dodaj składniki do listy zakupów" button to recipe details
- Implement logic to merge recipe ingredients into the shopping list and show a success toast with shortcut to the Shopping List tab
- Update translations and shopping list helper to sum quantities

## Testing
- `node --check app/static/script.js`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68965c2cb0bc832a9d1eecdd92202e5b