### PR TITLE
feat: add translation fallback helper

### DIFF
--- a/app/static/js/components/recipe-detail.js
+++ b/app/static/js/components/recipe-detail.js
@@ -1,4 +1,4 @@
-import { t } from '../helpers.js';
+import { t, productName, unitName } from '../helpers.js';
 
 export function openRecipeDetails(recipe) {
   const modal = document.getElementById('recipe-detail-modal');
@@ -26,10 +26,10 @@ export function openRecipeDetails(recipe) {
       const li = document.createElement('li');
       const name = document.createElement('span');
       const qty = document.createElement('span');
-      name.textContent = t(ing.productKey);
+      name.textContent = productName(ing.productKey);
       let text = '';
       if (ing.quantity != null) text += ing.quantity;
-      if (ing.unit) text += ` ${t(ing.unit)}`;
+      if (ing.unit) text += ` ${unitName(ing.unit)}`;
       qty.textContent = text.trim();
       li.append(name, qty);
       ingList.appendChild(li);

--- a/app/static/js/components/shopping-list.js
+++ b/app/static/js/components/shopping-list.js
@@ -32,7 +32,7 @@ export function renderShoppingList() {
     const nameWrap = document.createElement('div');
     nameWrap.className = 'flex-1 overflow-hidden';
     const nameEl = document.createElement('div');
-    nameEl.textContent = t(item.name);
+    nameEl.textContent = productName(item.name);
     nameEl.className = 'truncate';
     if (item.inCart) nameEl.classList.add('line-through');
     nameWrap.appendChild(nameEl);

--- a/app/static/js/helpers.js
+++ b/app/static/js/helpers.js
@@ -63,10 +63,27 @@ export function t(key) {
   return state.uiTranslations[state.currentLang][key] || key;
 }
 
-export function productName(key) { return t(key); }
-export function unitName(key) { return t(key); }
-export function categoryName(key) { return t(CATEGORY_KEYS[key] || key); }
-export function storageName(key) { return t(STORAGE_KEYS[key] || key); }
+export function productName(key) {
+  const translated = t(key);
+  return translated === key ? key.replace(/^product\./, '') : translated;
+}
+
+export function unitName(key) {
+  const translated = t(key);
+  return translated === key ? key : translated;
+}
+
+export function categoryName(key) {
+  const tKey = CATEGORY_KEYS[key] || key;
+  const translated = t(tKey);
+  return translated === tKey ? key : translated;
+}
+
+export function storageName(key) {
+  const tKey = STORAGE_KEYS[key] || key;
+  const translated = t(tKey);
+  return translated === tKey ? key : translated;
+}
 
 export function parseTimeToMinutes(str) {
   if (!str) return null;


### PR DESCRIPTION
## Summary
- add translation helpers for product, category, storage and unit names
- use translation helpers in recipe detail and shopping list components

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `node --check app/static/js/helpers.js app/static/js/components/recipe-detail.js app/static/js/components/shopping-list.js`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6896674ce500832a856981e6fe7e392e