### PR TITLE
Stabilize data handling and app init

### DIFF
--- a/README_DEV.md
+++ b/README_DEV.md
@@ -1,0 +1,40 @@
+# Developer Notes
+
+## Data Models
+
+### products.json
+Array of objects:
+- `name` (string)
+- `unit` (string)
+- `quantity` (number)
+- `package_size` (number, default 1)
+- `pack_size` (integer|null)
+- `threshold` (number, default 1)
+- `main` (boolean)
+- `category` (string)
+- `storage` (string)
+
+### recipes.json
+Array of objects:
+- `name` (string)
+- `portions` (integer)
+- `time` (string, optional)
+- `ingredients` (array of ingredient)
+- `steps` (array of strings)
+- `tags` (array of strings)
+
+Ingredient can be either legacy `"product.key"` string or object:
+`{ "product": "product.key", "quantity": number?, "unit": string? }`
+
+## Validation Policy
+Data files are validated against JSON Schemas in `app/schemas`. Invalid items
+are logged as warnings and skipped; processing never aborts responses.
+Use `/api/validate` to view counts and the first five warnings for each dataset.
+
+## Running Validation
+`curl http://localhost:5000/api/validate` when the server is running.
+
+## Known Limitations / Next Steps
+- Frontend layout still needs fine‑tuning for narrow screens.
+- History view is minimal and lacks editing features.
+- Validation only reports first five warnings per dataset.

