### PR TITLE
feat: unify stock highlighting

### DIFF
--- a/app/static/js/components/product-table.js
+++ b/app/static/js/components/product-table.js
@@ -106,10 +106,22 @@ function setCategoryUI(categorySection, open) {
   setHidden(body, !open);
 }
 function highlightRow(tr, p) {
-  tr.classList.remove('product-low', 'product-missing');
+  tr.classList.remove(
+    'text-warning',
+    'text-error',
+    'bg-warning/10',
+    'bg-error/10',
+    'opacity-60',
+    'font-semibold'
+  );
   const level = stockLevel(p);
-  if (level === 'low') tr.classList.add('product-low');
-  if (level === 'none') tr.classList.add('product-missing');
+  if (p.main) {
+    if (level === 'none') tr.classList.add('text-error', 'bg-error/10', 'font-semibold');
+    else if (level === 'low') tr.classList.add('text-warning', 'bg-warning/10');
+  } else {
+    if (level === 'none') tr.classList.add('text-error', 'bg-error/10', 'opacity-60');
+    else if (level === 'low') tr.classList.add('text-warning', 'bg-warning/10', 'opacity-60');
+  }
 }
 
 function adjustRow(tr, delta) {

--- a/app/static/js/helpers.js
+++ b/app/static/js/helpers.js
@@ -300,7 +300,10 @@ export function isSpice(p = {}) {
 
 export function stockLevel(p = {}) {
   if (isSpice(p)) {
-    return p.level || 'none';
+    const lvl = String(p.level || '').toLowerCase();
+    if (lvl === 'brak' || lvl === 'none') return 'none';
+    if (lvl === 'malo' || lvl === 'low') return 'low';
+    return 'ok';
   }
   if (p.quantity === 0) return 'none';
   if (p.threshold != null && p.quantity <= p.threshold) return 'low';
@@ -317,6 +320,7 @@ export function matchesFilter(p = {}, filter = 'all') {
     case 'missing':
       return level === 'none';
     default:
+      if (!p.main && p.quantity === 0) return false;
       return true;
   }
 }


### PR DESCRIPTION
## Summary
- map spice levels to standard stock states
- hide non-main zero stock in default product filters
- revamp row highlighting using class-based warning/error styles

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68978d620d90832abb2ac39063634468