### PR TITLE
Refactor Flask app to application factory and fix imports

### DIFF
--- a/README_DEV.md
+++ b/README_DEV.md
@@ -1,5 +1,13 @@
 # Developer Notes
 
+## Uruchom serwer / Run server
+
+From the project root run the development server with:
+
+```
+flask --app app:create_app run
+```
+
 ## Data Models
 
 ### products.json
@@ -38,3 +46,9 @@ Use `/api/validate` to view counts and the first five warnings for each dataset.
 - Frontend layout still needs fine‑tuning for narrow screens.
 - History view is minimal and lacks editing features.
 - Validation only reports first five warnings per dataset.
+
+## UI Labels (PL/EN)
+- Uruchom serwer / Run server
+- Aplikacja / Application
+- Błąd / Error
+- Start / Start

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,0 +1,14 @@
+from flask import Flask
+
+
+def create_app() -> Flask:
+    """Application factory for the Food project."""
+    app = Flask(__name__, static_folder="static", template_folder="templates")
+
+    from .routes import bp, run_initial_validation
+
+    app.register_blueprint(bp)
+    run_initial_validation()
+
+    return app
+


### PR DESCRIPTION
## Summary
- convert project to Flask application factory with `create_app`
- move routes into a blueprint module and validate data on startup
- update README with new `flask --app app:create_app run` instructions and UI label translations

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python -m flake8 app` *(fails: No module named flake8, installation blocked by proxy)*
- `pytest`
- `flask --app app:create_app routes`


------
https://chatgpt.com/codex/tasks/task_e_6898e5a2a97c832a9a3e0fde59b2d1e2