### PR TITLE
Normalize and render recipe cards

### DIFF
--- a/app/static/js/components/recipe-detail.js
+++ b/app/static/js/components/recipe-detail.js
@@ -26,15 +26,11 @@ export function openRecipeDetails(recipe) {
       const li = document.createElement('li');
       const name = document.createElement('span');
       const qty = document.createElement('span');
-      if (typeof ing === 'string') {
-        name.textContent = t(ing);
-      } else {
-        name.textContent = t(ing.product);
-        let text = '';
-        if (ing.quantity != null) text += ing.quantity;
-        if (ing.unit) text += ` ${t(ing.unit)}`;
-        qty.textContent = text.trim();
-      }
+      name.textContent = t(ing.productKey);
+      let text = '';
+      if (ing.quantity != null) text += ing.quantity;
+      if (ing.unit) text += ` ${t(ing.unit)}`;
+      qty.textContent = text.trim();
       li.append(name, qty);
       ingList.appendChild(li);
     });

--- a/app/static/js/components/recipe-list.js
+++ b/app/static/js/components/recipe-list.js
@@ -22,10 +22,28 @@ export function renderRecipes() {
     }
     return a.name.localeCompare(b.name);
   });
+  if (data.length === 0) {
+    const empty = document.createElement('div');
+    empty.className = 'card bg-base-200 shadow';
+    const body = document.createElement('div');
+    body.className = 'card-body';
+    body.textContent = t('recipes_empty_state');
+    empty.appendChild(body);
+    list.appendChild(empty);
+    return;
+  }
   data.forEach(r => {
-    const li = document.createElement('li');
+    const card = document.createElement('div');
+    card.className = 'card bg-base-200 shadow';
+    const body = document.createElement('div');
+    body.className = 'card-body';
+    const header = document.createElement('div');
+    header.className = 'flex justify-between items-start';
+    const title = document.createElement('h3');
+    title.className = 'card-title';
+    title.textContent = t(r.name);
     const favBtn = document.createElement('button');
-    favBtn.className = 'btn btn-ghost btn-xs mr-2';
+    favBtn.className = 'btn btn-ghost btn-xs';
     favBtn.innerHTML = state.favoriteRecipes.has(r.name)
       ? '<i class="fa-solid fa-heart"></i>'
       : '<i class="fa-regular fa-heart"></i>';
@@ -34,22 +52,76 @@ export function renderRecipes() {
       toggleFavorite(r.name);
       renderRecipes();
     });
-    const title = document.createElement('span');
-    title.textContent = `${r.name} (${r.ingredients.join(', ')})`;
-    title.className = 'cursor-pointer';
-    title.addEventListener('click', () => openRecipeDetails(r));
-    li.appendChild(favBtn);
-    li.appendChild(title);
-    list.appendChild(li);
+    header.appendChild(title);
+    header.appendChild(favBtn);
+    body.appendChild(header);
+    const meta = document.createElement('div');
+    meta.className = 'flex items-center gap-4 text-sm';
+    if (r.time) {
+      const timeDiv = document.createElement('div');
+      timeDiv.className = 'flex items-center gap-1';
+      timeDiv.innerHTML = '<i class="fa-regular fa-clock"></i>';
+      const span = document.createElement('span');
+      span.textContent = r.time;
+      timeDiv.appendChild(span);
+      meta.appendChild(timeDiv);
+    }
+    if (r.portions != null) {
+      const portionsDiv = document.createElement('div');
+      portionsDiv.className = 'flex items-center gap-1';
+      portionsDiv.innerHTML = '<i class="fa-solid fa-users"></i>';
+      const span = document.createElement('span');
+      span.textContent = String(r.portions);
+      portionsDiv.appendChild(span);
+      meta.appendChild(portionsDiv);
+    }
+    if (meta.children.length) body.appendChild(meta);
+    const btn = document.createElement('button');
+    btn.className = 'btn btn-sm btn-primary self-start';
+    btn.textContent = t('history_show_details');
+    btn.addEventListener('click', () => openRecipeDetails(r));
+    body.appendChild(btn);
+    card.appendChild(body);
+    list.appendChild(card);
   });
 }
 
 export async function loadRecipes() {
-  const res = await fetch('/api/recipes');
-  const data = await res.json();
-  data.forEach(r => {
-    r.timeBucket = timeToBucket(r.time);
-  });
-  state.recipesData = data;
-  renderRecipes();
+  try {
+    const res = await fetch('/api/recipes');
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    const data = await res.json();
+    const processed = [];
+    data.forEach(r => {
+      try {
+        if (!r || !r.name || !Array.isArray(r.ingredients)) throw new Error('invalid structure');
+        const ingredients = r.ingredients.map(ing => {
+          if (typeof ing === 'string') {
+            return { productKey: ing, quantity: null, unit: null };
+          }
+          if (ing && typeof ing === 'object' && typeof ing.product === 'string') {
+            return {
+              productKey: ing.product,
+              quantity: ing.quantity != null ? ing.quantity : null,
+              unit: ing.unit || null
+            };
+          }
+          throw new Error('invalid ingredient');
+        });
+        processed.push({
+          ...r,
+          ingredients,
+          timeBucket: timeToBucket(r.time)
+        });
+      } catch (err) {
+        console.warn(`Skipping recipe ${r && r.name ? r.name : '(unknown)'}`, err.message);
+      }
+    });
+    state.recipesData = processed;
+    renderRecipes();
+  } catch (err) {
+    console.error('Failed to load recipes', err);
+    state.recipesData = [];
+    renderRecipes();
+  }
 }

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -193,7 +193,7 @@
                 <button id="recipe-favorites-toggle" class="btn btn-outline btn-sm self-start" data-i18n="recipe_filter_favorites">Ulubione przepisy</button>
                 <button id="recipe-clear-filters" class="btn btn-outline btn-sm self-start" data-i18n="recipe_clear_filters">Wyczyść filtry</button>
             </div>
-            <ul id="recipe-list" class="list-disc pl-4 mb-8"></ul>
+            <div id="recipe-list" class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4 mb-8"></div>
             <dialog id="recipe-detail-modal" class="modal">
                 <div class="modal-box max-w-lg">
                     <h3 id="recipe-detail-title" class="font-bold text-lg mb-2"></h3>


### PR DESCRIPTION
## Summary
- normalize recipe ingredient formats and skip invalid recipes
- render recipes as responsive cards with empty state and details link
- update recipe detail modal to use normalized ingredients

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689660ea6b0c832a9a444e0451a5a0fa