### PR TITLE
Improve accessibility and motion preferences

### DIFF
--- a/app/static/js/components/toast.js
+++ b/app/static/js/components/toast.js
@@ -41,6 +41,7 @@ export function showNotification({ type = 'success', title = '', message = '', r
   }
   const close = document.createElement('button');
   close.className = 'btn btn-xs btn-circle btn-ghost absolute top-1 right-1';
+  close.setAttribute('aria-label', t('close'));
   close.innerHTML = '<i class="fa-regular fa-xmark"></i>';
   close.addEventListener('click', () => alert.remove());
   alert.appendChild(close);
@@ -78,6 +79,7 @@ export function showLowStockToast(activateTab, renderSuggestions, renderShopping
   close.className = 'btn btn-xs btn-circle btn-ghost absolute top-1 right-1';
   close.dataset.action = 'close';
   close.setAttribute('title', t('toast_close'));
+  close.setAttribute('aria-label', t('close'));
   close.innerHTML = '<i class="fa-regular fa-xmark"></i>';
   close.addEventListener('click', () => {
     alert.remove();

--- a/app/static/js/helpers.js
+++ b/app/static/js/helpers.js
@@ -86,6 +86,14 @@ export function applyTranslations() {
       el.textContent = txt;
     }
   });
+  document.querySelectorAll('[data-i18n-aria-label]').forEach(el => {
+    const key = el.getAttribute('data-i18n-aria-label');
+    el.setAttribute('aria-label', t(key));
+  });
+  document.querySelectorAll('[data-i18n-title]').forEach(el => {
+    const key = el.getAttribute('data-i18n-title');
+    el.setAttribute('title', t(key));
+  });
 }
 
 export function parseTimeToMinutes(value) {

--- a/app/static/script.js
+++ b/app/static/script.js
@@ -349,10 +349,14 @@ document.addEventListener('DOMContentLoaded', async () => {
     APP.editBackup = JSON.parse(JSON.stringify(APP.state.products));
     APP.state.editing = true;
     editBtn.textContent = t('edit_mode_button_off');
+    editBtn.setAttribute('aria-label', t('edit_mode_button_off'));
+    editBtn.setAttribute('aria-pressed', 'true');
     saveBtn.style.display = '';
+    saveBtn.setAttribute('aria-label', t('save_button'));
     deleteBtn.style.display = '';
     deleteBtn.disabled = true;
     deleteBtn.textContent = t('delete_selected_button');
+    deleteBtn.setAttribute('aria-label', t('delete_selected_button'));
     selectHeader.style.display = '';
     renderProducts();
   }
@@ -364,10 +368,13 @@ document.addEventListener('DOMContentLoaded', async () => {
     APP.editBackup = null;
     APP.state.editing = false;
     editBtn.textContent = t('edit_mode_button_on');
+    editBtn.setAttribute('aria-label', t('edit_mode_button_on'));
+    editBtn.setAttribute('aria-pressed', 'false');
     saveBtn.style.display = 'none';
     deleteBtn.style.display = 'none';
     deleteBtn.disabled = true;
     deleteBtn.textContent = t('delete_selected_button');
+    deleteBtn.setAttribute('aria-label', t('delete_selected_button'));
     selectHeader.style.display = 'none';
     renderProducts();
   }
@@ -383,12 +390,18 @@ document.addEventListener('DOMContentLoaded', async () => {
   });
 
   const viewBtn = document.getElementById('view-toggle');
-  viewBtn?.addEventListener('click', () => {
-    if (APP.state.editing) exitEditMode(true);
-    APP.state.view = APP.state.view === 'flat' ? 'grouped' : 'flat';
-    viewBtn.textContent = APP.state.view === 'grouped' ? t('change_view_toggle_flat') : t('change_view_toggle_grouped');
-    renderProducts();
-  });
+  if (viewBtn) {
+    viewBtn.setAttribute('aria-pressed', APP.state.view === 'grouped' ? 'true' : 'false');
+    viewBtn.addEventListener('click', () => {
+      if (APP.state.editing) exitEditMode(true);
+      APP.state.view = APP.state.view === 'flat' ? 'grouped' : 'flat';
+      const label = APP.state.view === 'grouped' ? t('change_view_toggle_flat') : t('change_view_toggle_grouped');
+      viewBtn.textContent = label;
+      viewBtn.setAttribute('aria-label', label);
+      viewBtn.setAttribute('aria-pressed', APP.state.view === 'grouped' ? 'true' : 'false');
+      renderProducts();
+    });
+  }
   const filterSel = document.getElementById('state-filter');
   filterSel?.addEventListener('change', () => {
     APP.state.filter = filterSel.value;

--- a/app/static/styles.css
+++ b/app/static/styles.css
@@ -395,7 +395,25 @@ html[data-layout="mobile"] .touch-btn {
 
 .owned-info {
   font-size: 0.75rem;
-  color: hsl(var(--bc) / 0.7);
+  color: hsl(var(--bc) / 0.8);
+}
+
+button:focus-visible,
+[role="button"]:focus-visible,
+input:focus-visible,
+select:focus-visible,
+textarea:focus-visible {
+  outline: 2px solid hsl(var(--p));
+  outline-offset: 2px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
 }
 
 /* JSON editor adjustments */

--- a/app/static/translations/en.json
+++ b/app/static/translations/en.json
@@ -139,6 +139,7 @@
   "toast_low_stock": "Some products are running low! Check the shopping list.",
   "toast_go_shopping": "Go to shopping list",
   "toast_close": "Close",
+  "close": "Close",
   "notify_success_title": "Success",
   "notify_error_title": "Error",
   "retry": "Retry",

--- a/app/static/translations/pl.json
+++ b/app/static/translations/pl.json
@@ -139,6 +139,7 @@
   "toast_low_stock": "Niektóre produkty się kończą! Przejrzyj listę zakupów.",
   "toast_go_shopping": "Przejdź do listy zakupów",
   "toast_close": "Zamknij",
+  "close": "Zamknij",
   "notify_success_title": "Sukces",
   "notify_error_title": "Błąd",
   "retry": "Ponów",

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -35,13 +35,13 @@
         <i class="fa-solid fa-gear"></i>
     </button>
 </div>
-<div id="notification-container" class="toast toast-end top-auto bottom-[4.5rem] z-40"></div>
+<div id="notification-container" class="toast toast-end top-auto bottom-[4.5rem] z-40" aria-live="polite"></div>
 <div class="max-w-screen-lg mx-auto px-4 py-6 main-container">
     <div class="tabs tabs-bordered flex-nowrap overflow-x-auto whitespace-nowrap mb-6 desktop-nav">
-        <a class="tab tab-active font-bold" data-tab-target="tab-products" data-i18n="tab_products">Produkty</a>
-        <a class="tab" data-tab-target="tab-recipes" data-i18n="tab_recipes">Przepisy</a>
-        <a class="tab" data-tab-target="tab-history" data-i18n="tab_history">Historia dań</a>
-        <a class="tab" data-tab-target="tab-shopping" data-i18n="tab_shopping">Lista zakupów</a>
+        <button class="tab tab-active font-bold" data-tab-target="tab-products" data-i18n="tab_products">Produkty</button>
+        <button class="tab" data-tab-target="tab-recipes" data-i18n="tab_recipes">Przepisy</button>
+        <button class="tab" data-tab-target="tab-history" data-i18n="tab_history">Historia dań</button>
+        <button class="tab" data-tab-target="tab-shopping" data-i18n="tab_shopping">Lista zakupów</button>
     </div>
         <div id="tab-products" class="tab-panel">
             <h1 class="text-2xl font-bold mb-4" data-i18n="heading_products">Produkty</h1>
@@ -55,10 +55,10 @@
                         <option value="all" data-i18n="state_filter_all">Wszystkie</option>
                     </select>
                 </div>
-                <button id="view-toggle" class="btn btn-outline btn-primary btn-sm" data-i18n="change_view_toggle_grouped">Widok z podziałem</button>
-                <button id="edit-toggle" class="btn btn-outline btn-warning btn-sm" data-i18n="edit_mode_button_on">Edytuj</button>
-                <button id="save-btn" style="display:none;" class="btn btn-success btn-sm" data-i18n="save_button">Zapisz</button>
-                <button id="delete-selected" style="display:none;" class="btn btn-error btn-sm" disabled data-i18n="delete_selected_button">Usuń zaznaczone</button>
+                <button id="view-toggle" class="btn btn-outline btn-primary btn-sm" data-i18n="change_view_toggle_grouped" data-i18n-aria-label="change_view_toggle_grouped" aria-pressed="false">Widok z podziałem</button>
+                <button id="edit-toggle" class="btn btn-outline btn-warning btn-sm" data-i18n="edit_mode_button_on" data-i18n-aria-label="edit_mode_button_on" aria-pressed="false">Edytuj</button>
+                <button id="save-btn" style="display:none;" class="btn btn-success btn-sm" data-i18n="save_button" data-i18n-aria-label="save_button">Zapisz</button>
+                <button id="delete-selected" style="display:none;" class="btn btn-error btn-sm" disabled data-i18n="delete_selected_button" data-i18n-aria-label="delete_selected_button">Usuń zaznaczone</button>
             </div>
             <div class="overflow-x-auto">
                 <table id="product-table" class="table table-zebra table-fixed w-full">
@@ -93,8 +93,8 @@
                     <p class="py-4" data-i18n="delete_modal_question">Czy na pewno chcesz usunąć zaznaczone produkty?</p>
                     <div id="delete-summary" class="space-y-1"></div>
                     <div class="modal-action">
-                        <button id="confirm-delete" class="btn btn-error btn-sm" data-i18n="delete_confirm_button">Usuń</button>
-                        <button id="cancel-delete" class="btn btn-outline btn-sm" data-i18n="delete_cancel_button">Anuluj</button>
+                        <button id="confirm-delete" class="btn btn-error btn-sm" data-i18n="delete_confirm_button" data-i18n-aria-label="delete_confirm_button">Usuń</button>
+                        <button id="cancel-delete" class="btn btn-outline btn-sm" data-i18n="delete_cancel_button" data-i18n-aria-label="delete_cancel_button">Anuluj</button>
                     </div>
                 </form>
             </dialog>
@@ -397,22 +397,22 @@
 
     </div>
     <nav class="mobile-nav fixed bottom-0 left-0 w-full z-50 bg-base-100 flex">
-        <a class="tab tab-active font-bold flex flex-col items-center justify-center flex-1 py-3 px-2 border-r border-base-300" data-tab-target="tab-products">
+        <button class="tab tab-active font-bold flex flex-col items-center justify-center flex-1 py-3 px-2 border-r border-base-300" data-tab-target="tab-products">
             <i class="fa-solid fa-box text-xl"></i>
             <span class="text-xs" data-i18n="tab_products">Produkty</span>
-        </a>
-        <a class="tab flex flex-col items-center justify-center flex-1 py-3 px-2 border-r border-base-300" data-tab-target="tab-recipes">
+        </button>
+        <button class="tab flex flex-col items-center justify-center flex-1 py-3 px-2 border-r border-base-300" data-tab-target="tab-recipes">
             <i class="fa-solid fa-utensils text-xl"></i>
             <span class="text-xs" data-i18n="tab_recipes">Przepisy</span>
-        </a>
-        <a class="tab flex flex-col items-center justify-center flex-1 py-3 px-2 border-r border-base-300" data-tab-target="tab-history">
+        </button>
+        <button class="tab flex flex-col items-center justify-center flex-1 py-3 px-2 border-r border-base-300" data-tab-target="tab-history">
             <i class="fa-solid fa-clock-rotate-left text-xl"></i>
             <span class="text-xs" data-i18n="tab_history">Historia dań</span>
-        </a>
-        <a class="tab flex flex-col items-center justify-center flex-1 py-3 px-2" data-tab-target="tab-shopping">
+        </button>
+        <button class="tab flex flex-col items-center justify-center flex-1 py-3 px-2" data-tab-target="tab-shopping">
             <i class="fa-solid fa-cart-shopping text-xl"></i>
             <span class="text-xs" data-i18n="tab_shopping">Lista zakupów</span>
-        </a>
+        </button>
     </nav>
     <script src="https://cdn.jsdelivr.net/npm/tesseract.js@2.1.5/dist/tesseract.min.js"></script>
     <script type="module" src="{{ url_for('static', filename='script.js') }}"></script>


### PR DESCRIPTION
## Summary
- ensure toast messages are announced and closable via keyboard
- add aria labels and pressed states to view/edit controls and navigation tabs
- add focus-visible styles and respect user motion preferences

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68977aa5a2b8832ab99d04b51c933831