### PR TITLE
Fix product tab add flow and interactions

### DIFF
--- a/app/static/js/components/product-table.js
+++ b/app/static/js/components/product-table.js
@@ -143,7 +143,7 @@ function attachCollapses(root) {
       icon.classList.toggle('fa-caret-right');
     }
     btn.addEventListener('click', e => { e.stopPropagation(); toggle(); });
-    if (state.displayMode === 'mobile' && header) {
+    if (header) {
       header.addEventListener('click', toggle);
     }
   });

--- a/app/static/js/helpers.js
+++ b/app/static/js/helpers.js
@@ -239,7 +239,7 @@ export function stockLevel(p = {}) {
   if (isSpice(p)) {
     return p.level || 'none';
   }
-  if (p.quantity === 0 && p.main) return 'none';
+  if (p.quantity === 0) return 'none';
   if (p.main && p.threshold != null && p.quantity <= p.threshold) return 'low';
   return 'ok';
 }

--- a/app/static/styles.css
+++ b/app/static/styles.css
@@ -48,6 +48,39 @@ html[data-layout="mobile"] #product-table:not(.edit-mode) td:nth-child(n+4) {
   display: none;
 }
 
+/* Add-product form layout */
+#add-form {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+#add-form .add-name {
+  flex: 2 1 12rem;
+}
+#add-form .add-qty,
+#add-form .add-unit,
+#add-form .add-category,
+#add-form .add-storage,
+#add-form .add-main,
+#add-form .add-submit {
+  flex: 1 1 8rem;
+}
+#add-form .add-main {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+#add-form [name="package_size"],
+#add-form [name="pack_size"],
+#add-form [name="threshold"] {
+  display: none;
+}
+@media (max-width: 639px) {
+  #add-form .add-name {
+    flex-basis: 100%;
+  }
+}
+
 html[data-layout="mobile"] {
   font-size: 150%;
 }


### PR DESCRIPTION
## Summary
- Add product form posts to API, updates state and re-renders
- Style add-product form for desktop/mobile and remove number spinners
- Improve stock level detection and re-enable highlighting/filters
- Make headers toggle grouped tables reliably

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689681fdff34832a9860a520460d680b