### PR TITLE
feat: refresh product list after save

### DIFF
--- a/app/static/js/components/product-table.js
+++ b/app/static/js/components/product-table.js
@@ -1,4 +1,5 @@
-import { t, state, productName, unitName, categoryName, storageName, formatPackQuantity, getStatusIcon, STORAGE_ICONS, CATEGORY_KEYS, STORAGE_KEYS, matchesFilter, stockLevel } from '../helpers.js';
+import { t, state, productName, unitName, categoryName, storageName, formatPackQuantity, getStatusIcon, STORAGE_ICONS, CATEGORY_KEYS, STORAGE_KEYS, matchesFilter, stockLevel, normalizeProduct } from '../helpers.js';
+import { showToast } from './toast.js';
 
 const APP = (window.APP = window.APP || {});
 
@@ -66,6 +67,25 @@ function adjustRow(input, product, delta) {
   const newVal = Math.max(0, (parseFloat(input.value) || 0) + delta);
   input.value = newVal;
   product.quantity = newVal;
+}
+
+export async function refreshProducts() {
+  const res = await fetch('/api/products');
+  if (!res.ok) throw new Error('Fetch failed');
+  const data = await res.json();
+  APP.state.products = data.map(normalizeProduct);
+  renderProducts();
+}
+
+export async function saveProduct(payload) {
+  const res = await fetch('/api/products', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload)
+  });
+  if (!res.ok) throw new Error('Save failed');
+  await refreshProducts();
+  showToast(t('save_success'));
 }
 
 function createFlatRow(p, idx, editable) {

--- a/app/static/js/components/toast.js
+++ b/app/static/js/components/toast.js
@@ -48,6 +48,10 @@ export function showNotification({ type = 'success', title = '', message = '', r
   setTimeout(() => alert.remove(), 5000);
 }
 
+export function showToast(message, type = 'success') {
+  showNotification({ type, title: message });
+}
+
 export function showLowStockToast(activateTab, renderSuggestions, renderShoppingList) {
   const container = document.getElementById('notification-container');
   if (!container) return;


### PR DESCRIPTION
## Summary
- add saveProduct and refreshProducts helpers to product table
- add showToast helper built atop showNotification

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689752fc4390832ab5f3309c6bd2ea4b