### PR TITLE
refactor: unify translation helper usage

### DIFF
--- a/app/static/js/components/ocr-modal.js
+++ b/app/static/js/components/ocr-modal.js
@@ -52,7 +52,7 @@ export async function handleReceiptUpload(file) {
     const nameInput = document.createElement('input');
     nameInput.type = 'text';
     const firstMatch = item.matches[0];
-    nameInput.value = firstMatch ? firstMatch.name : item.original;
+    nameInput.value = firstMatch ? t(firstMatch.name) : item.original;
     if (firstMatch) nameInput.dataset.key = firstMatch.name;
     nameInput.className = 'input input-bordered w-full';
     nameTd.appendChild(nameInput);
@@ -72,11 +72,11 @@ export async function handleReceiptUpload(file) {
       item.matches.forEach(m => {
         const opt = document.createElement('option');
         opt.value = m.name;
-        opt.textContent = m.name;
+        opt.textContent = t(m.name);
         select.appendChild(opt);
       });
       select.addEventListener('change', () => {
-        nameInput.value = select.value;
+        nameInput.value = t(select.value);
         nameInput.dataset.key = select.value;
       });
       statusTd.appendChild(select);

--- a/app/static/js/components/product-table.js
+++ b/app/static/js/components/product-table.js
@@ -1,10 +1,6 @@
 import {
   t,
   state,
-  productName,
-  unitName,
-  categoryName,
-  storageName,
   formatPackQuantity,
   getStatusIcon,
   STORAGE_ICONS,
@@ -47,7 +43,7 @@ deleteBtn?.addEventListener('click', () => {
   const list = document.createElement('ul');
   selected.forEach(cb => {
     const li = document.createElement('li');
-    li.textContent = productName(cb.dataset.name);
+    li.textContent = t(cb.dataset.name);
     list.appendChild(li);
   });
   deleteSummary.appendChild(list);
@@ -256,7 +252,7 @@ function createFlatRow(p, idx, editable) {
     // name
     const nameTd = document.createElement('td');
     nameTd.className = 'name-cell';
-    nameTd.textContent = productName(p.name);
+    nameTd.textContent = t(p.name);
     tr.appendChild(nameTd);
     // quantity with steppers
     const qtyTd = buildQtyCell(p, tr);
@@ -269,7 +265,7 @@ function createFlatRow(p, idx, editable) {
     Object.keys(state.units).forEach(u => {
       const opt = document.createElement('option');
       opt.value = u;
-      opt.textContent = unitName(u);
+      opt.textContent = t(u);
       if (u === p.unit) opt.selected = true;
       unitSel.appendChild(opt);
     });
@@ -283,7 +279,7 @@ function createFlatRow(p, idx, editable) {
     Object.keys(CATEGORY_KEYS).forEach(c => {
       const opt = document.createElement('option');
       opt.value = c;
-      opt.textContent = categoryName(c);
+      opt.textContent = t(CATEGORY_KEYS[c] || c);
       if (c === (p.category || 'uncategorized')) opt.selected = true;
       catSel.appendChild(opt);
     });
@@ -297,7 +293,7 @@ function createFlatRow(p, idx, editable) {
     Object.keys(STORAGE_KEYS).forEach(s => {
       const opt = document.createElement('option');
       opt.value = s;
-      opt.textContent = storageName(s);
+      opt.textContent = t(STORAGE_KEYS[s] || s);
       if (s === (p.storage || 'pantry')) opt.selected = true;
       storSel.appendChild(opt);
     });
@@ -314,19 +310,19 @@ function createFlatRow(p, idx, editable) {
     tr.appendChild(statusTd);
   } else {
     const nameTd = document.createElement('td');
-    nameTd.textContent = productName(p.name);
+    nameTd.textContent = t(p.name);
     tr.appendChild(nameTd);
     const qtyTd = document.createElement('td');
     qtyTd.textContent = formatPackQuantity(p);
     tr.appendChild(qtyTd);
     const unitTd = document.createElement('td');
-    unitTd.textContent = unitName(p.unit);
+    unitTd.textContent = t(p.unit);
     tr.appendChild(unitTd);
     const catTd = document.createElement('td');
-    catTd.textContent = categoryName(p.category);
+    catTd.textContent = t(CATEGORY_KEYS[p.category] || p.category);
     tr.appendChild(catTd);
     const storTd = document.createElement('td');
-    storTd.textContent = storageName(p.storage);
+    storTd.textContent = t(STORAGE_KEYS[p.storage] || p.storage);
     tr.appendChild(storTd);
     const statusTd = document.createElement('td');
     const status = getStatusIcon(p);
@@ -389,7 +385,7 @@ export function renderProducts() {
       storages[s][c].push(p);
     });
     Object.keys(storages)
-      .sort((a, b) => storageName(a).localeCompare(storageName(b)))
+      .sort((a, b) => t(STORAGE_KEYS[a] || a).localeCompare(t(STORAGE_KEYS[b] || b)))
       .forEach(stor => {
         const block = document.createElement('section');
         block.className = 'storage-section storage-block border border-base-300 rounded-lg p-4 mb-4';
@@ -400,7 +396,7 @@ export function renderProducts() {
         if (state.displayMode === 'mobile') header.classList.add('cursor-pointer');
         const nameSpan = document.createElement('span');
         nameSpan.className = 'inline-flex items-center text-xl font-semibold';
-        nameSpan.textContent = `${STORAGE_ICONS[stor] || ''} ${storageName(stor)}`;
+        nameSpan.textContent = `${STORAGE_ICONS[stor] || ''} ${t(STORAGE_KEYS[stor] || stor)}`;
         const btn = document.createElement('button');
         btn.type = 'button';
         btn.className = 'toggle-storage ml-auto h-8 w-8 flex items-center justify-center';
@@ -411,7 +407,7 @@ export function renderProducts() {
         block.appendChild(header);
 
         Object.keys(storages[stor])
-          .sort((a, b) => categoryName(a).localeCompare(categoryName(b)))
+          .sort((a, b) => t(CATEGORY_KEYS[a] || a).localeCompare(t(CATEGORY_KEYS[b] || b)))
           .forEach(cat => {
           const catBlock = document.createElement('div');
           catBlock.className = 'category-section category-block';
@@ -423,7 +419,7 @@ export function renderProducts() {
           if (state.displayMode === 'mobile') catHeader.classList.add('cursor-pointer');
           const catSpan = document.createElement('span');
           catSpan.className = 'font-medium';
-          catSpan.textContent = categoryName(cat);
+          catSpan.textContent = t(CATEGORY_KEYS[cat] || cat);
           const catBtn = document.createElement('button');
           catBtn.type = 'button';
           catBtn.className = 'toggle-category ml-auto h-8 w-8 flex items-center justify-center';
@@ -474,12 +470,12 @@ export function renderProducts() {
               cbTd.appendChild(cb);
               tr.appendChild(cbTd);
               const n = document.createElement('td');
-              n.textContent = productName(p.name);
+            n.textContent = t(p.name);
               tr.appendChild(n);
               const q = buildQtyCell(p, tr);
               tr.appendChild(q);
               const u = document.createElement('td');
-              u.textContent = unitName(p.unit);
+              u.textContent = t(p.unit);
               tr.appendChild(u);
               const s = document.createElement('td');
               const ic = getStatusIcon(p);
@@ -490,11 +486,11 @@ export function renderProducts() {
               tr.appendChild(s);
             } else {
               const n = document.createElement('td');
-              n.textContent = productName(p.name);
+            n.textContent = t(p.name);
               const q = document.createElement('td');
               q.textContent = formatPackQuantity(p);
               const u = document.createElement('td');
-              u.textContent = unitName(p.unit);
+              u.textContent = t(p.unit);
               const s = document.createElement('td');
               const ic = getStatusIcon(p);
               if (ic) {

--- a/app/static/js/components/shopping-list.js
+++ b/app/static/js/components/shopping-list.js
@@ -1,4 +1,4 @@
-import { t, state, productName, isSpice, stockLevel } from '../helpers.js';
+import { t, state, isSpice, stockLevel } from '../helpers.js';
 
 function saveShoppingList() {
   localStorage.setItem('shoppingList', JSON.stringify(state.shoppingList));
@@ -23,7 +23,7 @@ export function renderShoppingList() {
   state.shoppingList.sort((a, b) => {
     if (a.inCart && b.inCart) return (a.cartTime || 0) - (b.cartTime || 0);
     if (a.inCart !== b.inCart) return a.inCart ? 1 : -1;
-    return productName(a.name).localeCompare(productName(b.name));
+    return t(a.name).localeCompare(t(b.name));
   });
   state.shoppingList.forEach((item, idx) => {
     const row = document.createElement('div');
@@ -40,7 +40,7 @@ export function renderShoppingList() {
 
     const nameEl = document.createElement('span');
     nameEl.className = 'truncate max-w-[10rem]';
-    nameEl.textContent = productName(item.name);
+    nameEl.textContent = t(item.name);
     if (item.inCart) nameEl.classList.add('line-through');
     row.appendChild(nameEl);
 
@@ -133,7 +133,7 @@ export function renderSuggestions() {
       return p.main && (p.quantity === 0 || (p.threshold != null && p.quantity <= p.threshold));
     })
     .filter(p => !state.dismissedSuggestions.has(p.name))
-    .sort((a, b) => productName(a.name).localeCompare(productName(b.name)));
+    .sort((a, b) => t(a.name).localeCompare(t(b.name)));
   suggestions.forEach(p => {
     let qty = p.threshold != null ? p.threshold : 1;
     const row = document.createElement('div');
@@ -147,8 +147,8 @@ export function renderSuggestions() {
     nameWrap.className = 'w-full sm:flex-1 overflow-hidden';
     const nameEl = document.createElement('div');
     nameEl.className = 'truncate';
-    nameEl.textContent = productName(p.name);
-    nameEl.title = productName(p.name);
+    nameEl.textContent = t(p.name);
+    nameEl.title = t(p.name);
     nameWrap.appendChild(nameEl);
     row.appendChild(nameWrap);
 

--- a/app/static/js/helpers.js
+++ b/app/static/js/helpers.js
@@ -73,28 +73,6 @@ export function t(key) {
   return state.uiTranslations[state.currentLang]?.[key] ?? state.uiTranslations.en?.[key] ?? key;
 }
 
-export function productName(key) {
-  const translated = t(key);
-  return translated;
-}
-
-export function unitName(key) {
-  const translated = t(key);
-  return translated === key ? key : translated;
-}
-
-export function categoryName(key) {
-  const tKey = CATEGORY_KEYS[key] || key;
-  const translated = t(tKey);
-  return translated === tKey ? key : translated;
-}
-
-export function storageName(key) {
-  const tKey = STORAGE_KEYS[key] || key;
-  const translated = t(tKey);
-  return translated === tKey ? key : translated;
-}
-
 export function applyTranslations() {
   document.querySelectorAll('[data-i18n]').forEach(el => {
     const key = el.getAttribute('data-i18n');

--- a/app/static/script.js
+++ b/app/static/script.js
@@ -1,4 +1,4 @@
-import { loadTranslations, loadUnits, loadFavorites, state, t, normalizeProduct, unitName, applyTranslations } from './js/helpers.js';
+import { loadTranslations, loadUnits, loadFavorites, state, t, normalizeProduct, applyTranslations } from './js/helpers.js';
 import { renderProducts } from './js/components/product-table.js';
 import { renderRecipes, loadRecipes } from './js/components/recipe-list.js';
 import { renderShoppingList, addToShoppingList, renderSuggestions } from './js/components/shopping-list.js';
@@ -157,7 +157,7 @@ function initAddForm() {
   Object.keys(state.units).forEach(u => {
     const opt = document.createElement('option');
     opt.value = u;
-    opt.textContent = unitName(u);
+    opt.textContent = t(u);
     unitSel.appendChild(opt);
   });
   qtyInput.insertAdjacentElement('afterend', unitSel);
@@ -270,6 +270,12 @@ document.addEventListener('DOMContentLoaded', async () => {
     renderRecipes();
     renderShoppingList();
     renderSuggestions();
+    const unitSel = document.querySelector('#add-form select[name="unit"]');
+    if (unitSel) {
+      Array.from(unitSel.options).forEach(opt => {
+        opt.textContent = t(opt.value);
+      });
+    }
     window.scrollTo(0, scroll);
   });
 


### PR DESCRIPTION
## Summary
- centralize translation lookup in `t()` with English fallback and key fallback
- ensure products, units, categories and storages use translation keys directly
- refresh UI strings on language toggle without page reload

## Testing
- `node --check app/static/js/helpers.js && node --check app/static/script.js && node --check app/static/js/components/product-table.js && node --check app/static/js/components/shopping-list.js && node --check app/static/js/components/ocr-modal.js`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68976b0de170832a94a2a1c883667ab5