### PR TITLE
Reset product filters when leaving Products tab

### DIFF
--- a/app/static/js/components/product-table.js
+++ b/app/static/js/components/product-table.js
@@ -381,9 +381,18 @@ function createFlatRow(p, idx, editable) {
 }
 
 export function renderProducts() {
-  const { products = [], view = 'flat', filter = 'all', editing = false } = APP.state || {};
+  const {
+    products = [],
+    view = 'flat',
+    filter = 'all',
+    editing = false,
+    search = ''
+  } = APP.state || {};
   const data = Array.isArray(products) ? products.filter(p => p && p.name) : [];
-  const filtered = data.filter(p => matchesFilter(p, filter));
+  const term = (search || '').toLowerCase();
+  const filtered = data.filter(
+    p => matchesFilter(p, filter) && (!term || t(p.name).toLowerCase().includes(term) || p.name.toLowerCase().includes(term))
+  );
 
   const table = document.getElementById('product-table');
   const list = document.getElementById('products-by-category');

--- a/app/static/script.js
+++ b/app/static/script.js
@@ -16,6 +16,7 @@ APP.state = APP.state || {
   products: [],
   view: 'flat',
   filter: 'available',
+  search: '',
   editing: false
 };
 APP.activeTab = APP.activeTab || null;
@@ -73,8 +74,11 @@ async function checkHealth() {
 
 function resetProductFilter() {
   APP.state.filter = 'available';
+  APP.state.search = '';
   const sel = document.getElementById('state-filter');
   if (sel) sel.value = 'available';
+  const search = document.getElementById('product-search');
+  if (search) search.value = '';
 }
 
 function resetRecipeFilters() {
@@ -105,6 +109,9 @@ function activateTab(targetId) {
   document.querySelectorAll('.tab-panel').forEach(panel => (panel.style.display = 'none'));
   const panel = document.getElementById(targetId);
   if (panel) panel.style.display = 'block';
+  if (APP.activeTab === 'tab-products' && targetId !== 'tab-products') {
+    resetProductFilter();
+  }
   if (targetId === 'tab-products' && APP.activeTab !== 'tab-products') {
     resetProductFilter();
     renderProducts();
@@ -385,6 +392,11 @@ document.addEventListener('DOMContentLoaded', async () => {
   const filterSel = document.getElementById('state-filter');
   filterSel?.addEventListener('change', () => {
     APP.state.filter = filterSel.value;
+    renderProducts();
+  });
+  const searchInput = document.getElementById('product-search');
+  searchInput?.addEventListener('input', () => {
+    APP.state.search = searchInput.value.trim().toLowerCase();
     renderProducts();
   });
   const copyBtn = document.getElementById('copy-btn');


### PR DESCRIPTION
## Summary
- Reset product filter and search input whenever navigating away from or back to the Products tab
- Track search term in state and filter products accordingly

## Testing
- `npm test` (fails: Could not read package.json)
- `pytest` (no tests ran)


------
https://chatgpt.com/codex/tasks/task_e_6897744d654c832a8bec63b50842b532