### PR TITLE
feat: expose product search endpoint and translations

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -20,6 +20,7 @@ from .utils import (
     file_lock,
     save_json,
 )
+from .search import search_products
 
 """Flask application providing basic CRUD APIs for a pantry manager."""
 
@@ -199,6 +200,19 @@ def domain():
         logger.info(str(exc))
         return jsonify({"error": str(exc)}), 500
     return jsonify(data)
+
+
+@bp.route("/api/search")
+def search():
+    """Search products in the domain using query and locale."""
+    query = request.args.get("q", "")
+    locale = request.args.get("locale", "pl")
+    try:
+        results = search_products(query, locale)
+    except ValueError as exc:
+        logger.info(str(exc))
+        return jsonify({"error": str(exc)}), 400
+    return jsonify(results)
 
 @bp.route("/api/products", methods=["GET", "POST", "PUT"])
 def products():

--- a/app/static/js/helpers.js
+++ b/app/static/js/helpers.js
@@ -252,6 +252,10 @@ export function getProduct(id) {
 }
 
 export function productName(id) {
+  if (!id) {
+    console.warn('Missing product id');
+    return t('unknown');
+  }
   const p = resolveProduct(id);
   if (!p) {
     console.warn('Unknown product', id);
@@ -276,6 +280,18 @@ export function unitName(id) {
     return t('unknown');
   }
   return u.names[state.currentLang] ?? u.names.en ?? t('unknown');
+}
+
+export async function searchProducts(query) {
+  if (!query) return [];
+  try {
+    const locale = state.currentLang || 'pl';
+    const res = await fetchJson(`/api/search?q=${encodeURIComponent(query)}&locale=${locale}`);
+    return Array.isArray(res) ? res : [];
+  } catch (err) {
+    console.error('searchProducts failed', err);
+    return [];
+  }
 }
 
 export async function loadFavorites() {

--- a/app/static/translations/en.json
+++ b/app/static/translations/en.json
@@ -40,6 +40,7 @@
   "unknown": "Unknown",
   "name_label": "Name",
   "select_product": "Select product",
+  "search_products": "Search products",
   "edit": "Edit",
   "edit_json_placeholder": "JSON",
   "edit_json_submit_button": "Submit JSON",

--- a/app/static/translations/pl.json
+++ b/app/static/translations/pl.json
@@ -40,6 +40,7 @@
   "unknown": "Nieznane",
   "name_label": "Nazwa",
   "select_product": "Wybierz produkt",
+  "search_products": "Szukaj produktów",
   "edit": "Edytuj",
   "edit_json_placeholder": "JSON",
   "edit_json_submit_button": "Wyślij JSON",


### PR DESCRIPTION
## Summary
- add `/api/search` endpoint backed by `search_products`
- expose frontend helper for product lookup with graceful missing-id fallback
- localize "Search products" label in EN/PL translations

## Testing
- `pytest`
- `pre-commit run --files app/static/translations/en.json app/static/translations/pl.json` *(failed: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_6899105b45a8832a93eab37ec51b960e