### PR TITLE
Improve edit mode controls and cancel behaviour

### DIFF
--- a/app/static/script.js
+++ b/app/static/script.js
@@ -291,7 +291,6 @@ async function saveEdits() {
       body: updates
     });
     showNotification({ type: 'success', title: t('save_success') });
-    await refreshProducts();
     return true;
   } catch (err) {
     showNotification({ type: 'error', title: t('save_failed'), message: err.status || err.message });
@@ -346,6 +345,7 @@ document.addEventListener('DOMContentLoaded', async () => {
   const saveBtn = document.getElementById('save-btn');
   const deleteBtn = document.getElementById('delete-selected');
   const selectHeader = document.getElementById('select-header');
+  const addSection = document.getElementById('add-section');
   function enterEditMode() {
     APP.editBackup = JSON.parse(JSON.stringify(APP.state.products));
     APP.state.editing = true;
@@ -355,6 +355,7 @@ document.addEventListener('DOMContentLoaded', async () => {
     deleteBtn.disabled = true;
     deleteBtn.textContent = t('delete_selected_button');
     selectHeader.style.display = '';
+    if (addSection) addSection.style.display = '';
     renderProducts();
     updateAriaLabels();
   }
@@ -371,6 +372,7 @@ document.addEventListener('DOMContentLoaded', async () => {
     deleteBtn.disabled = true;
     deleteBtn.textContent = t('delete_selected_button');
     selectHeader.style.display = 'none';
+    if (addSection) addSection.style.display = 'none';
     renderProducts();
     updateAriaLabels();
   }
@@ -382,7 +384,10 @@ document.addEventListener('DOMContentLoaded', async () => {
 
   saveBtn?.addEventListener('click', async () => {
     const ok = await saveEdits();
-    if (ok) exitEditMode(false);
+    if (ok) {
+      await refreshProducts();
+      exitEditMode(false);
+    }
   });
 
   deleteBtn?.addEventListener('click', async () => {

--- a/app/static/translations/en.json
+++ b/app/static/translations/en.json
@@ -15,7 +15,7 @@
   "theme_light": "Light mode",
   "theme_dark": "Dark mode",
   "edit_mode_button_on": "Edit mode",
-  "edit_mode_button_off": "Cancel edit",
+  "edit_mode_button_off": "Cancel",
   "save_button": "Save",
   "delete_selected_button": "Delete selected",
   "table_header_name": "Name",

--- a/app/static/translations/pl.json
+++ b/app/static/translations/pl.json
@@ -15,7 +15,7 @@
   "theme_light": "Tryb jasny",
   "theme_dark": "Tryb ciemny",
   "edit_mode_button_on": "Tryb edycji",
-  "edit_mode_button_off": "Anuluj edycję",
+  "edit_mode_button_off": "Anuluj",
   "save_button": "Zapisz",
   "delete_selected_button": "Usuń zaznaczone",
   "table_header_name": "Nazwa",

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -56,7 +56,7 @@
                     </select>
                 </div>
                 <button id="view-toggle" class="btn btn-outline btn-primary btn-sm" role="switch" aria-pressed="false" aria-label="Widok z podziałem" data-i18n="change_view_toggle_grouped">Widok z podziałem</button>
-                <button id="edit-toggle" class="btn btn-outline btn-warning btn-sm" role="switch" aria-pressed="false" aria-label="Edytuj" data-i18n="edit_mode_button_on">Edytuj</button>
+                <button id="edit-toggle" class="btn btn-outline btn-warning btn-sm" role="switch" aria-pressed="false" aria-label="Tryb edycji" data-i18n="edit_mode_button_on">Tryb edycji</button>
                 <button id="save-btn" style="display:none;" class="btn btn-success btn-sm" aria-label="Zapisz" data-i18n="save_button">Zapisz</button>
                 <button id="delete-selected" style="display:none;" class="btn btn-error btn-sm" disabled aria-label="Usuń zaznaczone" data-i18n="delete_selected_button">Usuń zaznaczone</button>
             </div>
@@ -99,6 +99,7 @@
                 </form>
             </dialog>
 
+            <div id="add-section" style="display:none;">
             <hr class="border-t border-base-300 my-6">
 
             <h2 class="text-xl font-semibold mt-6 mb-4" data-i18n="heading_add_edit_product">Dodaj / edytuj produkt</h2>
@@ -144,8 +145,8 @@
                 </select>
                 <button type="submit" class="btn btn-success btn-sm w-full sm:col-span-2" data-i18n="save_button">Zapisz</button>
             </form>
-
             <hr class="border-t border-base-300 my-6">
+            </div>
 
             <h3 class="text-lg font-semibold mt-6 mb-2" data-i18n="heading_edit_json">Edytuj produkty (JSON)</h3>
             <textarea id="edit-json" rows="10" placeholder='JSON' data-i18n="edit_json_placeholder" class="textarea textarea-bordered w-full max-w-full mb-4 h-60 overflow-y-auto overflow-x-hidden resize-none p-4"></textarea>


### PR DESCRIPTION
## Summary
- Rename end-edit toggle to clear "Cancel" with proper translations
- Show add-product form, bulk delete, and steppers only while editing
- Save refreshes products and exits edit mode; switching view discards edits

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python -m json.tool app/static/translations/en.json | head -n 3`
- `python -m json.tool app/static/translations/pl.json | head -n 3`


------
https://chatgpt.com/codex/tasks/task_e_68978b565e14832a9efa57cd2f86097a