### PR TITLE
refactor: consolidate frontend boot

### DIFF
--- a/app/static/js/components/ocr-modal.js
+++ b/app/static/js/components/ocr-modal.js
@@ -1,4 +1,4 @@
-import { t, state, fetchJson } from '../helpers.js';
+import { t, state, fetchJSON } from '../helpers.js';
 import { addToShoppingList, renderShoppingList } from './shopping-list.js';
 import { toast } from './toast.js';
 
@@ -38,11 +38,12 @@ export async function handleReceiptUpload(file) {
   const tableBody = document.querySelector('#receipt-table tbody');
   if (!modal || !tableBody || !file) return;
   if (!modal.open) modal.showModal();
+  const { default: Tesseract } = await import('https://cdn.jsdelivr.net/npm/tesseract.js@2.1.5/dist/tesseract.esm.min.js');
   const { data: { text } } = await Tesseract.recognize(file, state.currentLang === 'pl' ? 'pol' : 'eng');
   const lines = text.split('\n').map(l => l.trim()).filter(l => l);
   let data;
   try {
-    data = await fetchJson('/api/ocr-match', {
+    data = await fetchJSON('/api/ocr-match', {
       method: 'POST',
       body: { items: lines }
     });
@@ -103,6 +104,3 @@ export async function handleReceiptUpload(file) {
     tableBody.appendChild(tr);
   });
 }
-
-window.initReceiptImport = initReceiptImport;
-window.handleReceiptUpload = handleReceiptUpload;

--- a/app/static/js/components/toast.js
+++ b/app/static/js/components/toast.js
@@ -157,8 +157,3 @@ export function showTopBanner(message, { actionLabel, onAction } = {}) {
   banner.appendChild(close);
   container.appendChild(banner);
 }
-
-window.toast = toast;
-window.showNotification = showNotification;
-window.checkLowStockToast = checkLowStockToast;
-window.showTopBanner = showTopBanner;

--- a/app/static/script.js
+++ b/app/static/script.js
@@ -1,14 +1,23 @@
 // FIX: Render & responsive boot (2025-08-09)
-import { t, fetchJSON, showTopBanner } from './js/helpers.js';
-import { loadTranslations, loadUnits, loadFavorites, state, normalizeProduct, applyTranslations, isSpice, debounce } from './js/helpers.js';
+import {
+  t,
+  fetchJSON,
+  showTopBanner,
+  loadTranslations,
+  loadUnits,
+  loadFavorites,
+  state,
+  normalizeProduct,
+  applyTranslations,
+  isSpice,
+  debounce
+} from './js/helpers.js';
 import * as ProductTable from './js/components/product-table.js';
 import * as Shopping from './js/components/shopping-list.js';
 import * as Recipes from './js/components/recipe-list.js';
+import { initReceiptImport } from './js/components/ocr-modal.js';
+import { toast, showNotification, checkLowStockToast } from './js/components/toast.js';
 import './js/components/recipe-detail.js';
-import './js/components/ocr-modal.js';
-import './js/components/toast.js';
-
-const { toast, showNotification, checkLowStockToast, initReceiptImport } = window;
 
 window.__BOOT_TRACE = [];
 function trace(p){
@@ -291,7 +300,7 @@ function initAddForm() {
     }
     submitBtn.disabled = true;
     try {
-      await fetchJson('/api/products', { method: 'POST', body: payload });
+      await fetchJSON('/api/products', { method: 'POST', body: payload });
       await loadProducts();
       ProductTable.renderProducts();
       Shopping.renderShoppingList();
@@ -345,7 +354,7 @@ async function saveEdits() {
   const btn = document.getElementById('save-btn');
   btn.disabled = true;
   try {
-    await fetchJson('/api/products', {
+    await fetchJSON('/api/products', {
       method: 'PUT',
       body: updates
     });

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -14,7 +14,6 @@
     <link href="https://cdn.jsdelivr.net/npm/daisyui@4.10.2/dist/full.min.css" rel="stylesheet" type="text/css" />
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css">
     <link rel="stylesheet" href="{{ url_for('static', filename='styles.css') }}">
-    <script src="https://cdn.jsdelivr.net/npm/tesseract.js@2.1.5/dist/tesseract.min.js"></script>
 </head>
 <body class="min-h-screen bg-base-100">
 <div id="top-sentinel"></div>


### PR DESCRIPTION
## Summary
- Load all frontend modules from a single entry script and remove inline component scripts
- Export component functions and toast utilities for controlled boot sequencing
- Lazy-load Tesseract for OCR to defer heavy work until needed

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6897a56897e4832ab3138d9ad7ef2db3