### PR TITLE
refactor: consolidate frontend loading

### DIFF
--- a/app/static/js/components/ocr-modal.js
+++ b/app/static/js/components/ocr-modal.js
@@ -103,3 +103,6 @@ export async function handleReceiptUpload(file) {
     tableBody.appendChild(tr);
   });
 }
+
+window.initReceiptImport = initReceiptImport;
+window.handleReceiptUpload = handleReceiptUpload;

--- a/app/static/js/components/product-table.js
+++ b/app/static/js/components/product-table.js
@@ -21,7 +21,7 @@ import { toast } from './toast.js';
 const APP = (window.APP = window.APP || {});
 
 // --- delete selected handling (button state only; actual deletion handled in script.js)
-const deleteBtn = document.getElementById('delete-selected');
+let deleteBtn;
 
 function updateDeleteButton() {
   const selected = document.querySelectorAll('input.product-select:checked').length;
@@ -34,14 +34,16 @@ function updateDeleteButton() {
   }
 }
 
-document.addEventListener('change', e => {
-  if (e.target.matches('input.product-select')) updateDeleteButton();
-});
-
-document.addEventListener('click', (e) => {
-  if (e.target.closest('.qty-inc')) adjustRow(e.target.closest('tr'), 1);
-  if (e.target.closest('.qty-dec')) adjustRow(e.target.closest('tr'), -1);
-});
+export function bindProductEvents() {
+  deleteBtn = document.getElementById('delete-selected');
+  document.addEventListener('change', e => {
+    if (e.target.matches('input.product-select')) updateDeleteButton();
+  });
+  document.addEventListener('click', e => {
+    if (e.target.closest('.qty-inc')) adjustRow(e.target.closest('tr'), 1);
+    if (e.target.closest('.qty-dec')) adjustRow(e.target.closest('tr'), -1);
+  });
+}
 
 // --- expand/collapse state
 const expandedStorages = new Map(); // storageId -> true/false

--- a/app/static/js/components/recipe-list.js
+++ b/app/static/js/components/recipe-list.js
@@ -175,11 +175,11 @@ export async function loadRecipes() {
   }
 }
 
-document.addEventListener('favorites-changed', () => {
-  renderRecipes();
-});
+export function bindRecipeEvents() {
+  document.addEventListener('favorites-changed', () => {
+    renderRecipes();
+  });
 
-document.addEventListener('DOMContentLoaded', () => {
   const sortField = document.getElementById('recipe-sort-field');
   const sortAsc = document.getElementById('recipe-sort-dir-asc');
   const sortDesc = document.getElementById('recipe-sort-dir-desc');
@@ -249,4 +249,4 @@ document.addEventListener('DOMContentLoaded', () => {
   });
 
   updateSortButtons();
-});
+}

--- a/app/static/js/components/toast.js
+++ b/app/static/js/components/toast.js
@@ -64,6 +64,11 @@ export const toast = {
     createToast({ type: 'error', title, message, action })
 };
 
+export function showNotification({ type = 'info', title = '', message = '', action = null }) {
+  const fn = toast[type] || toast.info;
+  fn(title, message, action);
+}
+
 export function showLowStockToast(activateTab, renderSuggestions, renderShoppingList) {
   const container = document.getElementById('notification-container');
   if (!container) return;
@@ -152,3 +157,8 @@ export function showTopBanner(message, { actionLabel, onAction } = {}) {
   banner.appendChild(close);
   container.appendChild(banner);
 }
+
+window.toast = toast;
+window.showNotification = showNotification;
+window.checkLowStockToast = checkLowStockToast;
+window.showTopBanner = showTopBanner;

--- a/app/static/js/helpers.js
+++ b/app/static/js/helpers.js
@@ -4,6 +4,7 @@
 // - Single translation helper with English fallback.
 
 import { showTopBanner } from './components/toast.js';
+export { showTopBanner };
 
 export const CATEGORY_KEYS = {
   uncategorized: 'category_uncategorized',

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -14,6 +14,7 @@
     <link href="https://cdn.jsdelivr.net/npm/daisyui@4.10.2/dist/full.min.css" rel="stylesheet" type="text/css" />
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css">
     <link rel="stylesheet" href="{{ url_for('static', filename='styles.css') }}">
+    <script src="https://cdn.jsdelivr.net/npm/tesseract.js@2.1.5/dist/tesseract.min.js"></script>
 </head>
 <body class="min-h-screen bg-base-100">
 <div id="top-sentinel"></div>
@@ -428,20 +429,6 @@
             <span class="text-xs" data-i18n="tab_shopping">Lista zakupów</span>
         </a>
     </nav>
-    <script src="https://cdn.jsdelivr.net/npm/tesseract.js@2.1.5/dist/tesseract.min.js"></script>
-    <script type="module" src="{{ url_for('static', filename='script.js') }}"></script>
-    <script>
-    if ('serviceWorker' in navigator) {
-      let refreshing;
-      navigator.serviceWorker.addEventListener('controllerchange', () => {
-        if (refreshing) return;
-        refreshing = true;
-        window.location.reload();
-      });
-      window.addEventListener('load', () => {
-        navigator.serviceWorker.register('/service-worker.js');
-      });
-    }
-    </script>
+    <script type="module" src="/static/script.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- load all frontend components from a single ES module
- expose component event binders and global utilities for side-effect imports
- collapse template scripts to one script.js entry

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68979d820c98832aac9d0779e7016bb9