### PR TITLE
feat: render and filter recipes from API

### DIFF
--- a/app/static/js/components/recipe-list.js
+++ b/app/static/js/components/recipe-list.js
@@ -1,9 +1,17 @@
-import { t, state, parseTimeToMinutes, timeToBucket, toggleFavorite } from '../helpers.js';
-import { openRecipeDetails } from './recipe-detail.js';
+import {
+  t,
+  state,
+  parseTimeToMinutes,
+  timeToBucket,
+  toggleFavorite,
+  normalizeRecipe
+} from '../helpers.js';
+import { showNotification } from './toast.js';
 
 // CHANGELOG:
 // - Exposed ``loadRecipes`` without internal catch to allow caller-side retry/toast handling.
 // - Added defensive rendering and normalization of ingredient structures.
+// - Inline recipe details with expandable cards and single-shot event bindings.
 
 export function renderRecipes() {
   const list = document.getElementById('recipe-list');
@@ -11,17 +19,25 @@ export function renderRecipes() {
   list.innerHTML = '';
   let data = state.recipesData.slice();
   if (state.recipeTimeFilter) data = data.filter(r => r.timeBucket === state.recipeTimeFilter);
-  if (state.recipePortionsFilter) data = data.filter(r => String(r.portions) === state.recipePortionsFilter);
+  if (state.recipePortionsFilter) {
+    if (state.recipePortionsFilter === '5+') {
+      data = data.filter(r => (r.portions || 0) >= 5);
+    } else {
+      data = data.filter(r => String(r.portions) === state.recipePortionsFilter);
+    }
+  }
   if (state.showFavoritesOnly) data = data.filter(r => state.favoriteRecipes.has(r.name));
   data.sort((a, b) => {
     if (state.recipeSortField === 'time') {
-      const ta = parseTimeToMinutes(a.time) || 0;
-      const tb = parseTimeToMinutes(b.time) || 0;
-      return state.recipeSortDir === 'asc' ? ta - tb : tb - ta;
+      const ta = parseTimeToMinutes(a.time);
+      const tb = parseTimeToMinutes(b.time);
+      const taVal = ta == null ? Infinity : ta;
+      const tbVal = tb == null ? Infinity : tb;
+      return state.recipeSortDir === 'asc' ? taVal - tbVal : tbVal - taVal;
     }
     if (state.recipeSortField === 'portions') {
-      const pa = a.portions || 0;
-      const pb = b.portions || 0;
+      const pa = a.portions == null ? Infinity : a.portions;
+      const pb = b.portions == null ? Infinity : b.portions;
       return state.recipeSortDir === 'asc' ? pa - pb : pb - pa;
     }
     return a.name.localeCompare(b.name);
@@ -60,7 +76,7 @@ export function renderRecipes() {
     header.appendChild(favBtn);
     body.appendChild(header);
     const meta = document.createElement('div');
-    meta.className = 'flex items-center gap-4 text-sm';
+    meta.className = 'flex justify-between items-center text-sm';
     if (r.time) {
       const timeDiv = document.createElement('div');
       timeDiv.className = 'flex items-center gap-1';
@@ -83,44 +99,150 @@ export function renderRecipes() {
     const btn = document.createElement('button');
     btn.className = 'btn btn-sm btn-primary self-start';
     btn.textContent = t('history_show_details');
-    btn.addEventListener('click', () => openRecipeDetails(r));
+    const details = document.createElement('div');
+    details.className = 'hidden mt-4 space-y-4';
+    const ingHeader = document.createElement('h4');
+    ingHeader.className = 'font-semibold';
+    ingHeader.textContent = t('recipe_ingredients_header');
+    details.appendChild(ingHeader);
+    const ingGrid = document.createElement('div');
+    ingGrid.className = 'space-y-1 text-sm';
+    (r.ingredients || []).forEach(ing => {
+      const row = document.createElement('div');
+      row.className = 'grid grid-cols-2 gap-2';
+      const nameSpan = document.createElement('span');
+      nameSpan.textContent = t(ing.product);
+      const qtySpan = document.createElement('span');
+      let qt = '';
+      if (ing.quantity != null) {
+        qt += String(ing.quantity);
+        if (ing.unit) qt += ' ' + t(ing.unit);
+      }
+      qtySpan.textContent = qt;
+      row.appendChild(nameSpan);
+      row.appendChild(qtySpan);
+      ingGrid.appendChild(row);
+    });
+    details.appendChild(ingGrid);
+    const stepsHeader = document.createElement('h4');
+    stepsHeader.className = 'font-semibold';
+    stepsHeader.textContent = t('recipe_steps_header');
+    details.appendChild(stepsHeader);
+    const stepsList = document.createElement('ol');
+    stepsList.className = 'list-decimal pl-4 space-y-1 text-sm';
+    (r.steps || []).forEach(step => {
+      const li = document.createElement('li');
+      li.textContent = step;
+      stepsList.appendChild(li);
+    });
+    details.appendChild(stepsList);
+    btn.addEventListener('click', () => details.classList.toggle('hidden'));
     body.appendChild(btn);
+    body.appendChild(details);
     card.appendChild(body);
     list.appendChild(card);
   });
 }
 
 export async function loadRecipes() {
-  const res = await fetch('/api/recipes');
-  if (!res.ok) throw new Error(`HTTP ${res.status}`);
-  const data = await res.json();
-  const processed = [];
-  data.forEach(r => {
-    try {
-      if (!r || !r.name || !Array.isArray(r.ingredients)) throw new Error('invalid structure');
-      const ingredients = r.ingredients.map(ing => {
-        if (typeof ing === 'string') {
-          return { productKey: ing, quantity: null, unit: null };
-        }
-        if (ing && typeof ing === 'object' && typeof ing.product === 'string') {
-          return {
-            productKey: ing.product,
-            quantity: ing.quantity != null ? ing.quantity : null,
-            unit: ing.unit || null
-          };
-        }
-        throw new Error('invalid ingredient');
-      });
-      processed.push({
-        ...r,
-        ingredients,
-        timeBucket: timeToBucket(r.time)
-      });
-    } catch (err) {
-      console.warn(`Skipping recipe ${r && r.name ? r.name : '(unknown)'}`, err.message);
+  if (state.recipesLoaded || state.recipesLoading) return state.recipesData;
+  const panel = document.getElementById('tab-recipes');
+  if (panel && panel.style.display === 'none') {
+    if (!state.recipesLoadQueued) {
+      const tab = document.querySelector('[data-tab-target="tab-recipes"]');
+      tab?.addEventListener('click', () => loadRecipes(), { once: true });
+      state.recipesLoadQueued = true;
     }
-  });
-  state.recipesData = processed;
-  renderRecipes();
-  return processed;
+    return state.recipesData;
+  }
+  state.recipesLoading = true;
+  try {
+    const res = await fetch('/api/recipes');
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    const data = await res.json();
+    const processed = data
+      .map(r => normalizeRecipe(r))
+      .map(r => ({ ...r, timeBucket: timeToBucket(r.time) }));
+    state.recipesData = processed;
+    state.recipesLoaded = true;
+    renderRecipes();
+    return processed;
+  } catch (err) {
+    showNotification({ type: 'error', title: t('recipes_load_failed'), message: err.message, retry: loadRecipes });
+    return [];
+  } finally {
+    state.recipesLoading = false;
+  }
 }
+
+document.addEventListener('DOMContentLoaded', () => {
+  const sortField = document.getElementById('recipe-sort-field');
+  const sortAsc = document.getElementById('recipe-sort-dir-asc');
+  const sortDesc = document.getElementById('recipe-sort-dir-desc');
+  const sortMobile = document.getElementById('recipe-sort-mobile');
+  const timeFilter = document.getElementById('recipe-time-filter');
+  const portionsFilter = document.getElementById('recipe-portions-filter');
+  const favToggle = document.getElementById('recipe-favorites-toggle');
+  const clearBtn = document.getElementById('recipe-clear-filters');
+
+  function updateSortButtons() {
+    sortAsc?.classList.toggle('btn-primary', state.recipeSortDir === 'asc');
+    sortAsc?.classList.toggle('btn-outline', state.recipeSortDir !== 'asc');
+    sortDesc?.classList.toggle('btn-primary', state.recipeSortDir === 'desc');
+    sortDesc?.classList.toggle('btn-outline', state.recipeSortDir !== 'desc');
+  }
+
+  sortField?.addEventListener('change', () => {
+    state.recipeSortField = sortField.value;
+    renderRecipes();
+  });
+  sortAsc?.addEventListener('click', () => {
+    state.recipeSortDir = 'asc';
+    updateSortButtons();
+    renderRecipes();
+  });
+  sortDesc?.addEventListener('click', () => {
+    state.recipeSortDir = 'desc';
+    updateSortButtons();
+    renderRecipes();
+  });
+  sortMobile?.addEventListener('change', () => {
+    const [field, dir] = sortMobile.value.split('-');
+    state.recipeSortField = field;
+    state.recipeSortDir = dir;
+    updateSortButtons();
+    renderRecipes();
+  });
+
+  timeFilter?.addEventListener('change', () => {
+    state.recipeTimeFilter = timeFilter.value;
+    renderRecipes();
+  });
+  portionsFilter?.addEventListener('change', () => {
+    state.recipePortionsFilter = portionsFilter.value;
+    renderRecipes();
+  });
+  favToggle?.addEventListener('click', () => {
+    state.showFavoritesOnly = !state.showFavoritesOnly;
+    favToggle.classList.toggle('btn-primary', state.showFavoritesOnly);
+    favToggle.classList.toggle('btn-outline', !state.showFavoritesOnly);
+    renderRecipes();
+  });
+  clearBtn?.addEventListener('click', () => {
+    state.recipeSortField = 'name';
+    state.recipeSortDir = 'asc';
+    state.recipeTimeFilter = '';
+    state.recipePortionsFilter = '';
+    state.showFavoritesOnly = false;
+    sortField && (sortField.value = 'name');
+    sortMobile && (sortMobile.value = 'name-asc');
+    timeFilter && (timeFilter.value = '');
+    portionsFilter && (portionsFilter.value = '');
+    favToggle?.classList.remove('btn-primary');
+    favToggle?.classList.add('btn-outline');
+    updateSortButtons();
+    renderRecipes();
+  });
+
+  updateSortButtons();
+});

--- a/app/static/js/helpers.js
+++ b/app/static/js/helpers.js
@@ -43,6 +43,9 @@ export const state = {
   dismissedSuggestions: new Set(),
   pendingRemoveIndex: null,
   recipesData: [],
+  recipesLoaded: false,
+  recipesLoadQueued: false,
+  recipesLoading: false,
   recipeSortField: 'name',
   recipeSortDir: 'asc',
   recipeTimeFilter: '',
@@ -90,14 +93,16 @@ export function storageName(key) {
   return translated === tKey ? key : translated;
 }
 
-export function parseTimeToMinutes(str) {
-  if (!str) return null;
+export function parseTimeToMinutes(value) {
+  if (value == null) return null;
+  if (typeof value === 'number') return value;
+  const str = String(value);
   let minutes = 0;
   const h = str.match(/(\d+)\s*h/);
   if (h) minutes += parseInt(h[1], 10) * 60;
   const m = str.match(/(\d+)\s*min/);
   if (m) minutes += parseInt(m[1], 10);
-  return minutes;
+  return minutes || null;
 }
 
 export function timeToBucket(str) {

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -193,10 +193,7 @@
                         <option value="2">2</option>
                         <option value="3">3</option>
                         <option value="4">4</option>
-                        <option value="5">5</option>
-                        <option value="6">6</option>
-                        <option value="7">7</option>
-                        <option value="8">8</option>
+                        <option value="5+">5+</option>
                     </select>
                 </div>
                 <button id="recipe-favorites-toggle" class="btn btn-outline btn-sm self-start" data-i18n="recipe_filter_favorites">Ulubione przepisy</button>


### PR DESCRIPTION
## Summary
- fetch and normalize recipes from the API when opening the tab
- render inline recipe details with ingredient and step lists
- add sorting, filtering and favorites controls without duplicate listeners

## Testing
- `pytest`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6896787ec994832abae3aa2fd7e1ccc5