### PR TITLE
Refactor shopping list interactions and layout

### DIFF
--- a/app/static/styles.css
+++ b/app/static/styles.css
@@ -396,6 +396,7 @@ html[data-layout="mobile"] .touch-btn {
 .owned-info {
   font-size: 0.75rem;
   color: hsl(var(--bc));
+  white-space: nowrap;
 }
 
 /* JSON editor adjustments */


### PR DESCRIPTION
## Summary
- Incrementally insert new shopping items without re-rendering the full list
- Align cart row layout to separate columns and use native confirm for deletions
- Show owned quantities in suggestions next to the quantity stepper and switch to outline action icons
- Prevent owned info wrapping on small screens

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68978b498bfc832aab70e9d531e329da