### PR TITLE
Refresh list and show toast after adding product

### DIFF
--- a/app/static/script.js
+++ b/app/static/script.js
@@ -2,7 +2,7 @@ import { loadTranslations, loadUnits, loadFavorites, state, t, normalizeProduct,
 import { renderProducts, refreshProducts } from './js/components/product-table.js';
 import { renderRecipes, loadRecipes } from './js/components/recipe-list.js';
 import { renderShoppingList, addToShoppingList, renderSuggestions } from './js/components/shopping-list.js';
-import { showNotification, checkLowStockToast } from './js/components/toast.js';
+import { toast, showNotification, checkLowStockToast } from './js/components/toast.js';
 import { initReceiptImport } from './js/components/ocr-modal.js';
 
 // CHANGELOG:
@@ -249,8 +249,23 @@ function initAddForm() {
     try {
       await fetchJson('/api/products', { method: 'POST', body: payload });
       await fetchProducts();
+      renderProducts();
+      renderShoppingList();
       form.reset();
-      document.getElementById('product-search')?.focus();
+      syncSpiceUI();
+      nameInput.focus();
+      const container = document.getElementById('notification-container');
+      if (container) {
+        container.classList.remove('toast-end', 'top-auto', 'bottom-[4.5rem]');
+        container.classList.add('toast-center', 'top-[4.5rem]', 'bottom-auto');
+      }
+      toast.success(t('product_added'));
+      setTimeout(() => {
+        if (container) {
+          container.classList.remove('toast-center', 'top-[4.5rem]', 'bottom-auto');
+          container.classList.add('toast-end', 'top-auto', 'bottom-[4.5rem]');
+        }
+      }, 5000);
     } catch (err) {
       showNotification({ type: 'error', title: t('save_failed'), message: err.status || err.message });
     } finally {

--- a/app/static/translations/en.json
+++ b/app/static/translations/en.json
@@ -144,6 +144,7 @@
   "notify_error_title": "Error",
   "retry": "Retry",
   "manual_add_success": "Added to shopping list",
+  "product_added": "Product added",
   "product.toast_bread": "Toast bread",
   "product.eggs": "Eggs",
   "product.natural_tofu": "Natural tofu",

--- a/app/static/translations/pl.json
+++ b/app/static/translations/pl.json
@@ -144,6 +144,7 @@
   "notify_error_title": "Błąd",
   "retry": "Ponów",
   "manual_add_success": "Dodano do listy zakupów",
+  "product_added": "Dodano produkt",
   "product.toast_bread": "Pieczywo tostowe",
   "product.eggs": "Jajka",
   "product.natural_tofu": "Tofu naturalne",


### PR DESCRIPTION
## Summary
- Refresh products and shopping list after new product submission
- Clear add form and focus name input on success
- Display a translated success toast near the top of the page

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68978b4fc378832a8e42c51927abbb1a