### PR TITLE
refactor: unify fetch helper with toast errors

### DIFF
--- a/app/static/js/components/ocr-modal.js
+++ b/app/static/js/components/ocr-modal.js
@@ -1,4 +1,4 @@
-import { t, state, fetchJSON, productName } from '../helpers.js';
+import { t, state, fetchJson, productName } from '../helpers.js';
 import { addToShoppingList, renderShoppingList } from './shopping-list.js';
 import { toast } from './toast.js';
 
@@ -43,7 +43,7 @@ export async function handleReceiptUpload(file) {
   const lines = text.split('\n').map(l => l.trim()).filter(l => l);
   let data;
   try {
-    data = await fetchJSON('/api/ocr-match', {
+    data = await fetchJson('/api/ocr-match', {
       method: 'POST',
       body: { items: lines }
     });

--- a/app/static/js/components/product-table.js
+++ b/app/static/js/components/product-table.js
@@ -10,7 +10,7 @@ import {
   matchesFilter,
   stockLevel,
   normalizeProduct,
-  fetchJSON,
+  fetchJson,
   isSpice,
   debounce,
   dlog,
@@ -212,7 +212,7 @@ function buildQtyCell(p, tr) {
 
 export async function refreshProducts() {
   try {
-    const data = await fetchJSON('/api/products');
+    const data = await fetchJson('/api/products');
     APP.state.products = data.map(normalizeProduct);
     renderProducts();
   } catch (err) {
@@ -222,7 +222,7 @@ export async function refreshProducts() {
 
 export async function saveProduct(payload) {
   try {
-    await fetchJSON('/api/products', {
+    await fetchJson('/api/products', {
       method: 'POST',
       body: payload
     });

--- a/app/static/js/components/shopping-list.js
+++ b/app/static/js/components/shopping-list.js
@@ -1,5 +1,5 @@
 // FIX: Render & responsive boot (2025-08-09)
-import { t, state, isSpice, stockLevel, fetchJSON, debounce, productName } from '../helpers.js';
+import { t, state, isSpice, stockLevel, fetchJson, debounce, productName } from '../helpers.js';
 import { toast } from './toast.js';
 
 function saveShoppingList() {
@@ -144,7 +144,7 @@ function renderShoppingItem(item, idx) {
     if (item.inCart && stock && isSpice(stock)) {
       cartBtn.innerHTML = '<i class="fa-solid fa-spinner fa-spin"></i>';
       try {
-        await fetchJSON('/api/products', { method: 'POST', body: { ...stock, level: 'high', quantity: 0 } });
+        await fetchJson('/api/products', { method: 'POST', body: { ...stock, level: 'high', quantity: 0 } });
         stock.level = 'high';
       } catch (err) {
         toast.error(t('notify_error_title'), err.message);

--- a/app/static/script.js
+++ b/app/static/script.js
@@ -1,7 +1,7 @@
 // FIX: Render & responsive boot (2025-08-09)
 import {
   t,
-  fetchJSON,
+  fetchJson,
   showTopBanner,
   loadTranslations,
   loadDomain,
@@ -49,7 +49,7 @@ APP.editBackup = APP.editBackup || null;
 async function loadProducts() {
   trace('loadProducts:enter');
   try {
-    const data = await fetchJSON('/api/products');
+    const data = await fetchJson('/api/products');
     APP.state.products = Array.isArray(data) ? data.map(normalizeProduct) : [];
     ProductTable.renderProducts();
     Shopping.renderSuggestions();
@@ -81,7 +81,7 @@ async function loadRecipes() {
 async function loadHistory() {
   trace('loadHistory:enter');
   try {
-    state.historyData = await fetchJSON('/api/history');
+    state.historyData = await fetchJson('/api/history');
     trace('loadHistory:ok');
   } catch (e) {
     console.error(e);
@@ -92,7 +92,7 @@ async function loadHistory() {
 
 async function checkHealth() {
   try {
-    await fetchJSON('/api/health');
+    await fetchJson('/api/health');
     return true;
   } catch (err) {
     const banner = document.getElementById('health-banner');
@@ -300,7 +300,7 @@ function initAddForm() {
     }
     submitBtn.disabled = true;
     try {
-      await fetchJSON('/api/products', { method: 'POST', body: payload });
+      await fetchJson('/api/products', { method: 'POST', body: payload });
       await loadProducts();
       ProductTable.renderProducts();
       Shopping.renderShoppingList();
@@ -354,7 +354,7 @@ async function saveEdits() {
   const btn = document.getElementById('save-btn');
   btn.disabled = true;
   try {
-    await fetchJSON('/api/products', {
+    await fetchJson('/api/products', {
       method: 'PUT',
       body: updates
     });
@@ -456,7 +456,7 @@ function initNavigationAndEvents() {
     deleteBtn.disabled = true;
     try {
       await Promise.allSettled(
-        names.map(n => fetchJSON(`/api/products/${encodeURIComponent(n)}`, { method: 'DELETE' }))
+        names.map(n => fetchJson(`/api/products/${encodeURIComponent(n)}`, { method: 'DELETE' }))
       );
       await loadProducts();
       exitEditMode(false);


### PR DESCRIPTION
## Summary
- add JSDoc typedefs for Product, Recipe, and Ingredient
- replace `fetchJSON` with `fetchJson` and show toast on errors with optional traceId
- update front-end modules to use the new fetch helper

## Testing
- `pytest`
- `pip install pre-commit` *(fails: Could not connect to proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6899142c2de4832a97ae575453cb8af3