### PR TITLE
Improve accessibility and keyboard behavior

### DIFF
--- a/app/static/js/components/shopping-list.js
+++ b/app/static/js/components/shopping-list.js
@@ -112,8 +112,11 @@ export function renderShoppingList() {
     cartBtn.classList.toggle('text-primary', item.inCart);
     cartBtn.setAttribute('aria-label', t('in_cart'));
     cartBtn.setAttribute('title', t('in_cart'));
+    cartBtn.setAttribute('aria-pressed', item.inCart);
     cartBtn.addEventListener('click', async () => {
       item.inCart = !item.inCart;
+      cartBtn.classList.toggle('text-primary', item.inCart);
+      cartBtn.setAttribute('aria-pressed', item.inCart);
       if (item.inCart) {
         item.cartTime = Date.now();
         if (stock && isSpice(stock)) {

--- a/app/static/js/components/toast.js
+++ b/app/static/js/components/toast.js
@@ -7,6 +7,8 @@ function createToast({ type = 'success', title = '', message = '', action = null
   const alertClass =
     type === 'error' ? 'alert-error' : type === 'info' ? 'alert-info' : 'alert-success';
   alert.className = `alert ${alertClass} shadow-lg relative`;
+  alert.setAttribute('role', 'status');
+  alert.setAttribute('aria-live', 'polite');
   const body = document.createElement('div');
   body.className = 'flex gap-2';
   const icon = document.createElement('span');
@@ -43,8 +45,8 @@ function createToast({ type = 'success', title = '', message = '', action = null
   }
   const close = document.createElement('button');
   close.className = 'btn btn-xs btn-circle btn-ghost absolute top-1 right-1';
-  close.setAttribute('title', t('toast_close'));
-  close.setAttribute('aria-label', t('toast_close'));
+  close.setAttribute('title', t('close'));
+  close.setAttribute('aria-label', t('close'));
   close.innerHTML = '<i class="fa-regular fa-xmark"></i>';
   close.addEventListener('click', () => alert.remove());
   alert.appendChild(close);
@@ -69,6 +71,8 @@ export function showLowStockToast(activateTab, renderSuggestions, renderShopping
   const alert = document.createElement('div');
   alert.className = 'alert alert-warning relative';
   alert.dataset.toast = 'low-stock';
+  alert.setAttribute('role', 'status');
+  alert.setAttribute('aria-live', 'polite');
   const span = document.createElement('span');
   span.textContent = t('toast_low_stock');
   const btn = document.createElement('button');
@@ -86,7 +90,8 @@ export function showLowStockToast(activateTab, renderSuggestions, renderShopping
   const close = document.createElement('button');
   close.className = 'btn btn-xs btn-circle btn-ghost absolute top-1 right-1';
   close.dataset.action = 'close';
-  close.setAttribute('title', t('toast_close'));
+  close.setAttribute('title', t('close'));
+  close.setAttribute('aria-label', t('close'));
   close.innerHTML = '<i class="fa-regular fa-xmark"></i>';
   close.addEventListener('click', () => {
     alert.remove();
@@ -113,7 +118,7 @@ export function checkLowStockToast(currentProducts, activateTab, renderSuggestio
       const btn = toast.querySelector('button[data-action="shopping"]');
       if (btn) btn.textContent = t('toast_go_shopping');
       const close = toast.querySelector('button[data-action="close"]');
-      if (close) close.setAttribute('title', t('toast_close'));
+      if (close) close.setAttribute('title', t('close'));
     }
   } else {
     if (toast) toast.remove();

--- a/app/static/script.js
+++ b/app/static/script.js
@@ -332,6 +332,7 @@ document.addEventListener('DOMContentLoaded', async () => {
     renderRecipes();
     renderShoppingList();
     renderSuggestions();
+    updateAriaLabels();
     const unitSel = document.querySelector('#add-form select[name="unit"]');
     if (unitSel) {
       Array.from(unitSel.options).forEach(opt => {
@@ -355,6 +356,7 @@ document.addEventListener('DOMContentLoaded', async () => {
     deleteBtn.textContent = t('delete_selected_button');
     selectHeader.style.display = '';
     renderProducts();
+    updateAriaLabels();
   }
 
   function exitEditMode(discard) {
@@ -370,6 +372,7 @@ document.addEventListener('DOMContentLoaded', async () => {
     deleteBtn.textContent = t('delete_selected_button');
     selectHeader.style.display = 'none';
     renderProducts();
+    updateAriaLabels();
   }
 
   editBtn?.addEventListener('click', () => {
@@ -388,6 +391,7 @@ document.addEventListener('DOMContentLoaded', async () => {
     APP.state.view = APP.state.view === 'flat' ? 'grouped' : 'flat';
     viewBtn.textContent = APP.state.view === 'grouped' ? t('change_view_toggle_flat') : t('change_view_toggle_grouped');
     renderProducts();
+    updateAriaLabels();
   });
   const filterSel = document.getElementById('state-filter');
   filterSel?.addEventListener('change', () => {
@@ -409,4 +413,20 @@ document.addEventListener('DOMContentLoaded', async () => {
     a.click();
     URL.revokeObjectURL(url);
   });
+
+  function updateAriaLabels() {
+    viewBtn?.setAttribute('aria-label', t(APP.state.view === 'grouped' ? 'change_view_toggle_flat' : 'change_view_toggle_grouped'));
+    viewBtn?.setAttribute('aria-pressed', APP.state.view === 'grouped');
+    editBtn?.setAttribute('aria-label', t(APP.state.editing ? 'edit_mode_button_off' : 'edit_mode_button_on'));
+    editBtn?.setAttribute('aria-pressed', APP.state.editing);
+    saveBtn?.setAttribute('aria-label', t('save_button'));
+    deleteBtn?.setAttribute('aria-label', t('delete_selected_button'));
+    document.getElementById('confirm-delete')?.setAttribute('aria-label', t('delete_confirm_button'));
+    document.getElementById('cancel-delete')?.setAttribute('aria-label', t('delete_cancel_button'));
+    document.getElementById('confirm-remove-item')?.setAttribute('aria-label', t('confirm_button'));
+    document.querySelector('#shopping-delete-modal .btn-outline')?.setAttribute('aria-label', t('delete_cancel_button'));
+    document.getElementById('history-detail-close')?.setAttribute('aria-label', t('close'));
+  }
+
+  updateAriaLabels();
 });

--- a/app/static/styles.css
+++ b/app/static/styles.css
@@ -395,7 +395,7 @@ html[data-layout="mobile"] .touch-btn {
 
 .owned-info {
   font-size: 0.75rem;
-  color: hsl(var(--bc) / 0.7);
+  color: hsl(var(--bc));
 }
 
 /* JSON editor adjustments */
@@ -469,4 +469,23 @@ html[data-layout="mobile"] #edit-json {
 /* Step list spacing */
 .step-list li + li {
   margin-top: 0.5rem;
+}
+
+button:focus-visible,
+.btn:focus-visible,
+.touch-btn:focus-visible,
+[role="button"]:focus-visible {
+  outline: 2px solid currentColor;
+  outline-offset: 2px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+  }
+  .rotate-180 {
+    transform: none !important;
+  }
 }

--- a/app/static/translations/en.json
+++ b/app/static/translations/en.json
@@ -139,7 +139,7 @@
   "toast_low_stock": "Some products are running low! Check the shopping list.",
   "toast_go_shopping": "Go to Shopping",
   "toast_go_products": "Go to Products",
-  "toast_close": "Close",
+  "close": "Close",
   "notify_success_title": "Success",
   "notify_error_title": "Error",
   "retry": "Retry",

--- a/app/static/translations/pl.json
+++ b/app/static/translations/pl.json
@@ -139,7 +139,7 @@
   "toast_low_stock": "Niektóre produkty się kończą! Przejrzyj listę zakupów.",
   "toast_go_shopping": "Przejdź do listy zakupów",
   "toast_go_products": "Przejdź do produktów",
-  "toast_close": "Zamknij",
+  "close": "Zamknij",
   "notify_success_title": "Sukces",
   "notify_error_title": "Błąd",
   "retry": "Ponów",

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -35,7 +35,7 @@
         <i class="fa-solid fa-gear"></i>
     </button>
 </div>
-<div id="notification-container" class="toast toast-end top-auto bottom-[4.5rem] z-40"></div>
+<div id="notification-container" class="toast toast-end top-auto bottom-[4.5rem] z-40" aria-live="polite"></div>
 <div class="max-w-screen-lg mx-auto px-4 py-6 main-container">
     <div class="tabs tabs-bordered flex-nowrap overflow-x-auto whitespace-nowrap mb-6 desktop-nav">
         <a class="tab tab-active font-bold" data-tab-target="tab-products" data-i18n="tab_products">Produkty</a>
@@ -55,10 +55,10 @@
                         <option value="all" data-i18n="state_filter_all">Wszystkie</option>
                     </select>
                 </div>
-                <button id="view-toggle" class="btn btn-outline btn-primary btn-sm" data-i18n="change_view_toggle_grouped">Widok z podziałem</button>
-                <button id="edit-toggle" class="btn btn-outline btn-warning btn-sm" data-i18n="edit_mode_button_on">Edytuj</button>
-                <button id="save-btn" style="display:none;" class="btn btn-success btn-sm" data-i18n="save_button">Zapisz</button>
-                <button id="delete-selected" style="display:none;" class="btn btn-error btn-sm" disabled data-i18n="delete_selected_button">Usuń zaznaczone</button>
+                <button id="view-toggle" class="btn btn-outline btn-primary btn-sm" role="switch" aria-pressed="false" aria-label="Widok z podziałem" data-i18n="change_view_toggle_grouped">Widok z podziałem</button>
+                <button id="edit-toggle" class="btn btn-outline btn-warning btn-sm" role="switch" aria-pressed="false" aria-label="Edytuj" data-i18n="edit_mode_button_on">Edytuj</button>
+                <button id="save-btn" style="display:none;" class="btn btn-success btn-sm" aria-label="Zapisz" data-i18n="save_button">Zapisz</button>
+                <button id="delete-selected" style="display:none;" class="btn btn-error btn-sm" disabled aria-label="Usuń zaznaczone" data-i18n="delete_selected_button">Usuń zaznaczone</button>
             </div>
             <div class="overflow-x-auto">
                 <table id="product-table" class="table table-zebra table-fixed w-full">
@@ -93,8 +93,8 @@
                     <p class="py-4" data-i18n="delete_modal_question">Czy na pewno chcesz usunąć zaznaczone produkty?</p>
                     <div id="delete-summary" class="space-y-1"></div>
                     <div class="modal-action">
-                        <button id="confirm-delete" class="btn btn-error btn-sm" data-i18n="delete_confirm_button">Usuń</button>
-                        <button id="cancel-delete" class="btn btn-outline btn-sm" data-i18n="delete_cancel_button">Anuluj</button>
+                        <button id="confirm-delete" class="btn btn-error btn-sm" data-i18n="delete_confirm_button" aria-label="Usuń">Usuń</button>
+                        <button id="cancel-delete" class="btn btn-outline btn-sm" data-i18n="delete_cancel_button" aria-label="Anuluj">Anuluj</button>
                     </div>
                 </form>
             </dialog>
@@ -264,7 +264,7 @@
                         </div>
                     </div>
                     <div class="modal-action">
-                        <button id="history-detail-close" class="btn btn-sm" data-i18n="toast_close" aria-label="Close">Zamknij</button>
+                        <button id="history-detail-close" class="btn btn-sm" data-i18n="close" aria-label="Zamknij">Zamknij</button>
                     </div>
                 </div>
             </dialog>
@@ -365,8 +365,8 @@
                     <h3 class="font-bold text-lg" data-i18n="delete_modal_title">Potwierdź usunięcie</h3>
                     <p class="py-4" data-i18n="delete_item_question">Czy na pewno chcesz usunąć ten produkt?</p>
                     <div class="modal-action">
-                        <button id="confirm-remove-item" class="btn btn-error btn-sm" data-i18n="confirm_button">Potwierdź</button>
-                        <button class="btn btn-outline btn-sm" data-i18n="delete_cancel_button">Anuluj</button>
+                        <button id="confirm-remove-item" class="btn btn-error btn-sm" data-i18n="confirm_button" aria-label="Potwierdź">Potwierdź</button>
+                        <button class="btn btn-outline btn-sm" data-i18n="delete_cancel_button" aria-label="Anuluj">Anuluj</button>
                     </div>
                 </form>
             </dialog>


### PR DESCRIPTION
## Summary
- Add ARIA roles and labels for toggles and action buttons
- Support reduced motion and visible focus outlines
- Make toasts screen-reader friendly with polite announcements and translated close control

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68977ecc08c0832aaf77e702227e219f