### PR TITLE
feat: add unified fetch helper and health check

### DIFF
--- a/app/static/js/components/product-table.js
+++ b/app/static/js/components/product-table.js
@@ -8,7 +8,8 @@ import {
   STORAGE_KEYS,
   matchesFilter,
   stockLevel,
-  normalizeProduct
+  normalizeProduct,
+  fetchJson
 } from '../helpers.js';
 import { showToast } from './toast.js';
 
@@ -56,9 +57,11 @@ confirmDeleteBtn?.addEventListener('click', async e => {
   const names = selected.map(cb => cb.dataset.name);
   try {
     await Promise.all(
-      names.map(name => fetch(`/api/products/${encodeURIComponent(name)}`, { method: 'DELETE' }))
+      names.map(name => fetchJson(`/api/products/${encodeURIComponent(name)}`, { method: 'DELETE' }))
     );
     await refreshProducts();
+  } catch (err) {
+    showToast(t('notify_error_title'), 'error');
   } finally {
     deleteModal.close();
     updateDeleteButton();
@@ -224,22 +227,26 @@ function buildQtyCell(p, tr) {
 }
 
 export async function refreshProducts() {
-  const res = await fetch('/api/products');
-  if (!res.ok) throw new Error('Fetch failed');
-  const data = await res.json();
-  APP.state.products = data.map(normalizeProduct);
-  renderProducts();
+  try {
+    const data = await fetchJson('/api/products');
+    APP.state.products = data.map(normalizeProduct);
+    renderProducts();
+  } catch (err) {
+    showToast(t('notify_error_title'), 'error');
+  }
 }
 
 export async function saveProduct(payload) {
-  const res = await fetch('/api/products', {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(payload)
-  });
-  if (!res.ok) throw new Error('Save failed');
-  await refreshProducts();
-  showToast(t('save_success'));
+  try {
+    await fetchJson('/api/products', {
+      method: 'POST',
+      body: payload
+    });
+    await refreshProducts();
+    showToast(t('save_success'));
+  } catch (err) {
+    showToast(t('notify_error_title'), 'error');
+  }
 }
 
 function createFlatRow(p, idx, editable) {

--- a/app/static/js/components/recipe-list.js
+++ b/app/static/js/components/recipe-list.js
@@ -4,7 +4,8 @@ import {
   parseTimeToMinutes,
   timeToBucket,
   toggleFavorite,
-  normalizeRecipe
+  normalizeRecipe,
+  fetchJson
 } from '../helpers.js';
 import { showNotification } from './toast.js';
 import { renderRecipeDetail } from './recipe-detail.js';
@@ -143,9 +144,7 @@ export async function loadRecipes() {
   }
   state.recipesLoading = true;
   try {
-    const res = await fetch('/api/recipes');
-    if (!res.ok) throw new Error(`HTTP ${res.status}`);
-    const data = await res.json();
+    const data = await fetchJson('/api/recipes');
     const processed = data
       .map(r => normalizeRecipe(r))
       .map(r => ({ ...r, timeBucket: timeToBucket(r.time) }));
@@ -154,7 +153,7 @@ export async function loadRecipes() {
     renderRecipes();
     return processed;
   } catch (err) {
-    showNotification({ type: 'error', title: t('recipes_load_failed'), message: err.message, retry: loadRecipes });
+    showNotification({ type: 'error', title: t('recipes_load_failed'), message: err.status || err.message, retry: loadRecipes });
     return [];
   } finally {
     state.recipesLoading = false;

--- a/app/static/translations/en.json
+++ b/app/static/translations/en.json
@@ -132,6 +132,7 @@
   "toast_close": "Close",
   "notify_success_title": "Success",
   "notify_error_title": "Error",
+  "retry": "Retry",
   "manual_add_success": "Added to shopping list",
   "product.toast_bread": "Toast bread",
   "product.eggs": "Eggs",

--- a/app/static/translations/pl.json
+++ b/app/static/translations/pl.json
@@ -132,6 +132,7 @@
   "toast_close": "Zamknij",
   "notify_success_title": "Sukces",
   "notify_error_title": "Błąd",
+  "retry": "Ponów",
   "manual_add_success": "Dodano do listy zakupów",
   "product.toast_bread": "Pieczywo tostowe",
   "product.eggs": "Jajka",

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -16,6 +16,10 @@
 </head>
 <body class="min-h-screen bg-base-100">
 <div id="top-sentinel"></div>
+<div id="health-banner" class="alert alert-error hidden justify-between">
+    <span data-i18n="notify_error_title">Error</span>
+    <button id="health-retry" class="btn btn-sm" data-i18n="retry">Retry</button>
+</div>
 <div class="corner-icons flex justify-end bg-base-100">
     <button id="layout-toggle" aria-label="Toggle layout" class="text-xl p-2 bg-transparent border-0">
         <i id="layout-icon" class="fa-solid fa-mobile-screen-button"></i>


### PR DESCRIPTION
## Summary
- add fetchJson wrapper for consistent API diagnostics
- show retry banner on failed health checks
- use fetchJson across UI and surface toast errors

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68976fab4874832ab1848425e36ddf52