### PR TITLE
chore: optimize frontend interactions

### DIFF
--- a/app/static/js/helpers.js
+++ b/app/static/js/helpers.js
@@ -290,3 +290,36 @@ export function matchesFilter(p = {}, filter = 'all') {
       return true;
   }
 }
+export function debounce(fn, delay = 200) {
+  let timer;
+  return function (...args) {
+    clearTimeout(timer);
+    timer = setTimeout(() => fn.apply(this, args), delay);
+  };
+}
+
+export function throttle(fn, limit = 200) {
+  let inThrottle, lastFn, lastTime;
+  return function (...args) {
+    const context = this;
+    if (!inThrottle) {
+      fn.apply(context, args);
+      lastTime = Date.now();
+      inThrottle = true;
+    } else {
+      clearTimeout(lastFn);
+      lastFn = setTimeout(() => {
+        if (Date.now() - lastTime >= limit) {
+          fn.apply(context, args);
+          lastTime = Date.now();
+        }
+      }, Math.max(limit - (Date.now() - lastTime), 0));
+    }
+  };
+}
+
+export function withRaf(fn) {
+  return function (...args) {
+    requestAnimationFrame(() => fn.apply(this, args));
+  };
+}


### PR DESCRIPTION
## Summary
- add debounce, throttle and requestAnimationFrame helpers
- batch DOM rendering and debounce inputs in product and recipe lists
- show inline loading states and disable buttons during async actions

## Testing
- `node --check app/static/js/helpers.js`
- `node --check app/static/js/components/product-table.js`
- `node --check app/static/js/components/shopping-list.js`
- `node --check app/static/js/components/recipe-list.js`
- `npm test` *(fails: Could not read package.json)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68977aa6c014832aa2da06650d1df2b6