### PR TITLE
Refresh product list after saving

### DIFF
--- a/app/static/js/components/product-table.js
+++ b/app/static/js/components/product-table.js
@@ -1,4 +1,5 @@
-import { t, state, productName, unitName, categoryName, storageName, formatPackQuantity, getStatusIcon, STORAGE_ICONS, CATEGORY_KEYS, STORAGE_KEYS, matchesFilter, stockLevel } from '../helpers.js';
+import { t, state, productName, unitName, categoryName, storageName, formatPackQuantity, getStatusIcon, STORAGE_ICONS, CATEGORY_KEYS, STORAGE_KEYS, matchesFilter, stockLevel, normalizeProduct } from '../helpers.js';
+import { showToast } from './toast.js';
 
 const APP = (window.APP = window.APP || {});
 
@@ -306,4 +307,23 @@ export function renderProducts() {
       });
     attachCollapses(list);
   }
+}
+
+export async function refreshProducts() {
+  const res = await fetch('/api/products');
+  if (!res.ok) throw new Error(`HTTP ${res.status}`);
+  const data = await res.json();
+  APP.state.products = data.map(normalizeProduct);
+  renderProducts();
+}
+
+export async function saveProduct(payload) {
+  const res = await fetch('/api/products', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload)
+  });
+  if (!res.ok) throw new Error('Save failed');
+  await refreshProducts();
+  showToast('Zapisano produkt');
 }

--- a/app/static/js/components/toast.js
+++ b/app/static/js/components/toast.js
@@ -48,6 +48,10 @@ export function showNotification({ type = 'success', title = '', message = '', r
   setTimeout(() => alert.remove(), 5000);
 }
 
+export function showToast(message, type = 'success') {
+  showNotification({ type, message });
+}
+
 export function showLowStockToast(activateTab, renderSuggestions, renderShoppingList) {
   const container = document.getElementById('notification-container');
   if (!container) return;


### PR DESCRIPTION
## Summary
- Add helper toast API `showToast`
- Provide `refreshProducts` to reload products and re-render current view
- Save products via `saveProduct` which refreshes the list and shows a toast

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689750b5270c832aa460336c80e5d817