### PR TITLE
feat: consolidate domain boot and wait on ready event

### DIFF
--- a/app/static/js/components/product-table.js
+++ b/app/static/js/components/product-table.js
@@ -349,7 +349,7 @@ function createFlatRow(p, idx, editable) {
 
 export function renderProducts() {
   if (!state.domainLoaded) {
-    document.addEventListener('domain-loaded', () => renderProducts(), { once: true });
+    document.addEventListener('domain:ready', () => renderProducts(), { once: true });
     return;
   }
   const {
@@ -578,9 +578,6 @@ export function renderProducts() {
   });
 }
 
-document.addEventListener('domain-loaded', () => {
-  if (APP.state?.products?.length) renderProducts();
-});
 
 function attachCollapses(root) {
   if (!root) return;
@@ -636,4 +633,17 @@ const groupedRoot = document.getElementById('products-by-category');
 if (groupedRoot) {
   initExpandDefaults(groupedRoot);
   attachCollapses(groupedRoot);
+}
+
+// Wait for domain data before initial render to avoid race conditions.
+if (window.__domain) {
+  renderProducts();
+} else {
+  document.addEventListener(
+    'domain:ready',
+    () => {
+      renderProducts();
+    },
+    { once: true }
+  );
 }

--- a/app/static/js/components/recipe-list.js
+++ b/app/static/js/components/recipe-list.js
@@ -251,3 +251,16 @@ export function bindRecipeEvents() {
 
   updateSortButtons();
 }
+
+// Render recipe list once the domain data is ready.
+if (window.__domain) {
+  renderRecipes();
+} else {
+  document.addEventListener(
+    'domain:ready',
+    () => {
+      renderRecipes();
+    },
+    { once: true }
+  );
+}

--- a/app/static/script.js
+++ b/app/static/script.js
@@ -573,10 +573,6 @@ async function boot() {
   trace('favorites');
   await loadHistory();
   trace('history');
-  await loadProducts();
-  trace('products');
-  await loadRecipes();
-  trace('recipes');
   initNavigationAndEvents();
   trace('events');
   initialRender();


### PR DESCRIPTION
## Summary
- Fetch `/api/domain` once, store payload globally, and emit a `domain:ready` event with product and recipe counts
- Delay product table and recipe list rendering until the `domain:ready` signal
- Simplify boot sequence to rely on the single domain call for initial state

## Testing
- `pre-commit run --files app/static/js/helpers.js app/static/js/components/product-table.js app/static/js/components/recipe-list.js app/static/script.js` *(fails: command not found)*
- `pip install pre-commit` *(fails: Could not find a version that satisfies the requirement pre-commit)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68991f48b204832aa251c849b6241e3f