### PR TITLE
feat: toggle recipe details inline

### DIFF
--- a/app/static/js/components/recipe-detail.js
+++ b/app/static/js/components/recipe-detail.js
@@ -1,50 +1,35 @@
-import { t, productName, unitName } from '../helpers.js';
+function t(key){ return window.t?.(key) ?? key; }
 
-export function openRecipeDetails(recipe) {
-  const modal = document.getElementById('recipe-detail-modal');
-  if (!modal) return;
-  const title = document.getElementById('recipe-detail-title');
-  if (title) title.textContent = t(recipe.name);
-  const timeWrap = document.getElementById('recipe-detail-time');
-  const timeSpan = timeWrap ? timeWrap.querySelector('span') : null;
-  if (timeWrap && timeSpan) {
-    timeSpan.textContent = recipe.time || '';
-    timeWrap.style.display = recipe.time ? 'inline-flex' : 'none';
-    timeWrap.setAttribute('aria-label', t('label_time'));
-  }
-  const portionsWrap = document.getElementById('recipe-detail-portions');
-  const portionsSpan = portionsWrap ? portionsWrap.querySelector('span') : null;
-  if (portionsWrap && portionsSpan) {
-    portionsSpan.textContent = recipe.portions ? String(recipe.portions) : '';
-    portionsWrap.style.display = recipe.portions ? 'inline-flex' : 'none';
-    portionsWrap.setAttribute('aria-label', t('label_portions'));
-  }
-  const ingList = document.getElementById('recipe-ingredients');
-  if (ingList) {
-    ingList.innerHTML = '';
-    (recipe.ingredients || []).forEach(ing => {
-      const li = document.createElement('li');
-      const name = document.createElement('span');
-      const qty = document.createElement('span');
-      name.textContent = productName(ing.productKey);
-      let text = '';
-      if (ing.quantity != null) text += ing.quantity;
-      if (ing.unit) text += ` ${unitName(ing.unit)}`;
-      qty.textContent = text.trim();
-      li.append(name, qty);
-      ingList.appendChild(li);
-    });
-  }
-  const stepsOl = document.getElementById('recipe-steps');
-  if (stepsOl) {
-    stepsOl.innerHTML = '';
-    (recipe.steps || []).forEach(step => {
-      const li = document.createElement('li');
-      li.textContent = step;
-      stepsOl.appendChild(li);
-    });
-  }
-  const addBtn = document.getElementById('recipe-add-to-shopping');
-  if (addBtn) addBtn.onclick = () => {};
-  modal.showModal();
+export function renderRecipeDetail(r){
+  const meta = `
+    <div class="meta flex items-center gap-6 mb-4">
+      <div class="flex items-center gap-2"><i class="fa-regular fa-clock"></i><span>${r.time ?? '—'}</span></div>
+      <div class="flex items-center gap-2"><i class="fa-regular fa-users"></i><span>${r.portions ?? '—'}</span></div>
+    </div>
+  `;
+
+  const ing = (r.ingredients||[]).map(i=>{
+    const name = t(i.product);
+    const qty  = (i.quantity ?? '').toString();
+    const unit = t(i.unit ?? '');
+    return `<div class="ing-row grid grid-cols-[1fr_auto] gap-3"><span>${name}</span><span class="opacity-80">${qty} ${unit}</span></div>`;
+  }).join('');
+
+  const steps = (r.steps||[]).map((s,idx)=>`
+    <li class="leading-relaxed"><span class="step-index">${idx+1}.</span> ${s}</li>
+  `).join('');
+
+  return `
+    ${meta}
+    <div class="grid md:grid-cols-2 gap-8">
+      <section>
+        <h4 class="font-semibold mb-2">${t('recipe_ingredients_header')}</h4>
+        <div class="ing-list flex flex-col gap-2">${ing}</div>
+      </section>
+      <section>
+        <h4 class="font-semibold mb-2">${t('recipe_steps_header')}</h4>
+        <ol class="list-decimal ml-5 flex flex-col gap-2">${steps}</ol>
+      </section>
+    </div>
+  `;
 }

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -200,29 +200,6 @@
                 <button id="recipe-clear-filters" class="btn btn-outline btn-sm self-start" data-i18n="recipe_clear_filters">Wyczyść filtry</button>
             </div>
             <div id="recipe-list" class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4 mb-8"></div>
-            <dialog id="recipe-detail-modal" class="modal">
-                <div class="modal-box max-w-lg">
-                    <h3 id="recipe-detail-title" class="font-bold text-lg mb-2"></h3>
-                    <div class="flex items-center gap-4 text-sm mb-4">
-                        <div id="recipe-detail-time" class="inline-flex items-center gap-1" aria-label="Time">
-                            <i class="fa-regular fa-clock" aria-hidden="true"></i>
-                            <span></span>
-                        </div>
-                        <div id="recipe-detail-portions" class="inline-flex items-center gap-1" aria-label="Portions">
-                            <i class="fa-solid fa-users" aria-hidden="true"></i>
-                            <span></span>
-                        </div>
-                    </div>
-                    <h4 class="font-semibold mb-2" data-i18n="recipe_ingredients_header">Składniki</h4>
-                    <ul id="recipe-ingredients" class="recipe-ingredients mb-4"></ul>
-                    <h4 class="font-semibold mb-2" data-i18n="recipe_steps_header">Kroki</h4>
-                    <ol id="recipe-steps" class="recipe-steps list-decimal pl-5 space-y-2"></ol>
-                    <div class="modal-action">
-                        <button id="recipe-add-to-shopping" class="btn btn-primary btn-sm" data-i18n="recipe_add_to_shopping">Dodaj składniki do listy zakupów</button>
-                        <button id="recipe-detail-close" class="btn btn-sm">OK</button>
-                    </div>
-                </div>
-            </dialog>
         </div>
 
         <div id="tab-history" class="tab-panel" style="display:none;">


### PR DESCRIPTION
## Summary
- show recipe details inline with a "Pokaż szczegóły" button
- render ingredients and steps on first open
- drop unused modal markup from recipes tab

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689750983014832ab1df54261f757605