--- a/app/schemas/products.schema.json
+++ b/app/schemas/products.schema.json
@@ -1,4 +1,5 @@
 {
+  "$comment": "CHANGELOG: Unified product schema (array of objects).",
   "$schema": "http://json-schema.org/draft-07/schema#",
   "type": "array",
   "items": {

--- a/app/schemas/recipes.schema.json
+++ b/app/schemas/recipes.schema.json
@@ -1,4 +1,5 @@
 {
+  "$comment": "CHANGELOG: Accepts legacy string or object ingredients.",
   "$schema": "http://json-schema.org/draft-07/schema#",
   "type": "array",
   "items": {

--- a/app/static/js/components/product-table.js
+++ b/app/static/js/components/product-table.js
@@ -1,132 +1,142 @@
 import { t, state, productName, unitName, categoryName, storageName, formatPackQuantity, getStatusIcon, STORAGE_ICONS, CATEGORY_KEYS, STORAGE_KEYS } from '../helpers.js';
+
+// CHANGELOG:
+// - Added defensive rendering with per-item guards to avoid crashes on malformed data.
+
 export function renderProducts(data, editable = false) {
   const table = document.getElementById('product-table');
   const tbody = table ? table.querySelector('tbody') : null;
+  const safeData = Array.isArray(data) ? data.filter(p => p && p.name) : [];
   if (editable) {
     table && table.classList.add('edit-mode');
   } else {
     table && table.classList.remove('edit-mode');
   }
   if (tbody) tbody.innerHTML = '';
-  data.forEach((p, idx) => {
-    const tr = document.createElement('tr');
-    if (editable) {
-      // Checkbox cell
-      const cbTd = document.createElement('td');
-      cbTd.className = 'checkbox-cell';
-      const cb = document.createElement('input');
-      cb.type = 'checkbox';
-      cb.className = 'checkbox checkbox-sm product-select';
-      cb.dataset.name = p.name;
-      cbTd.appendChild(cb);
-      tr.appendChild(cbTd);
-      // Name cell
-      const nameTd = document.createElement('td');
-      nameTd.className = 'name-cell';
-      nameTd.textContent = productName(p.name);
-      tr.appendChild(nameTd);
-      // Quantity cell with controls
-      const qtyTd = document.createElement('td');
-      qtyTd.className = 'qty-cell';
-      const qtyWrap = document.createElement('div');
-      qtyWrap.className = 'quantity-control';
-      const minus = document.createElement('button');
-      minus.type = 'button';
-      minus.className = 'btn btn-xs';
-      minus.textContent = '−';
-      const input = document.createElement('input');
-      input.type = 'number';
-      input.value = p.quantity;
-      input.className = 'input input-bordered w-full text-center';
-      const plus = document.createElement('button');
-      plus.type = 'button';
-      plus.className = 'btn btn-xs';
-      plus.textContent = '+';
-      minus.addEventListener('click', () => {
-        input.value = Math.max(0, (parseFloat(input.value) || 0) - 1);
-      });
-      plus.addEventListener('click', () => {
-        input.value = (parseFloat(input.value) || 0) + 1;
-      });
-      qtyWrap.append(minus, input, plus);
-      qtyTd.appendChild(qtyWrap);
-      tr.appendChild(qtyTd);
-      // Unit select
-      const unitTd = document.createElement('td');
-      unitTd.className = 'unit-cell';
-      const unitSel = document.createElement('select');
-      unitSel.className = 'select select-bordered w-full';
-      Object.keys(state.units).forEach(u => {
-        const opt = document.createElement('option');
-        opt.value = u;
-        opt.textContent = unitName(u);
-        if (u === p.unit) opt.selected = true;
-        unitSel.appendChild(opt);
-      });
-      unitTd.appendChild(unitSel);
-      tr.appendChild(unitTd);
-      // Category select
-      const catTd = document.createElement('td');
-      catTd.className = 'category-cell';
-      const catSel = document.createElement('select');
-      catSel.className = 'select select-bordered w-full';
-      Object.keys(CATEGORY_KEYS).forEach(c => {
-        const opt = document.createElement('option');
-        opt.value = c;
-        opt.textContent = categoryName(c);
-        if (c === (p.category || 'uncategorized')) opt.selected = true;
-        catSel.appendChild(opt);
-      });
-      catTd.appendChild(catSel);
-      tr.appendChild(catTd);
-      // Storage select
-      const storTd = document.createElement('td');
-      storTd.className = 'storage-cell';
-      const storSel = document.createElement('select');
-      storSel.className = 'select select-bordered w-full';
-      Object.keys(STORAGE_KEYS).forEach(s => {
-        const opt = document.createElement('option');
-        opt.value = s;
-        opt.textContent = storageName(s);
-        if (s === (p.storage || 'pantry')) opt.selected = true;
-        storSel.appendChild(opt);
-      });
-      storTd.appendChild(storSel);
-      tr.appendChild(storTd);
-      // Status icon
-      const statusTd = document.createElement('td');
-      statusTd.className = 'status-cell text-center';
-      const status = getStatusIcon(p);
-      if (status) {
-        statusTd.innerHTML = status.html;
-        statusTd.title = status.title;
+  safeData.forEach((p, idx) => {
+    try {
+      if (!p || !p.name) throw new Error('missing name');
+      const tr = document.createElement('tr');
+      if (editable) {
+        // Checkbox cell
+        const cbTd = document.createElement('td');
+        cbTd.className = 'checkbox-cell';
+        const cb = document.createElement('input');
+        cb.type = 'checkbox';
+        cb.className = 'checkbox checkbox-sm product-select';
+        cb.dataset.name = p.name;
+        cbTd.appendChild(cb);
+        tr.appendChild(cbTd);
+        // Name cell
+        const nameTd = document.createElement('td');
+        nameTd.className = 'name-cell';
+        nameTd.textContent = productName(p.name);
+        tr.appendChild(nameTd);
+        // Quantity cell with controls
+        const qtyTd = document.createElement('td');
+        qtyTd.className = 'qty-cell';
+        const qtyWrap = document.createElement('div');
+        qtyWrap.className = 'quantity-control';
+        const minus = document.createElement('button');
+        minus.type = 'button';
+        minus.className = 'btn btn-xs';
+        minus.textContent = '−';
+        const input = document.createElement('input');
+        input.type = 'number';
+        input.value = p.quantity;
+        input.className = 'input input-bordered w-full text-center';
+        const plus = document.createElement('button');
+        plus.type = 'button';
+        plus.className = 'btn btn-xs';
+        plus.textContent = '+';
+        minus.addEventListener('click', () => {
+          input.value = Math.max(0, (parseFloat(input.value) || 0) - 1);
+        });
+        plus.addEventListener('click', () => {
+          input.value = (parseFloat(input.value) || 0) + 1;
+        });
+        qtyWrap.append(minus, input, plus);
+        qtyTd.appendChild(qtyWrap);
+        tr.appendChild(qtyTd);
+        // Unit select
+        const unitTd = document.createElement('td');
+        unitTd.className = 'unit-cell';
+        const unitSel = document.createElement('select');
+        unitSel.className = 'select select-bordered w-full';
+        Object.keys(state.units).forEach(u => {
+          const opt = document.createElement('option');
+          opt.value = u;
+          opt.textContent = unitName(u);
+          if (u === p.unit) opt.selected = true;
+          unitSel.appendChild(opt);
+        });
+        unitTd.appendChild(unitSel);
+        tr.appendChild(unitTd);
+        // Category select
+        const catTd = document.createElement('td');
+        catTd.className = 'category-cell';
+        const catSel = document.createElement('select');
+        catSel.className = 'select select-bordered w-full';
+        Object.keys(CATEGORY_KEYS).forEach(c => {
+          const opt = document.createElement('option');
+          opt.value = c;
+          opt.textContent = categoryName(c);
+          if (c === (p.category || 'uncategorized')) opt.selected = true;
+          catSel.appendChild(opt);
+        });
+        catTd.appendChild(catSel);
+        tr.appendChild(catTd);
+        // Storage select
+        const storTd = document.createElement('td');
+        storTd.className = 'storage-cell';
+        const storSel = document.createElement('select');
+        storSel.className = 'select select-bordered w-full';
+        Object.keys(STORAGE_KEYS).forEach(s => {
+          const opt = document.createElement('option');
+          opt.value = s;
+          opt.textContent = storageName(s);
+          if (s === (p.storage || 'pantry')) opt.selected = true;
+          storSel.appendChild(opt);
+        });
+        storTd.appendChild(storSel);
+        tr.appendChild(storTd);
+        // Status icon
+        const statusTd = document.createElement('td');
+        statusTd.className = 'status-cell text-center';
+        const status = getStatusIcon(p);
+        if (status) {
+          statusTd.innerHTML = status.html;
+          statusTd.title = status.title;
+        }
+        tr.appendChild(statusTd);
+      } else {
+        const nameTd = document.createElement('td');
+        nameTd.textContent = productName(p.name);
+        tr.appendChild(nameTd);
+        const qtyTd = document.createElement('td');
+        qtyTd.textContent = formatPackQuantity(p);
+        tr.appendChild(qtyTd);
+        const unitTd = document.createElement('td');
+        unitTd.textContent = unitName(p.unit);
+        tr.appendChild(unitTd);
+        const catTd = document.createElement('td');
+        catTd.textContent = categoryName(p.category);
+        tr.appendChild(catTd);
+        const storTd = document.createElement('td');
+        storTd.textContent = storageName(p.storage);
+        tr.appendChild(storTd);
+        const statusTd = document.createElement('td');
+        const status = getStatusIcon(p);
+        if (status) {
+          statusTd.innerHTML = status.html;
+          statusTd.title = status.title;
+        }
+        tr.appendChild(statusTd);
       }
-      tr.appendChild(statusTd);
-    } else {
-      const nameTd = document.createElement('td');
-      nameTd.textContent = productName(p.name);
-      tr.appendChild(nameTd);
-      const qtyTd = document.createElement('td');
-      qtyTd.textContent = formatPackQuantity(p);
-      tr.appendChild(qtyTd);
-      const unitTd = document.createElement('td');
-      unitTd.textContent = unitName(p.unit);
-      tr.appendChild(unitTd);
-      const catTd = document.createElement('td');
-      catTd.textContent = categoryName(p.category);
-      tr.appendChild(catTd);
-      const storTd = document.createElement('td');
-      storTd.textContent = storageName(p.storage);
-      tr.appendChild(storTd);
-      const statusTd = document.createElement('td');
-      const status = getStatusIcon(p);
-      if (status) {
-        statusTd.innerHTML = status.html;
-        statusTd.title = status.title;
-      }
-      tr.appendChild(statusTd);
+      tbody && tbody.appendChild(tr);
+    } catch (err) {
+      console.warn('Skipping product', idx, err.message);
     }
-    tbody && tbody.appendChild(tr);
   });
 
   // grouped view
@@ -134,7 +144,7 @@ export function renderProducts(data, editable = false) {
   if (!container) return;
   container.innerHTML = '';
   const storages = {};
-  data.forEach(p => {
+  safeData.forEach(p => {
     const storage = p.storage || 'pantry';
     const cat = p.category || 'uncategorized';
     storages[storage] = storages[storage] || {};

--- a/app/static/js/components/toast.js
+++ b/app/static/js/components/toast.js
@@ -1,6 +1,9 @@
 import { t, state } from '../helpers.js';
 
-export function showNotification({ type = 'success', title = '', message = '' }) {
+// CHANGELOG:
+// - Added optional retry button to ``showNotification`` for non-blocking error toasts.
+
+export function showNotification({ type = 'success', title = '', message = '', retry = null }) {
   const container = document.getElementById('notification-container');
   if (!container) return;
   const alert = document.createElement('div');
@@ -26,6 +29,16 @@ export function showNotification({ type = 'success', title = '', message = '' })
   body.appendChild(icon);
   body.appendChild(text);
   alert.appendChild(body);
+  if (retry) {
+    const btn = document.createElement('button');
+    btn.className = 'btn btn-sm ml-4';
+    btn.textContent = t('retry');
+    btn.addEventListener('click', () => {
+      alert.remove();
+      retry();
+    });
+    alert.appendChild(btn);
+  }
   const close = document.createElement('button');
   close.className = 'btn btn-xs btn-circle btn-ghost absolute top-1 right-1';
   close.innerHTML = '<i class="fa-regular fa-xmark"></i>';

--- a/app/static/js/helpers.js
+++ b/app/static/js/helpers.js
@@ -1,3 +1,7 @@
+// CHANGELOG:
+// - Added normalization helpers and spice detector.
+// - Guaranteed translation fallback returns key when missing.
+
 export const CATEGORY_KEYS = {
   uncategorized: 'category_uncategorized',
   fresh_veg: 'category_fresh_veg',
@@ -188,4 +192,38 @@ export function toggleFavorite(name) {
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(arr)
   }).catch(() => {});
+}
+
+// Normalize product object ensuring required fields and defaults.
+export function normalizeProduct(p = {}) {
+  return {
+    name: p.name || '',
+    unit: p.unit || 'szt',
+    quantity: Number(p.quantity) || 0,
+    package_size: Number(p.package_size) || 1,
+    pack_size: p.pack_size != null ? Number(p.pack_size) : null,
+    threshold: p.threshold != null ? Number(p.threshold) : 1,
+    main: p.main !== false,
+    category: p.category || 'uncategorized',
+    storage: p.storage || 'pantry'
+  };
+}
+
+// Normalize recipe object and ensure ingredients are objects.
+export function normalizeRecipe(r = {}) {
+  const ingredients = Array.isArray(r.ingredients)
+    ? r.ingredients.map(ing => {
+        if (typeof ing === 'string') return { product: ing };
+        return {
+          product: ing.product || '',
+          quantity: ing.quantity != null ? Number(ing.quantity) : undefined,
+          unit: ing.unit || undefined
+        };
+      })
+    : [];
+  return { ...r, ingredients };
+}
+
+export function isSpice(p = {}) {
+  return p.category === 'spices' || p.is_spice === true;
 }

--- a/app/static/script.js
+++ b/app/static/script.js
@@ -1,20 +1,49 @@
-import { loadTranslations, loadUnits, loadFavorites, state, t } from './js/helpers.js';
+import { loadTranslations, loadUnits, loadFavorites, state, t, normalizeProduct } from './js/helpers.js';
 import { renderProducts } from './js/components/product-table.js';
 import { renderRecipes, loadRecipes } from './js/components/recipe-list.js';
 import { renderShoppingList, addToShoppingList, renderSuggestions } from './js/components/shopping-list.js';
 import { showNotification, checkLowStockToast } from './js/components/toast.js';
 import { initReceiptImport } from './js/components/ocr-modal.js';
 
+// CHANGELOG:
+// - Refactored app boot sequence for deterministic init and fail-soft data loading.
+// - Added retry-capable fetch helpers and mounted navigation before data fetching.
+
 let currentProducts = [];
 let editMode = false;
 
-async function loadProducts() {
-  const res = await fetch('/api/products');
-  currentProducts = await res.json();
-  window.currentProducts = currentProducts;
-  renderProducts(currentProducts, editMode);
-  renderSuggestions();
-  checkLowStockToast(currentProducts, activateTab, renderSuggestions, renderShoppingList);
+async function fetchProducts() {
+  try {
+    const res = await fetch('/api/products');
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    const data = await res.json();
+    currentProducts = data.map(normalizeProduct);
+    window.currentProducts = currentProducts;
+    renderProducts(currentProducts, editMode);
+    renderSuggestions();
+    checkLowStockToast(currentProducts, activateTab, renderSuggestions, renderShoppingList);
+  } catch (err) {
+    showNotification({ type: 'error', title: t('products_load_failed'), message: err.message, retry: fetchProducts });
+  }
+}
+
+async function fetchRecipes() {
+  try {
+    await loadRecipes();
+  } catch (err) {
+    showNotification({ type: 'error', title: t('recipes_load_failed'), message: err.message, retry: fetchRecipes });
+  }
+}
+
+async function fetchHistory() {
+  try {
+    const res = await fetch('/api/history');
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    state.historyData = await res.json();
+  } catch (err) {
+    state.historyData = [];
+    showNotification({ type: 'error', title: t('history_load_failed'), message: err.message, retry: fetchHistory });
+  }
 }
 
 function activateTab(targetId) {
@@ -26,17 +55,29 @@ function activateTab(targetId) {
   if (panel) panel.style.display = 'block';
 }
 
+function mountNavigation() {
+  document.querySelectorAll('[data-tab-target]').forEach(tab => {
+    tab.addEventListener('click', () => {
+      const target = tab.dataset.tabTarget;
+      activateTab(target);
+      localStorage.setItem('activeTab', target);
+    });
+  });
+  const initial = localStorage.getItem('activeTab') || 'tab-products';
+  activateTab(initial);
+}
+
 window.activateTab = activateTab;
 window.addToShoppingList = addToShoppingList;
 
 document.addEventListener('DOMContentLoaded', async () => {
   await loadTranslations();
   await loadUnits();
+  mountNavigation();
   await loadFavorites();
   renderShoppingList();
   initReceiptImport();
-  loadProducts();
-  loadRecipes();
+  await Promise.all([fetchProducts(), fetchRecipes(), fetchHistory()]);
   const editBtn = document.getElementById('edit-toggle');
   const saveBtn = document.getElementById('save-btn');
   const deleteBtn = document.getElementById('delete-selected');


### PR DESCRIPTION
## Summary
- move JSON schemas to dedicated folder and validate data on startup with fail-soft endpoints
- refactor client init to load translations/units before mounting navigation and add retryable fetch toasts
- add normalization helpers and defensive rendering guards for products and recipes

## Testing
- `python -m py_compile app/app.py app/utils.py`
- `node --check app/static/script.js app/static/js/helpers.js app/static/js/components/product-table.js app/static/js/components/recipe-list.js app/static/js/components/toast.js`
- `python - <<'PY'
from app import app
client=app.test_client()
print(client.get('/api/validate').json)
PY`

------
https://chatgpt.com/codex/tasks/task_e_68966d694ba4832a8c8930d02db1dffc