### PR TITLE
Reset product filter on browser history restore

### DIFF
--- a/app/static/script.js
+++ b/app/static/script.js
@@ -95,6 +95,16 @@ function mountNavigation() {
   });
 }
 
+window.addEventListener('pageshow', e => {
+  if (e.persisted) {
+    const target = localStorage.getItem('activeTab') || 'tab-products';
+    if (target === 'tab-products') {
+      resetProductFilter();
+      renderProducts();
+    }
+  }
+});
+
 window.activateTab = activateTab;
 window.addToShoppingList = addToShoppingList;
 


### PR DESCRIPTION
## Summary
- Reset product filter to `Dostępne` when returning to products via browser history

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6896a06cc17c832aae530203771be9fd