### PR TITLE
Improve recipe detail layout

### DIFF
--- a/app/static/js/components/recipe-detail.js
+++ b/app/static/js/components/recipe-detail.js
@@ -1,34 +1,56 @@
+import { state } from '../helpers.js';
+
 function t(key){ return window.t?.(key) ?? key; }
 
 export function renderRecipeDetail(r){
+  const favIcon = state.favoriteRecipes.has(r.name)
+    ? '<i class="fa-solid fa-heart"></i>'
+    : '<i class="fa-regular fa-heart"></i>';
+
+  const header = `
+    <div class="flex items-start justify-between mb-4">
+      <h3 class="text-xl font-bold">${t(r.name)}</h3>
+      <span class="text-lg">${favIcon}</span>
+    </div>
+  `;
+
   const meta = `
-    <div class="meta flex items-center gap-6 mb-4">
+    <div class="flex items-center gap-6 mb-4 text-sm">
       <div class="flex items-center gap-2"><i class="fa-regular fa-clock"></i><span>${r.time ?? '—'}</span></div>
-      <div class="flex items-center gap-2"><i class="fa-regular fa-users"></i><span>${r.portions ?? '—'}</span></div>
+      <div class="flex items-center gap-2"><i class="fa-solid fa-users"></i><span>${r.portions ?? '—'}</span></div>
     </div>
   `;
 
   const ing = (r.ingredients||[]).map(i=>{
-    const name = t(i.product);
+    const nameTr = window.t?.(i.product);
+    const name = nameTr && nameTr.trim() !== '' ? nameTr : i.product;
     const qty  = (i.quantity ?? '').toString();
     const unit = t(i.unit ?? '');
-    return `<div class="ing-row grid grid-cols-[1fr_auto] gap-3"><span>${name}</span><span class="opacity-80">${qty} ${unit}</span></div>`;
+    const qtyStr = [qty, unit].filter(Boolean).join(' ');
+    return `<li class="ingredient-item md:grid md:grid-cols-[1fr_auto] md:gap-4 flex items-center bg-base-200/40 rounded px-2 py-1">
+      <span class="ingredient-qty order-1 md:order-2 md:text-right">${qtyStr}</span>
+      <span class="ingredient-name order-2 md:order-1">${name}</span>
+    </li>`;
   }).join('');
 
   const steps = (r.steps||[]).map((s,idx)=>`
-    <li class="leading-relaxed"><span class="step-index">${idx+1}.</span> ${s}</li>
+    <li class="step-item flex gap-2 p-3 bg-base-200/40 rounded">
+      <span class="font-bold">${idx+1}.</span>
+      <span>${s}</span>
+    </li>
   `).join('');
 
   return `
+    ${header}
     ${meta}
-    <div class="grid md:grid-cols-2 gap-8">
+    <div class="space-y-6">
       <section>
         <h4 class="font-semibold mb-2">${t('recipe_ingredients_header')}</h4>
-        <div class="ing-list flex flex-col gap-2">${ing}</div>
+        <ul class="ingredient-list space-y-1">${ing}</ul>
       </section>
       <section>
         <h4 class="font-semibold mb-2">${t('recipe_steps_header')}</h4>
-        <ol class="list-decimal ml-5 flex flex-col gap-2">${steps}</ol>
+        <ol class="step-list space-y-3">${steps}</ol>
       </section>
     </div>
   `;

--- a/app/static/styles.css
+++ b/app/static/styles.css
@@ -425,18 +425,39 @@ html[data-layout="mobile"] #edit-json {
   display: none;
 }
 
-.ing-row {
-  border-bottom: 1px dashed rgba(255, 255, 255, 0.08);
+/* Ingredient list layout */
+.ingredient-list li {
   padding: 6px 0;
 }
 
-.step-index {
-  font-weight: 600;
-  margin-right: 0.5rem;
+.ingredient-list li:not(:last-child) {
+  border-bottom: 1px dashed rgba(255, 255, 255, 0.08);
+}
+
+@media (min-width: 769px) {
+  .ingredient-item {
+    display: grid;
+    grid-template-columns: 1fr auto;
+    gap: 0.75rem;
+  }
+
+  .ingredient-item .ingredient-qty {
+    text-align: right;
+  }
 }
 
 @media (max-width: 768px) {
-  .grid.md\:grid-cols-2 {
-    grid-template-columns: 1fr !important;
+  .ingredient-item {
+    display: flex;
+    align-items: center;
   }
+
+  .ingredient-item .ingredient-qty {
+    margin-right: 0.5rem;
+  }
+}
+
+/* Step list spacing */
+.step-list li + li {
+  margin-top: 0.5rem;
 }

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -199,7 +199,7 @@
                 <button id="recipe-favorites-toggle" class="btn btn-outline btn-sm self-start" data-i18n="recipe_filter_favorites">Ulubione przepisy</button>
                 <button id="recipe-clear-filters" class="btn btn-outline btn-sm self-start" data-i18n="recipe_clear_filters">Wyczyść filtry</button>
             </div>
-            <div id="recipe-list" class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4 mb-8"></div>
+            <div id="recipe-list" role="list" class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4 mb-8"></div>
         </div>
 
         <div id="tab-history" class="tab-panel" style="display:none;">


### PR DESCRIPTION
## Summary
- Split recipe detail into ingredient and step sections with responsive layout
- Show recipe name, time, portions and favorite state atop detail view
- Style lists with spacing, backgrounds and mobile-friendly ordering

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689755fae6bc832a816ce62babbf8657