### PR TITLE
Redesign suggested items UI

### DIFF
--- a/app/static/js/components/shopping-list.js
+++ b/app/static/js/components/shopping-list.js
@@ -116,3 +116,72 @@ export function renderShoppingList() {
     list.appendChild(row);
   });
 }
+
+export function renderSuggestions() {
+  const container = document.getElementById('suggestion-list');
+  if (!container) return;
+  container.innerHTML = '';
+  const suggestions = (window.currentProducts || [])
+    .filter(p => p.main && p.threshold !== null && parseFloat(p.quantity) <= p.threshold)
+    .filter(p => !state.dismissedSuggestions.has(p.name))
+    .sort((a, b) => productName(a.name).localeCompare(productName(b.name)));
+  suggestions.forEach(p => {
+    let qty = 1;
+    const row = document.createElement('div');
+    row.className = 'suggestion-item grid items-center gap-3 p-2 min-h-10 hover:bg-base-200 transition-colors flex-nowrap';
+    row.style.gridTemplateColumns = '1fr auto auto';
+    const nameEl = document.createElement('div');
+    nameEl.className = 'truncate';
+    nameEl.textContent = productName(p.name);
+    row.appendChild(nameEl);
+    const qtyWrap = document.createElement('div');
+    qtyWrap.className = 'flex items-center';
+    const dec = document.createElement('button');
+    dec.type = 'button';
+    dec.innerHTML = '<i class="fa-solid fa-minus"></i>';
+    dec.className = 'touch-btn';
+    const qtySpan = document.createElement('span');
+    qtySpan.textContent = qty;
+    qtySpan.className = 'w-10 h-10 inline-flex items-center justify-center text-center';
+    const inc = document.createElement('button');
+    inc.type = 'button';
+    inc.innerHTML = '<i class="fa-solid fa-plus"></i>';
+    inc.className = 'touch-btn';
+    dec.addEventListener('click', () => {
+      if (qty > 1) {
+        qty -= 1;
+        qtySpan.textContent = qty;
+      }
+    });
+    inc.addEventListener('click', () => {
+      qty += 1;
+      qtySpan.textContent = qty;
+    });
+    qtyWrap.append(dec, qtySpan, inc);
+    row.appendChild(qtyWrap);
+    const actions = document.createElement('div');
+    actions.className = 'flex items-center gap-2';
+    const accept = document.createElement('button');
+    accept.type = 'button';
+    accept.innerHTML = '<i class="fa-solid fa-check"></i>';
+    accept.className = 'touch-btn text-success';
+    accept.setAttribute('aria-label', t('accept_action'));
+    accept.addEventListener('click', () => {
+      state.dismissedSuggestions.add(p.name);
+      addToShoppingList(p.name, qty);
+      row.remove();
+    });
+    const reject = document.createElement('button');
+    reject.type = 'button';
+    reject.innerHTML = '<i class="fa-solid fa-xmark"></i>';
+    reject.className = 'touch-btn text-error';
+    reject.setAttribute('aria-label', t('reject_action'));
+    reject.addEventListener('click', () => {
+      state.dismissedSuggestions.add(p.name);
+      row.remove();
+    });
+    actions.append(accept, reject);
+    row.appendChild(actions);
+    container.appendChild(row);
+  });
+}

--- a/app/static/js/helpers.js
+++ b/app/static/js/helpers.js
@@ -36,6 +36,7 @@ export const state = {
   expandedStorages: {},
   expandedCategories: {},
   shoppingList: JSON.parse(localStorage.getItem('shoppingList') || '[]'),
+  dismissedSuggestions: new Set(),
   pendingRemoveIndex: null,
   recipesData: [],
   recipeSortField: 'name',

--- a/app/static/script.js
+++ b/app/static/script.js
@@ -1,7 +1,7 @@
 import { loadTranslations, loadUnits, loadFavorites, state, t } from './js/helpers.js';
 import { renderProducts } from './js/components/product-table.js';
 import { renderRecipes, loadRecipes } from './js/components/recipe-list.js';
-import { renderShoppingList, addToShoppingList } from './js/components/shopping-list.js';
+import { renderShoppingList, addToShoppingList, renderSuggestions } from './js/components/shopping-list.js';
 import { showNotification, checkLowStockToast } from './js/components/toast.js';
 import { initReceiptImport } from './js/components/ocr-modal.js';
 
@@ -13,7 +13,8 @@ async function loadProducts() {
   currentProducts = await res.json();
   window.currentProducts = currentProducts;
   renderProducts(currentProducts, editMode);
-  checkLowStockToast(currentProducts, activateTab, () => {}, renderShoppingList);
+  renderSuggestions();
+  checkLowStockToast(currentProducts, activateTab, renderSuggestions, renderShoppingList);
 }
 
 function activateTab(targetId) {

--- a/app/static/styles.css
+++ b/app/static/styles.css
@@ -290,16 +290,6 @@ input[type="number"] {
   -moz-appearance: textfield;
 }
 
-/* Table alignment for shopping sections */
-.suggestion-table th,
-.suggestion-table td {
-  vertical-align: middle;
-}
-
-.suggestion-table {
-  border-radius: 0.5rem;
-}
-
 /* Touch-friendly buttons for mobile */
 .touch-btn {
   width: 2.5rem;
@@ -320,38 +310,6 @@ input[type="number"] {
 
 .no-spinner {
   -moz-appearance: textfield;
-}
-
-/* Suggestion table mobile card layout */
-html[data-layout="mobile"] #suggestion-table thead {
-  display: none;
-}
-
-html[data-layout="mobile"] #suggestion-table tbody tr {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  padding: 0.5rem;
-  border-bottom: 1px solid hsl(var(--b3));
-}
-
-html[data-layout="mobile"] #suggestion-table tbody td {
-  border: none;
-  padding: 0;
-}
-
-html[data-layout="mobile"] #suggestion-table tbody td:nth-child(1) {
-  flex: 1;
-}
-
-html[data-layout="mobile"] #suggestion-table tbody td:nth-child(2) {
-  flex: 0 0 auto;
-}
-
-html[data-layout="mobile"] #suggestion-table tbody td:nth-child(3) {
-  flex: 0 0 auto;
-  display: flex;
-  gap: 0.5rem;
 }
 
 html[data-layout="mobile"] .touch-btn {

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -339,11 +339,7 @@
             </dialog>
             <div id="suggestions-section" class="mb-8">
                 <h2 class="text-xl font-semibold mb-4" data-i18n="heading_suggestions">Propozycje</h2>
-                <div class="overflow-x-auto">
-                    <table id="suggestion-table" class="table w-full border border-base-300 rounded-lg suggestion-table">
-                        <tbody></tbody>
-                    </table>
-                </div>
+                <div id="suggestion-list" class="border border-base-300 rounded-lg divide-y divide-base-300"></div>
             </div>
             <div id="shopping-list-section" class="mb-8">
                 <h2 class="text-xl font-semibold mb-4" data-i18n="heading_shopping_list">Lista zakupów</h2>


### PR DESCRIPTION
## Summary
- Show shopping proposals in a compact list with stepper and accept/reject actions
- Track dismissed suggestions and wire rendering into low-stock toast flow
- Remove table-based layout and unused CSS from suggestions section

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68966ace827c832a969327c9a4b3fcfe