### PR TITLE
Refine edit products table layout

### DIFF
--- a/app/static/js/components/product-table.js
+++ b/app/static/js/components/product-table.js
@@ -1,32 +1,131 @@
-import { t, state, productName, unitName, categoryName, storageName, formatPackQuantity, getStatusIcon, STORAGE_ICONS } from '../helpers.js';
-
-export function renderProducts(data) {
-  const tbody = document.querySelector('#product-table tbody');
+import { t, state, productName, unitName, categoryName, storageName, formatPackQuantity, getStatusIcon, STORAGE_ICONS, CATEGORY_KEYS, STORAGE_KEYS } from '../helpers.js';
+export function renderProducts(data, editable = false) {
+  const table = document.getElementById('product-table');
+  const tbody = table ? table.querySelector('tbody') : null;
+  if (editable) {
+    table && table.classList.add('edit-mode');
+  } else {
+    table && table.classList.remove('edit-mode');
+  }
   if (tbody) tbody.innerHTML = '';
   data.forEach((p, idx) => {
     const tr = document.createElement('tr');
-    const nameTd = document.createElement('td');
-    nameTd.textContent = productName(p.name);
-    tr.appendChild(nameTd);
-    const qtyTd = document.createElement('td');
-    qtyTd.textContent = formatPackQuantity(p);
-    tr.appendChild(qtyTd);
-    const unitTd = document.createElement('td');
-    unitTd.textContent = unitName(p.unit);
-    tr.appendChild(unitTd);
-    const catTd = document.createElement('td');
-    catTd.textContent = categoryName(p.category);
-    tr.appendChild(catTd);
-    const storTd = document.createElement('td');
-    storTd.textContent = storageName(p.storage);
-    tr.appendChild(storTd);
-    const statusTd = document.createElement('td');
-    const status = getStatusIcon(p);
-    if (status) {
-      statusTd.innerHTML = status.html;
-      statusTd.title = status.title;
+    if (editable) {
+      // Checkbox cell
+      const cbTd = document.createElement('td');
+      cbTd.className = 'checkbox-cell';
+      const cb = document.createElement('input');
+      cb.type = 'checkbox';
+      cb.className = 'checkbox checkbox-sm product-select';
+      cb.dataset.name = p.name;
+      cbTd.appendChild(cb);
+      tr.appendChild(cbTd);
+      // Name cell
+      const nameTd = document.createElement('td');
+      nameTd.className = 'name-cell';
+      nameTd.textContent = productName(p.name);
+      tr.appendChild(nameTd);
+      // Quantity cell with controls
+      const qtyTd = document.createElement('td');
+      qtyTd.className = 'qty-cell';
+      const qtyWrap = document.createElement('div');
+      qtyWrap.className = 'quantity-control';
+      const minus = document.createElement('button');
+      minus.type = 'button';
+      minus.className = 'btn btn-xs';
+      minus.textContent = '−';
+      const input = document.createElement('input');
+      input.type = 'number';
+      input.value = p.quantity;
+      input.className = 'input input-bordered w-full text-center';
+      const plus = document.createElement('button');
+      plus.type = 'button';
+      plus.className = 'btn btn-xs';
+      plus.textContent = '+';
+      minus.addEventListener('click', () => {
+        input.value = Math.max(0, (parseFloat(input.value) || 0) - 1);
+      });
+      plus.addEventListener('click', () => {
+        input.value = (parseFloat(input.value) || 0) + 1;
+      });
+      qtyWrap.append(minus, input, plus);
+      qtyTd.appendChild(qtyWrap);
+      tr.appendChild(qtyTd);
+      // Unit select
+      const unitTd = document.createElement('td');
+      unitTd.className = 'unit-cell';
+      const unitSel = document.createElement('select');
+      unitSel.className = 'select select-bordered w-full';
+      Object.keys(state.units).forEach(u => {
+        const opt = document.createElement('option');
+        opt.value = u;
+        opt.textContent = unitName(u);
+        if (u === p.unit) opt.selected = true;
+        unitSel.appendChild(opt);
+      });
+      unitTd.appendChild(unitSel);
+      tr.appendChild(unitTd);
+      // Category select
+      const catTd = document.createElement('td');
+      catTd.className = 'category-cell';
+      const catSel = document.createElement('select');
+      catSel.className = 'select select-bordered w-full';
+      Object.keys(CATEGORY_KEYS).forEach(c => {
+        const opt = document.createElement('option');
+        opt.value = c;
+        opt.textContent = categoryName(c);
+        if (c === (p.category || 'uncategorized')) opt.selected = true;
+        catSel.appendChild(opt);
+      });
+      catTd.appendChild(catSel);
+      tr.appendChild(catTd);
+      // Storage select
+      const storTd = document.createElement('td');
+      storTd.className = 'storage-cell';
+      const storSel = document.createElement('select');
+      storSel.className = 'select select-bordered w-full';
+      Object.keys(STORAGE_KEYS).forEach(s => {
+        const opt = document.createElement('option');
+        opt.value = s;
+        opt.textContent = storageName(s);
+        if (s === (p.storage || 'pantry')) opt.selected = true;
+        storSel.appendChild(opt);
+      });
+      storTd.appendChild(storSel);
+      tr.appendChild(storTd);
+      // Status icon
+      const statusTd = document.createElement('td');
+      statusTd.className = 'status-cell text-center';
+      const status = getStatusIcon(p);
+      if (status) {
+        statusTd.innerHTML = status.html;
+        statusTd.title = status.title;
+      }
+      tr.appendChild(statusTd);
+    } else {
+      const nameTd = document.createElement('td');
+      nameTd.textContent = productName(p.name);
+      tr.appendChild(nameTd);
+      const qtyTd = document.createElement('td');
+      qtyTd.textContent = formatPackQuantity(p);
+      tr.appendChild(qtyTd);
+      const unitTd = document.createElement('td');
+      unitTd.textContent = unitName(p.unit);
+      tr.appendChild(unitTd);
+      const catTd = document.createElement('td');
+      catTd.textContent = categoryName(p.category);
+      tr.appendChild(catTd);
+      const storTd = document.createElement('td');
+      storTd.textContent = storageName(p.storage);
+      tr.appendChild(storTd);
+      const statusTd = document.createElement('td');
+      const status = getStatusIcon(p);
+      if (status) {
+        statusTd.innerHTML = status.html;
+        statusTd.title = status.title;
+      }
+      tr.appendChild(statusTd);
     }
-    tr.appendChild(statusTd);
     tbody && tbody.appendChild(tr);
   });
 

--- a/app/static/script.js
+++ b/app/static/script.js
@@ -1,4 +1,4 @@
-import { loadTranslations, loadUnits, loadFavorites, state } from './js/helpers.js';
+import { loadTranslations, loadUnits, loadFavorites, state, t } from './js/helpers.js';
 import { renderProducts } from './js/components/product-table.js';
 import { renderRecipes, loadRecipes } from './js/components/recipe-list.js';
 import { renderShoppingList, addToShoppingList } from './js/components/shopping-list.js';
@@ -6,12 +6,13 @@ import { showNotification, checkLowStockToast } from './js/components/toast.js';
 import { initReceiptImport } from './js/components/ocr-modal.js';
 
 let currentProducts = [];
+let editMode = false;
 
 async function loadProducts() {
   const res = await fetch('/api/products');
   currentProducts = await res.json();
   window.currentProducts = currentProducts;
-  renderProducts(currentProducts);
+  renderProducts(currentProducts, editMode);
   checkLowStockToast(currentProducts, activateTab, () => {}, renderShoppingList);
 }
 
@@ -35,4 +36,16 @@ document.addEventListener('DOMContentLoaded', async () => {
   initReceiptImport();
   loadProducts();
   loadRecipes();
+  const editBtn = document.getElementById('edit-toggle');
+  const saveBtn = document.getElementById('save-btn');
+  const deleteBtn = document.getElementById('delete-selected');
+  const selectHeader = document.getElementById('select-header');
+  editBtn?.addEventListener('click', () => {
+    editMode = !editMode;
+    editBtn.textContent = editMode ? t('edit_mode_button_off') : t('edit_mode_button_on');
+    saveBtn.style.display = editMode ? '' : 'none';
+    deleteBtn.style.display = editMode ? '' : 'none';
+    selectHeader.style.display = editMode ? '' : 'none';
+    renderProducts(currentProducts, editMode);
+  });
 });

--- a/app/static/styles.css
+++ b/app/static/styles.css
@@ -43,8 +43,8 @@ html[data-layout="mobile"] #controls > * {
   width: 100%;
 }
 
-html[data-layout="mobile"] #product-table th:nth-child(n+4),
-html[data-layout="mobile"] #product-table td:nth-child(n+4) {
+html[data-layout="mobile"] #product-table:not(.edit-mode) th:nth-child(n+4),
+html[data-layout="mobile"] #product-table:not(.edit-mode) td:nth-child(n+4) {
   display: none;
 }
 
@@ -76,6 +76,94 @@ html[data-layout="mobile"] .btn {
   align-items: center;
   justify-content: center;
   line-height: 1;
+}
+
+/* Edit mode table layout */
+#product-table thead th {
+  position: sticky;
+  top: 0;
+  z-index: 10;
+}
+
+#product-table.edit-mode thead th,
+#product-table.edit-mode tbody td {
+  padding-top: 0.25rem;
+  padding-bottom: 0.25rem;
+  min-height: 2.5rem;
+}
+
+#product-table.edit-mode thead tr,
+#product-table.edit-mode tbody tr {
+  display: grid;
+  grid-template-columns: repeat(12, minmax(0, 1fr));
+  align-items: center;
+}
+
+#product-table.edit-mode .checkbox-cell { grid-column: span 1 / span 1; }
+#product-table.edit-mode .name-cell { grid-column: span 3 / span 3; }
+#product-table.edit-mode .qty-cell { grid-column: span 2 / span 2; }
+#product-table.edit-mode .unit-cell { grid-column: span 1 / span 1; }
+#product-table.edit-mode .category-cell { grid-column: span 2 / span 2; }
+#product-table.edit-mode .storage-cell { grid-column: span 2 / span 2; }
+#product-table.edit-mode .status-cell { grid-column: span 1 / span 1; }
+
+#product-table.edit-mode .quantity-control {
+  display: flex;
+  align-items: center;
+}
+
+#product-table.edit-mode .quantity-control .btn {
+  min-width: 2rem;
+  height: 2rem;
+}
+
+#product-table.edit-mode select,
+#product-table.edit-mode input[type="number"] {
+  height: 2.5rem;
+  border-radius: 0.375rem;
+}
+
+html[data-layout="mobile"] #product-table.edit-mode thead {
+  display: none;
+}
+
+html[data-layout="mobile"] #product-table.edit-mode tbody tr {
+  grid-template-columns: repeat(6, minmax(0, 1fr));
+}
+
+html[data-layout="mobile"] #product-table.edit-mode .checkbox-cell {
+  grid-row: span 3 / span 3;
+  grid-column: span 1 / span 1;
+}
+
+html[data-layout="mobile"] #product-table.edit-mode .name-cell {
+  grid-column: span 5 / span 5;
+}
+
+html[data-layout="mobile"] #product-table.edit-mode .qty-cell {
+  grid-column: span 3 / span 3;
+}
+
+html[data-layout="mobile"] #product-table.edit-mode .unit-cell {
+  grid-column: span 2 / span 2;
+}
+
+html[data-layout="mobile"] #product-table.edit-mode .category-cell {
+  grid-column: span 3 / span 3;
+}
+
+html[data-layout="mobile"] #product-table.edit-mode .storage-cell {
+  grid-column: span 2 / span 2;
+}
+
+html[data-layout="mobile"] #product-table.edit-mode .status-cell {
+  grid-row: span 3 / span 3;
+  grid-column: span 1 / span 1;
+  align-self: center;
+}
+
+html[data-layout="mobile"] #product-table .status-label {
+  display: none;
 }
 
 /* Product view spacing adjustments */

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -57,7 +57,16 @@
                 <button id="delete-selected" style="display:none;" class="btn btn-error btn-sm" disabled data-i18n="delete_selected_button">Usuń zaznaczone</button>
             </div>
             <div class="overflow-x-auto">
