### PR TITLE
feat: add persistent theme switch

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -250,9 +250,12 @@ def remove_used_products(used_ingredients):
         safe_write(PRODUCTS_PATH, products)
 
 
+APP_VERSION = "2"
+
+
 @bp.route("/")
 def index():
-    return render_template("index.html")
+    return render_template("index.html", app_version=APP_VERSION)
 
 
 @bp.route("/manifest.json")

--- a/app/static/script.js
+++ b/app/static/script.js
@@ -399,6 +399,25 @@ function initNavigationAndEvents() {
     window.scrollTo(0, scroll);
   });
 
+  const themeBtn = document.getElementById('theme-toggle');
+  const themeIcon = document.getElementById('theme-icon');
+  function updateThemeUI() {
+    const current = localStorage.getItem('theme') || 'system';
+    const icons = { light: 'fa-sun', dark: 'fa-moon', system: 'fa-desktop' };
+    if (themeIcon) {
+      themeIcon.className = `fa-solid ${icons[current]}`;
+    }
+    themeBtn?.setAttribute('aria-label', `Theme: ${current}`);
+  }
+  themeBtn?.addEventListener('click', () => {
+    const current = localStorage.getItem('theme') || 'system';
+    const order = ['light', 'dark', 'system'];
+    const next = order[(order.indexOf(current) + 1) % order.length];
+    window.setTheme(next);
+    updateThemeUI();
+  });
+  updateThemeUI();
+
   const editBtn = document.getElementById('edit-toggle');
   const saveBtn = document.getElementById('save-btn');
   const deleteBtn = document.getElementById('delete-selected');

--- a/app/static/service-worker.js
+++ b/app/static/service-worker.js
@@ -1,12 +1,12 @@
-const CACHE_VERSION = 'v1';
-const CACHE_NAME = `food-cache-${CACHE_VERSION}`;
+const APP_VERSION = '2';
+const CACHE_NAME = `food-cache-${APP_VERSION}`;
 const OFFLINE_URL = '/offline';
 const OFFLINE_HTML = `<!DOCTYPE html><html lang="en"><head><meta charset="utf-8"><title>Offline</title></head><body><h1>You're offline</h1></body></html>`;
 
 const PRECACHE_URLS = [
   '/',
-  '/static/styles.css',
-  '/static/script.js',
+  `/static/styles.css?v=${APP_VERSION}`,
+  `/static/script.js?v=${APP_VERSION}`,
   '/api/ui/en',
   '/api/ui/pl',
   '/static/icons/icon-192x192.png',

--- a/app/static/styles.css
+++ b/app/static/styles.css
@@ -1,5 +1,13 @@
 /* FIX: Render & responsive boot (2025-08-09) */
 
+html[data-theme='light'] {
+  color-scheme: light;
+}
+
+html[data-theme='dark'] {
+  color-scheme: dark;
+}
+
 #top-sentinel {
   height: 3rem;
 }
@@ -410,8 +418,12 @@ html[data-layout="mobile"] #edit-json {
   padding: 6px 0;
 }
 
-.ingredient-list li:not(:last-child) {
+html[data-theme='dark'] .ingredient-list li:not(:last-child) {
   border-bottom: 1px dashed rgba(255, 255, 255, 0.08);
+}
+
+html[data-theme='light'] .ingredient-list li:not(:last-child) {
+  border-bottom: 1px dashed rgba(0, 0, 0, 0.08);
 }
 
 @media (min-width: 769px) {

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -1,7 +1,7 @@
 <!doctype html>
 <!-- FIX: Render & responsive boot (2025-08-09) -->
-<html lang="pl" data-theme="dark" data-layout="desktop">
-<head>
+<html lang="pl" data-layout="desktop">
+  <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Food App</title>
@@ -11,10 +11,39 @@
     <meta name="apple-mobile-web-app-capable" content="yes">
     <meta name="apple-mobile-web-app-status-bar-style" content="default">
     <meta name="apple-mobile-web-app-title" content="Food App">
-    <link href="https://cdn.jsdelivr.net/npm/daisyui@4.10.2/dist/full.min.css" rel="stylesheet" type="text/css" />
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css">
-    <link rel="stylesheet" href="{{ url_for('static', filename='styles.css') }}">
-</head>
+      <script>
+        (() => {
+          const key = 'theme';
+          const mql = window.matchMedia('(prefers-color-scheme: dark)');
+          const apply = t => {
+            document.documentElement.setAttribute('data-theme', t);
+            document.documentElement.style.colorScheme = t;
+          };
+          const resolve = () => {
+            const stored = localStorage.getItem(key) || 'system';
+            return stored === 'system' ? (mql.matches ? 'dark' : 'light') : stored;
+          };
+          apply(resolve());
+          console.info('theme:', resolve());
+          mql.addEventListener('change', e => {
+            if ((localStorage.getItem(key) || 'system') === 'system') {
+              const t = e.matches ? 'dark' : 'light';
+              apply(t);
+              console.info('theme:', t);
+            }
+          });
+          window.setTheme = v => {
+            localStorage.setItem(key, v);
+            const t = v === 'system' ? (mql.matches ? 'dark' : 'light') : v;
+            apply(t);
+            console.info('theme:', t);
+          };
+        })();
+      </script>
+      <link href="https://cdn.jsdelivr.net/npm/daisyui@4.10.2/dist/full.min.css" rel="stylesheet" type="text/css" />
+      <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css">
+      <link rel="stylesheet" href="{{ url_for('static', filename='styles.css') }}?v={{ app_version }}">
+      </head>
 <body class="min-h-screen bg-base-100">
 <div id="top-sentinel"></div>
 <div id="health-banner" class="alert alert-error hidden justify-between">
@@ -26,9 +55,9 @@
         <i id="layout-icon" class="fa-solid fa-mobile-screen-button"></i>
     </button>
     <button id="lang-toggle" aria-label="Toggle language" class="text-xl p-2 bg-transparent border-0">PL</button>
-    <button id="theme-toggle" aria-label="Toggle theme" class="text-xl p-2 bg-transparent border-0">
-        <i id="theme-icon" class="fa-solid fa-circle-half-stroke"></i>
-    </button>
+      <button id="theme-toggle" aria-label="Toggle theme" class="text-xl p-2 bg-transparent border-0">
+          <i id="theme-icon" class="fa-solid fa-desktop"></i>
+      </button>
     <button id="install-btn" aria-label="Install app" class="text-xl p-2 bg-transparent border-0" style="display:none;">
         <i class="fa-solid fa-download"></i>
     </button>
@@ -428,6 +457,6 @@
             <span class="text-xs" data-i18n="tab_shopping">Lista zakupów</span>
         </a>
     </nav>
-    <script type="module" src="/static/script.js"></script>
+      <script type="module" src="/static/script.js?v={{ app_version }}"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- support light, dark, and system themes with persistence in `localStorage`
- add theme icons/ARIA updates and auto-detect system changes
- version static assets and caches to bust outdated resources

## Testing
- `pytest`
- `pre-commit run --files app/templates/index.html app/static/script.js app/static/styles.css app/static/service-worker.js app/routes.py` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68991c7b62a0832a888f724c8827fbdd