### PR TITLE
Add unified fetch wrapper and startup health check

### DIFF
--- a/app/static/js/components/ocr-modal.js
+++ b/app/static/js/components/ocr-modal.js
@@ -1,5 +1,6 @@
-import { t, state } from '../helpers.js';
+import { t, state, fetchJson } from '../helpers.js';
 import { addToShoppingList, renderShoppingList } from './shopping-list.js';
+import { showToast } from './toast.js';
 
 export function initReceiptImport() {
   const btn = document.getElementById('receipt-btn');
@@ -39,17 +40,16 @@ export async function handleReceiptUpload(file) {
   if (!modal.open) modal.showModal();
   const { data: { text } } = await Tesseract.recognize(file, state.currentLang === 'pl' ? 'pol' : 'eng');
   const lines = text.split('\n').map(l => l.trim()).filter(l => l);
-  const res = await fetch('/api/ocr-match', {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ items: lines })
-  });
-  const data = await res.json();
-  tableBody.innerHTML = '';
-  data.forEach(item => {
-    const tr = document.createElement('tr');
-    const nameTd = document.createElement('td');
-    const nameInput = document.createElement('input');
+  try {
+    const data = await fetchJson('/api/ocr-match', {
+      method: 'POST',
+      body: { items: lines }
+    });
+    tableBody.innerHTML = '';
+    data.forEach(item => {
+      const tr = document.createElement('tr');
+      const nameTd = document.createElement('td');
+      const nameInput = document.createElement('input');
     nameInput.type = 'text';
     const firstMatch = item.matches[0];
     nameInput.value = firstMatch ? t(firstMatch.name) : item.original;
@@ -95,6 +95,9 @@ export async function handleReceiptUpload(file) {
     removeBtn.addEventListener('click', () => tr.remove());
     removeTd.appendChild(removeBtn);
     tr.appendChild(removeTd);
-    tableBody.appendChild(tr);
-  });
+      tableBody.appendChild(tr);
+    });
+  } catch (err) {
+    showToast(t('notify_error_title'), 'error');
+  }
 }

--- a/app/static/js/components/recipe-list.js
+++ b/app/static/js/components/recipe-list.js
@@ -4,7 +4,8 @@ import {
   parseTimeToMinutes,
   timeToBucket,
   toggleFavorite,
-  normalizeRecipe
+  normalizeRecipe,
+  fetchJson
 } from '../helpers.js';
 import { showNotification } from './toast.js';
 import { renderRecipeDetail } from './recipe-detail.js';
@@ -143,9 +144,7 @@ export async function loadRecipes() {
   }
   state.recipesLoading = true;
   try {
-    const res = await fetch('/api/recipes');
-    if (!res.ok) throw new Error(`HTTP ${res.status}`);
-    const data = await res.json();
+    const data = await fetchJson('/api/recipes');
     const processed = data
       .map(r => normalizeRecipe(r))
       .map(r => ({ ...r, timeBucket: timeToBucket(r.time) }));
@@ -154,7 +153,7 @@ export async function loadRecipes() {
     renderRecipes();
     return processed;
   } catch (err) {
-    showNotification({ type: 'error', title: t('recipes_load_failed'), message: err.message, retry: loadRecipes });
+    showNotification({ type: 'error', title: t('recipes_load_failed'), message: err.body?.message || String(err.status), retry: loadRecipes });
     return [];
   } finally {
     state.recipesLoading = false;

--- a/app/static/translations/en.json
+++ b/app/static/translations/en.json
@@ -133,6 +133,8 @@
   "notify_success_title": "Success",
   "notify_error_title": "Error",
   "manual_add_success": "Added to shopping list",
+  "retry": "Retry",
+  "health_check_failed": "Unable to reach server",
   "product.toast_bread": "Toast bread",
   "product.eggs": "Eggs",
   "product.natural_tofu": "Natural tofu",

--- a/app/static/translations/pl.json
+++ b/app/static/translations/pl.json
@@ -133,6 +133,8 @@
   "notify_success_title": "Sukces",
   "notify_error_title": "Błąd",
   "manual_add_success": "Dodano do listy zakupów",
+  "retry": "Ponów",
+  "health_check_failed": "Brak połączenia z serwerem",
   "product.toast_bread": "Pieczywo tostowe",
   "product.eggs": "Jajka",
   "product.natural_tofu": "Tofu naturalne",

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -16,6 +16,10 @@
 </head>
 <body class="min-h-screen bg-base-100">
 <div id="top-sentinel"></div>
+<div id="health-banner" class="bg-error text-error-content text-center py-2 hidden">
+    <span data-i18n="health_check_failed">Brak połączenia z serwerem</span>
+    <button id="health-retry" class="btn btn-sm ml-4" data-i18n="retry">Retry</button>
+</div>
 <div class="corner-icons flex justify-end bg-base-100">
     <button id="layout-toggle" aria-label="Toggle layout" class="text-xl p-2 bg-transparent border-0">
         <i id="layout-icon" class="fa-solid fa-mobile-screen-button"></i>


### PR DESCRIPTION
## Summary
- add `fetchJson` utility for consistent headers, JSON parsing, and error diagnostics
- check `/api/health` on load with retry banner and translations
- replace raw `fetch` calls with `fetchJson` and show toast errors

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68976d6c5b64832a9e185db5c84e16cc