### PR TITLE
Use modal for recipe details

### DIFF
--- a/app/static/js/components/recipe-detail.js
+++ b/app/static/js/components/recipe-detail.js
@@ -1,39 +1,86 @@
-import { state, t } from '../helpers.js';
+import { state, t, toggleFavorite } from '../helpers.js';
 
-export function renderRecipeDetail(r) {
-  const ing = (r.ingredients || []).map(i => {
+function renderRecipeDetail(r) {
+  const nameTr = t(r.name);
+  const title = nameTr && nameTr.trim() !== '' ? nameTr : r.name;
+
+  const meta = [];
+  if (r.time) {
+    meta.push(`<div class="flex items-center gap-1"><i class="fa-regular fa-clock"></i><span>${r.time}</span></div>`);
+  }
+  if (r.portions != null) {
+    meta.push(`<div class="flex items-center gap-1"><i class="fa-solid fa-users"></i><span>${r.portions}</span></div>`);
+  }
+  const metaHtml = meta.length ? `<div class="flex gap-4 text-sm mb-4">${meta.join('')}</div>` : '';
+
+  const ingRows = (r.ingredients || []).map(i => {
     const nameTr = t(i.product);
     const name = nameTr && nameTr.trim() !== '' ? nameTr : i.product;
     const qty = (i.quantity ?? '').toString();
     const unit = t(i.unit ?? '');
     const qtyStr = [qty, unit].filter(Boolean).join(' ');
-    if (state.displayMode === 'mobile') {
-      const mobileLine = [qtyStr, name].filter(Boolean).join(' – ');
-      return `<li class="ingredient-item bg-base-200/40 rounded px-2 py-1">${mobileLine}</li>`;
-    }
-    return `<li class="ingredient-item grid grid-cols-[1fr_auto] gap-4 items-center bg-base-200/40 rounded px-2 py-1">
-      <span class="ingredient-name">${name}</span>
-      <span class="ingredient-qty text-right">${qtyStr}</span>
-    </li>`;
+    return `<tr><td class="pr-4">${name}</td><td class="text-right">${qtyStr}</td></tr>`;
   }).join('');
 
-  const steps = (r.steps || []).map((s, idx) => `
-    <li class="step-item flex gap-2 p-3 bg-base-200/40 rounded">
-      <span class="font-bold">${idx + 1}.</span>
-      <span>${s}</span>
-    </li>
-  `).join('');
+  const steps = (r.steps || []).map(s => `<li class="mb-2">${s}</li>`).join('');
+
+  const favIcon = state.favoriteRecipes.has(r.name)
+    ? '<i class="fa-solid fa-heart"></i>'
+    : '<i class="fa-regular fa-heart"></i>';
 
   return `
-    <div class="space-y-6">
-      <section>
-        <h4 class="font-semibold mb-2">${t('recipe_ingredients_header')}</h4>
-        <ul class="ingredient-list space-y-1">${ing}</ul>
-      </section>
-      <section>
-        <h4 class="font-semibold mb-2">${t('recipe_steps_header')}</h4>
-        <ol class="step-list space-y-3">${steps}</ol>
-      </section>
+    <div class="flex justify-between items-start mb-4">
+      <h3 class="text-lg font-bold">${title}</h3>
+      <button id="recipe-detail-fav" class="btn btn-ghost btn-sm" type="button" aria-label="${t('checkbox_favorite_label')}">${favIcon}</button>
     </div>
+    ${metaHtml}
+    <section class="mb-4">
+      <h4 class="font-semibold mb-2">${t('recipe_ingredients_header')}</h4>
+      <table class="table w-full">
+        <tbody>${ingRows}</tbody>
+      </table>
+    </section>
+    <section>
+      <h4 class="font-semibold mb-2">${t('recipe_steps_header')}</h4>
+      <ol class="list-decimal pl-6 space-y-2">${steps}</ol>
+    </section>
   `;
 }
+
+export function openRecipeDetails(r) {
+  const modal = document.getElementById('recipe-detail-modal');
+  const content = modal?.querySelector('#recipe-detail-content');
+  if (!modal || !content) return;
+
+  content.innerHTML = renderRecipeDetail(r);
+
+  let favChanged = false;
+  const favBtn = content.querySelector('#recipe-detail-fav');
+  favBtn?.addEventListener('click', async () => {
+    favBtn.disabled = true;
+    const prev = favBtn.innerHTML;
+    favBtn.innerHTML = '<i class="fa-solid fa-spinner fa-spin"></i>';
+    try {
+      await toggleFavorite(r.name);
+      favBtn.innerHTML = state.favoriteRecipes.has(r.name)
+        ? '<i class="fa-solid fa-heart"></i>'
+        : '<i class="fa-regular fa-heart"></i>';
+      favChanged = true;
+    } catch (_) {
+      favBtn.innerHTML = prev;
+    } finally {
+      favBtn.disabled = false;
+    }
+  });
+
+  const onClose = () => {
+    if (favChanged) {
+      document.dispatchEvent(new Event('favorites-changed'));
+    }
+    modal.removeEventListener('close', onClose);
+  };
+  modal.addEventListener('close', onClose);
+
+  modal.showModal();
+}
+

--- a/app/static/js/components/recipe-list.js
+++ b/app/static/js/components/recipe-list.js
@@ -9,31 +9,13 @@ import {
   debounce
 } from '../helpers.js';
 import { toast } from './toast.js';
-import { renderRecipeDetail } from './recipe-detail.js';
+import { openRecipeDetails } from './recipe-detail.js';
 
 // CHANGELOG:
 // - Exposed ``loadRecipes`` without internal catch to allow caller-side retry/toast handling.
 // - Added defensive rendering and normalization of ingredient structures.
 // - Inline recipe details with expandable cards and single-shot event bindings.
 
-function getRecipeById(id) {
-  return state.recipesData.find(r => r.name === id);
-}
-
-document.addEventListener('click', async e => {
-  const btn = e.target.closest('.show-recipe');
-  if (!btn) return;
-  const id = btn.dataset.recipeId;
-  const panel = document.getElementById(`recipe-detail-${id}`);
-  if (!panel) return;
-  const open = panel.classList.toggle('hidden') === false;
-  btn.textContent = open ? t('recipe_hide_details') : t('recipe_show_details');
-  if (open && !panel.dataset.hydrated) {
-    const recipe = getRecipeById(id);
-    panel.innerHTML = renderRecipeDetail(recipe);
-    panel.dataset.hydrated = '1';
-  }
-});
 
 export function renderRecipes() {
   const list = document.getElementById('recipe-list');
@@ -143,14 +125,10 @@ export function renderRecipes() {
       }
       if (meta.children.length) body.appendChild(meta);
       const btn = document.createElement('button');
-      btn.className = 'btn btn-primary show-recipe';
-      btn.dataset.recipeId = r.name;
+      btn.className = 'btn btn-primary';
       btn.textContent = t('recipe_show_details');
-      const panel = document.createElement('div');
-      panel.id = `recipe-detail-${r.name}`;
-      panel.className = 'recipe-detail hidden';
+      btn.addEventListener('click', () => openRecipeDetails(r));
       body.appendChild(btn);
-      body.appendChild(panel);
       card.appendChild(body);
       frag.appendChild(card);
     });
@@ -196,6 +174,10 @@ export async function loadRecipes() {
     state.recipesLoading = false;
   }
 }
+
+document.addEventListener('favorites-changed', () => {
+  renderRecipes();
+});
 
 document.addEventListener('DOMContentLoaded', () => {
   const sortField = document.getElementById('recipe-sort-field');

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -396,6 +396,16 @@
         </div>
 
     </div>
+
+    <dialog id="recipe-detail-modal" class="modal">
+        <form method="dialog" class="modal-box max-w-2xl">
+            <div id="recipe-detail-content"></div>
+            <div class="modal-action">
+                <button class="btn" data-i18n="close">Zamknij</button>
+            </div>
+        </form>
+    </dialog>
+
     <nav class="mobile-nav fixed bottom-0 left-0 w-full z-50 bg-base-100 flex">
         <a class="tab tab-active font-bold flex flex-col items-center justify-center flex-1 py-3 px-2 border-r border-base-300" data-tab-target="tab-products">
             <i class="fa-solid fa-box text-xl"></i>


### PR DESCRIPTION
## Summary
- Remove inline recipe detail panels and add a modal-based `openRecipeDetails` helper
- Show recipe ingredients and steps in a structured modal with favorite toggling
- Include modal container in index template and refresh list on favorite change

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68978b439644832aaf9eab95157026f3