### PR TITLE
Add JSON schema validation and validation endpoint

### DIFF
--- a/app/data/products.schema.json
+++ b/app/data/products.schema.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "array",
+  "items": {
+    "type": "object",
+    "required": ["name", "quantity"],
+    "properties": {
+      "name": {"type": "string"},
+      "unit": {"type": "string"},
+      "quantity": {"type": "number"},
+      "package_size": {"type": "number"},
+      "pack_size": {"type": ["integer", "null"]},
+      "threshold": {"type": "number"},
+      "main": {"type": "boolean"},
+      "category": {"type": "string"},
+      "storage": {"type": "string"},
+      "key": {"type": "string"},
+      "name_key": {"type": "string"}
+    },
+    "additionalProperties": true
+  }
+}

--- a/app/data/recipes.schema.json
+++ b/app/data/recipes.schema.json
@@ -1,0 +1,34 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "array",
+  "items": {
+    "type": "object",
+    "required": ["name", "ingredients"],
+    "properties": {
+      "name": {"type": "string"},
+      "ingredients": {
+        "type": "array",
+        "items": {
+          "anyOf": [
+            {"type": "string"},
+            {
+              "type": "object",
+              "required": ["product"],
+              "properties": {
+                "product": {"type": "string"},
+                "quantity": {"type": "number"},
+                "unit": {"type": "string"}
+              },
+              "additionalProperties": false
+            }
+          ]
+        }
+      },
+      "tags": {"type": "array", "items": {"type": "string"}},
+      "steps": {"type": "array", "items": {"type": "string"}},
+      "portions": {"type": "integer"},
+      "time": {"type": "string"}
+    },
+    "additionalProperties": true
+  }
+}

--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -1,1 +1,2 @@
 Flask
+jsonschema

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 Flask
 gunicorn
+jsonschema


### PR DESCRIPTION
## Summary
- add JSON schemas for products and recipes (supports object or string ingredients)
- validate JSON on load/save with clear logging and coercion helpers
- expose `/api/validate` route for dev validation of data files
- include jsonschema dependency

## Testing
- `python -m py_compile app/utils.py app/app.py`
- `pip install jsonschema` *(fails: 403 ProxyError)*


------
https://chatgpt.com/codex/tasks/task_e_68965c53ed50832ab9f9cb62f7e7eb68