### PR TITLE
Fix products table rendering and filters

### DIFF
--- a/app/static/script.js
+++ b/app/static/script.js
@@ -38,7 +38,7 @@ const APP = window.APP;
 APP.state = APP.state || {
   products: [],
   view: 'flat',
-  filter: 'available',
+  filter: 'all',
   search: '',
   editing: false
 };
@@ -124,12 +124,12 @@ function registerServiceWorker() {
 }
 
 function resetProductFilters() {
-  APP.state.filter = 'available';
+  APP.state.filter = 'all';
   APP.state.search = '';
   const sel = document.getElementById('state-filter');
-  if (sel) sel.value = 'available';
+  if (sel) sel.value = 'all';
   const selMobile = document.getElementById('state-filter-mobile');
-  if (selMobile) selMobile.value = 'available';
+  if (selMobile) selMobile.value = 'all';
   const search = document.getElementById('product-search');
   if (search) search.value = '';
   const searchMobile = document.getElementById('product-search-mobile');


### PR DESCRIPTION
## Summary
- Rework product normalization and filter logic to handle missing quantities and retain IDs
- Render products only after domain data loads and add render debugging info
- Default product filters to All and clear searches on load

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689918bbe5a4832a8ae1c074e34358d4