### PR TITLE
Add logging summaries and domain endpoint test

### DIFF
--- a/tests/test_domain_endpoint.py
+++ b/tests/test_domain_endpoint.py
@@ -1,0 +1,17 @@
+import os
+import sys
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from app import create_app
+
+
+def test_domain_endpoint_returns_data():
+    app = create_app()
+    client = app.test_client()
+    resp = client.get("/api/domain")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert isinstance(data, dict)
+    assert "products" in data and "categories" in data and "units" in data
+    assert len(data["products"]) > 0


### PR DESCRIPTION
## Summary
- log counts and first IDs for domain, products and recipes endpoints
- return trace IDs on adapter load failures
- add smoke test for `/api/domain`

## Testing
- `black --check app/routes.py tests/test_domain_endpoint.py`
- `pytest tests/test_domain_endpoint.py tests/test_products_adapter.py tests/test_recipes_adapter.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689916edf624832a9466d16e55f1f549