### PR TITLE
Revamp suggested items UI for shopping list

### DIFF
--- a/app/static/js/components/suggestions.js
+++ b/app/static/js/components/suggestions.js
@@ -1,0 +1,79 @@
+import { t, productName, state } from '../helpers.js';
+import { addToShoppingList } from './shopping-list.js';
+
+const dismissed = new Set();
+
+export function renderSuggestions() {
+  const container = document.getElementById('suggestion-list');
+  if (!container) return;
+  container.innerHTML = '';
+
+  const products = window.currentProducts || [];
+  const inShopping = new Set(state.shoppingList.map(item => item.name));
+
+  products
+    .filter(p =>
+      p.main && p.threshold !== null && p.quantity <= p.threshold &&
+      !dismissed.has(p.name) && !inShopping.has(p.name)
+    )
+    .sort((a, b) => productName(a.name).localeCompare(productName(b.name)))
+    .forEach(p => {
+      const row = document.createElement('div');
+      row.className = 'flex items-center justify-between gap-2 p-2 suggestion-item';
+
+      const nameEl = document.createElement('div');
+      nameEl.className = 'flex-1 truncate';
+      nameEl.textContent = productName(p.name);
+      row.appendChild(nameEl);
+
+      const qtyWrap = document.createElement('div');
+      qtyWrap.className = 'flex items-center gap-2';
+      const dec = document.createElement('button');
+      dec.type = 'button';
+      dec.innerHTML = '<i class="fa-solid fa-minus"></i>';
+      dec.className = 'touch-btn';
+      const qty = document.createElement('span');
+      qty.className = 'w-10 h-10 inline-flex items-center justify-center text-center';
+      qty.textContent = '1';
+      const inc = document.createElement('button');
+      inc.type = 'button';
+      inc.innerHTML = '<i class="fa-solid fa-plus"></i>';
+      inc.className = 'touch-btn';
+      dec.addEventListener('click', () => {
+        const val = Math.max(1, (parseInt(qty.textContent) || 1) - 1);
+        qty.textContent = val;
+      });
+      inc.addEventListener('click', () => {
+        const val = (parseInt(qty.textContent) || 1) + 1;
+        qty.textContent = val;
+      });
+      qtyWrap.append(dec, qty, inc);
+      row.appendChild(qtyWrap);
+
+      const actions = document.createElement('div');
+      actions.className = 'flex items-center gap-2';
+      const acceptBtn = document.createElement('button');
+      acceptBtn.type = 'button';
+      acceptBtn.className = 'touch-btn text-success';
+      acceptBtn.innerHTML = '<i class="fa-solid fa-check"></i>';
+      acceptBtn.setAttribute('aria-label', t('save_button'));
+      acceptBtn.addEventListener('click', () => {
+        addToShoppingList(p.name, parseInt(qty.textContent) || 1);
+        dismissed.add(p.name);
+        row.remove();
+      });
+      const rejectBtn = document.createElement('button');
+      rejectBtn.type = 'button';
+      rejectBtn.className = 'touch-btn text-error';
+      rejectBtn.innerHTML = '<i class="fa-solid fa-xmark"></i>';
+      rejectBtn.setAttribute('aria-label', t('delete_cancel_button'));
+      rejectBtn.addEventListener('click', () => {
+        dismissed.add(p.name);
+        row.remove();
+      });
+      actions.append(acceptBtn, rejectBtn);
+      row.appendChild(actions);
+
+      container.appendChild(row);
+    });
+}

--- a/app/static/script.js
+++ b/app/static/script.js
@@ -2,6 +2,7 @@ import { loadTranslations, loadUnits, loadFavorites, state } from './js/helpers.
 import { renderProducts } from './js/components/product-table.js';
 import { renderRecipes, loadRecipes } from './js/components/recipe-list.js';
 import { renderShoppingList, addToShoppingList } from './js/components/shopping-list.js';
+import { renderSuggestions } from './js/components/suggestions.js';
 import { showNotification, checkLowStockToast } from './js/components/toast.js';
 import { initReceiptImport } from './js/components/ocr-modal.js';
 
@@ -12,7 +13,8 @@ async function loadProducts() {
   currentProducts = await res.json();
   window.currentProducts = currentProducts;
   renderProducts(currentProducts);
-  checkLowStockToast(currentProducts, activateTab, () => {}, renderShoppingList);
+  renderSuggestions();
+  checkLowStockToast(currentProducts, activateTab, renderSuggestions, renderShoppingList);
 }
 
 function activateTab(targetId) {

--- a/app/static/styles.css
+++ b/app/static/styles.css
@@ -193,16 +193,6 @@ input[type="number"] {
   -moz-appearance: textfield;
 }
 
-/* Table alignment for shopping sections */
-.suggestion-table th,
-.suggestion-table td {
-  vertical-align: middle;
-}
-
-.suggestion-table {
-  border-radius: 0.5rem;
-}
-
 /* Touch-friendly buttons for mobile */
 .touch-btn {
   width: 2.5rem;
@@ -223,38 +213,6 @@ input[type="number"] {
 
 .no-spinner {
   -moz-appearance: textfield;
-}
-
-/* Suggestion table mobile card layout */
-html[data-layout="mobile"] #suggestion-table thead {
-  display: none;
-}
-
-html[data-layout="mobile"] #suggestion-table tbody tr {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  padding: 0.5rem;
-  border-bottom: 1px solid hsl(var(--b3));
-}
-
-html[data-layout="mobile"] #suggestion-table tbody td {
-  border: none;
-  padding: 0;
-}
-
-html[data-layout="mobile"] #suggestion-table tbody td:nth-child(1) {
-  flex: 1;
-}
-
-html[data-layout="mobile"] #suggestion-table tbody td:nth-child(2) {
-  flex: 0 0 auto;
-}
-
-html[data-layout="mobile"] #suggestion-table tbody td:nth-child(3) {
-  flex: 0 0 auto;
-  display: flex;
-  gap: 0.5rem;
 }
 
 html[data-layout="mobile"] .touch-btn {

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -330,11 +330,7 @@
             </dialog>
             <div id="suggestions-section" class="mb-8">
                 <h2 class="text-xl font-semibold mb-4" data-i18n="heading_suggestions">Propozycje</h2>
-                <div class="overflow-x-auto">
-                    <table id="suggestion-table" class="table w-full border border-base-300 rounded-lg suggestion-table">
-                        <tbody></tbody>
-                    </table>
-                </div>
+                <div id="suggestion-list" class="border border-base-300 rounded-lg divide-y divide-base-300"></div>
             </div>
             <div id="shopping-list-section" class="mb-8">
                 <h2 class="text-xl font-semibold mb-4" data-i18n="heading_shopping_list">Lista zakupów</h2>


### PR DESCRIPTION
## Summary
- Replace proposal table with compact flex list
- Add Suggestions component with stepper and accept/reject actions
- Integrate suggestions rendering with product load and low stock toast

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68966743c9bc832a83d48cd41aa9d4e4