### PR TITLE
Reset product list filter on tab navigation

### DIFF
--- a/app/static/js/components/toast.js
+++ b/app/static/js/components/toast.js
@@ -65,6 +65,7 @@ export function showLowStockToast(activateTab, renderSuggestions, renderShopping
   btn.addEventListener('click', () => {
     activateTab('tab-shopping');
     localStorage.setItem('activeTab', 'tab-shopping');
+    history.pushState({ tab: 'tab-shopping' }, '');
     renderSuggestions();
     renderShoppingList();
     alert.remove();

--- a/app/static/script.js
+++ b/app/static/script.js
@@ -18,6 +18,7 @@ APP.state = APP.state || {
   filter: 'available',
   editing: false
 };
+APP.activeTab = APP.activeTab || null;
 
 async function fetchProducts() {
   try {
@@ -54,6 +55,12 @@ async function fetchHistory() {
   }
 }
 
+function resetProductFilter() {
+  APP.state.filter = 'available';
+  const sel = document.getElementById('state-filter');
+  if (sel) sel.value = 'available';
+}
+
 function activateTab(targetId) {
   document.querySelectorAll('[data-tab-target]').forEach(t => t.classList.remove('tab-active', 'font-bold'));
   const tab = document.querySelector(`[data-tab-target="${targetId}"]`);
@@ -61,18 +68,31 @@ function activateTab(targetId) {
   document.querySelectorAll('.tab-panel').forEach(panel => (panel.style.display = 'none'));
   const panel = document.getElementById(targetId);
   if (panel) panel.style.display = 'block';
+  if (targetId === 'tab-products' && APP.activeTab !== 'tab-products') {
+    resetProductFilter();
+    renderProducts();
+  }
+  APP.activeTab = targetId;
 }
 
 function mountNavigation() {
   document.querySelectorAll('[data-tab-target]').forEach(tab => {
     tab.addEventListener('click', () => {
       const target = tab.dataset.tabTarget;
+      if (target === APP.activeTab) return;
       activateTab(target);
       localStorage.setItem('activeTab', target);
+      history.pushState({ tab: target }, '');
     });
   });
   const initial = localStorage.getItem('activeTab') || 'tab-products';
+  history.replaceState({ tab: initial }, '');
   activateTab(initial);
+  window.addEventListener('popstate', e => {
+    const target = e.state?.tab || 'tab-products';
+    activateTab(target);
+    localStorage.setItem('activeTab', target);
+  });
 }
 
 window.activateTab = activateTab;


### PR DESCRIPTION
## Summary
- Reset product filter to Available whenever the products tab is activated from another tab or via browser navigation.
- Track active tab, push history state, and handle popstate events so back/forward navigation also resets the filter.
- Add history state when navigating to the shopping tab from the low stock toast.

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68969328778c832abdd91b0d83ddd1ab