### PR TITLE
Standardize storage category tables

### DIFF
--- a/app/static/js/components/product-table.js
+++ b/app/static/js/components/product-table.js
@@ -57,8 +57,24 @@ export function renderProducts(data) {
       Object.keys(storages[stor])
         .sort((a, b) => categoryName(a).localeCompare(categoryName(b)))
         .forEach(cat => {
+          const categoryBlock = document.createElement('div');
+          categoryBlock.className = 'category-block';
+          const header = document.createElement('h4');
+          header.className = 'text-xl font-semibold mt-4 mb-2';
+          header.textContent = categoryName(cat);
+          categoryBlock.appendChild(header);
+
           const table = document.createElement('table');
           table.className = 'table table-zebra w-full grouped-table';
+
+          const colgroup = document.createElement('colgroup');
+          ['grouped-col-name', 'grouped-col-qty', 'grouped-col-unit', 'grouped-col-status'].forEach(cls => {
+            const col = document.createElement('col');
+            col.className = cls;
+            colgroup.appendChild(col);
+          });
+          table.appendChild(colgroup);
+
           const thead = document.createElement('thead');
           const hr = document.createElement('tr');
           [t('table_header_name'), t('table_header_quantity'), t('table_header_unit'), t('table_header_status')].forEach(txt => {
@@ -68,6 +84,7 @@ export function renderProducts(data) {
           });
           thead.appendChild(hr);
           table.appendChild(thead);
+
           const tb = document.createElement('tbody');
           storages[stor][cat].forEach(p => {
             const tr = document.createElement('tr');
@@ -84,11 +101,9 @@ export function renderProducts(data) {
             tb.appendChild(tr);
           });
           table.appendChild(tb);
-          const header = document.createElement('h4');
-          header.className = 'text-xl font-semibold mt-4 mb-2';
-          header.textContent = categoryName(cat);
-          content.appendChild(header);
-          content.appendChild(table);
+
+          categoryBlock.appendChild(table);
+          content.appendChild(categoryBlock);
         });
       block.appendChild(content);
       container.appendChild(block);

--- a/app/static/styles.css
+++ b/app/static/styles.css
@@ -90,16 +90,20 @@ html[data-layout="mobile"] .btn {
 
 #product-list .category-block {
   margin-bottom: 1rem;
+  padding-left: 0;
+  padding-right: 0;
 }
 
 #product-list .category-block table {
   margin-top: 0;
   margin-bottom: 0;
+  margin-left: 0;
 }
 
 #product-list .grouped-table {
   table-layout: fixed;
   width: 100%;
+  border-spacing: 0;
 }
 
 #product-list .grouped-table col.grouped-col-name {
@@ -116,6 +120,13 @@ html[data-layout="mobile"] .btn {
 
 #product-list .grouped-table col.grouped-col-status {
   width: 15%;
+}
+
+#product-list .grouped-table thead th {
+  position: sticky;
+  top: 0;
+  background-color: hsl(var(--b1));
+  z-index: 1;
 }
 
 /* Recipe detail layout */
@@ -141,7 +152,7 @@ html[data-layout="mobile"] .btn {
 
 #product-list .grouped-table th,
 #product-list .grouped-table td {
-  padding: 0.25rem 0.25rem;
+  padding: 0.5rem 1rem;
 }
 
 #product-list .grouped-table th:first-child,
@@ -149,11 +160,9 @@ html[data-layout="mobile"] .btn {
   padding-left: 0;
 }
 
-@media (min-width: 640px) {
-  #product-list .grouped-table th,
-  #product-list .grouped-table td {
-    padding: 0.5rem 1rem;
-  }
+html[data-layout="mobile"] #product-list .grouped-table th,
+html[data-layout="mobile"] #product-list .grouped-table td {
+  padding: 0.25rem 0.25rem;
 }
 
 /* Navigation positioning for mobile view */


### PR DESCRIPTION
## Summary
- Ensure grouped category tables share colgroup widths and a dedicated wrapper
- Add sticky headers and remove left spacing so tables align with category titles
- Reduce grouped-table padding on mobile layouts

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689667515374832a9fb587bb975bbd93