### PR TITLE
Fix product category collapse functionality

### DIFF
--- a/app/static/js/components/product-table.js
+++ b/app/static/js/components/product-table.js
@@ -137,11 +137,24 @@ function attachCollapses(root) {
     const target = root.querySelector(`#${targetId}`);
     const icon = btn.querySelector('i');
     const header = btn.parentElement;
-    function toggle() {
-      target?.classList.toggle('hidden');
-      icon.classList.toggle('fa-caret-down');
-      icon.classList.toggle('fa-caret-right');
+    const parts = targetId.split('-').slice(1); // drop leading "storage"
+    const isStorage = parts.length === 1;
+    const key = isStorage ? parts[0] : parts.join('-');
+    const store = isStorage ? state.expandedStorages : state.expandedCategories;
+
+    if (store[key] === false) {
+      target?.classList.add('hidden');
+      icon.classList.remove('fa-caret-down');
+      icon.classList.add('fa-caret-right');
     }
+
+    function toggle() {
+      const isHidden = target?.classList.toggle('hidden');
+      icon.classList.toggle('fa-caret-down', !isHidden);
+      icon.classList.toggle('fa-caret-right', isHidden);
+      store[key] = !isHidden;
+    }
+
     btn.addEventListener('click', e => { e.stopPropagation(); toggle(); });
     if (header) {
       header.addEventListener('click', toggle);
@@ -203,7 +216,7 @@ export function renderProducts() {
         const block = document.createElement('div');
         block.className = 'storage-block border border-base-300 rounded-lg p-4 mb-4';
         const header = document.createElement('h3');
-        header.className = 'text-2xl font-bold flex items-center gap-2';
+        header.className = 'text-2xl font-bold flex items-center gap-2 cursor-pointer';
         const btn = document.createElement('button');
         btn.type = 'button';
         btn.innerHTML = '<i class="fa-solid fa-caret-down"></i>';
@@ -223,7 +236,7 @@ export function renderProducts() {
             const catBlock = document.createElement('div');
             catBlock.className = 'category-block';
             const catHeader = document.createElement('h4');
-            catHeader.className = 'text-xl font-semibold mt-4 mb-2 flex items-center gap-2';
+            catHeader.className = 'text-xl font-semibold mt-4 mb-2 flex items-center gap-2 cursor-pointer';
             const catBtn = document.createElement('button');
             catBtn.type = 'button';
             catBtn.innerHTML = '<i class="fa-solid fa-caret-down"></i>';

--- a/app/static/translations/en.json
+++ b/app/static/translations/en.json
@@ -8,7 +8,7 @@
   "search_placeholder": "Search product",
   "state_filter_available": "Available",
   "state_filter_missing": "Missing",
-  "state_filter_low": "Low stock",
+  "state_filter_low": "Ending",
   "state_filter_all": "All",
   "change_view_toggle_grouped": "Categories view",
   "change_view_toggle_flat": "Flat list",


### PR DESCRIPTION
## Summary
- Make grouped product categories collapsible with independent state tracking
- Display proper arrow icons and pointer cursor for collapsible headers
- Rename low-stock filter label to "Ending"

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68968aa4dfac832aa1d5b2de410ec021