-                <table id="product-table" class="table table-zebra w-full">
+                <table id="product-table" class="table table-zebra table-fixed w-full">
+                    <colgroup>
+                        <col style="width:6%">
+                        <col style="width:24%">
+                        <col style="width:12%">
+                        <col style="width:12%">
+                        <col style="width:17%">
+                        <col style="width:17%">
+                        <col style="width:12%">
+                    </colgroup>
                     <thead>
                         <tr>
                             <th id="select-header" style="display:none;"></th>
@@ -66,7 +75,7 @@
                             <th data-i18n="table_header_unit">Jednostka</th>
                             <th data-i18n="table_header_category">Kategoria</th>
                             <th data-i18n="table_header_storage">Miejsce</th>
-                            <th data-i18n="table_header_status">Status</th>
+                            <th class="status-header text-center"><i class="fa-solid fa-circle-info"></i> <span class="status-label" data-i18n="table_header_status">Status</span></th>
                         </tr>
                     </thead>
                     <tbody></tbody>


### PR DESCRIPTION
## Summary
- Rework product table with fixed column widths and sticky header for stable edit mode
- Add responsive 12-column grid, inline quantity controls, and unified input/select styling
- Toggle edit mode via JS to show editable rows and controls

## Testing
- `pytest`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6896673f058c832a98d7089568671a9d