### PR TITLE
feat: add legacy recipes adapter

### DIFF
--- a/tests/test_recipes_adapter.py
+++ b/tests/test_recipes_adapter.py
@@ -1,0 +1,17 @@
+import os
+import sys
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from app import create_app
+
+
+def test_recipes_endpoint_returns_mapped_items():
+    app = create_app()
+    client = app.test_client()
+    resp = client.get('/api/recipes')
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert isinstance(data, list)
+    assert len(data) > 0
+    assert any(len(r.get('ingredients', [])) >= 1 for r in data)


### PR DESCRIPTION
## Summary
- adapt `/api/recipes` to legacy format and resolve product/unit names
- provide minimal test to ensure recipes include ingredients

## Testing
- `pre-commit run --files app/routes.py tests/test_recipes_adapter.py` *(fails: command not found)*
- `pip install pre-commit` *(fails: Could not connect to proxy)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689912d36f24832a955e811091df692a