### PR TITLE
feat: serve normalized recipes with localized names

### DIFF
--- a/app/static/js/components/recipe-detail.js
+++ b/app/static/js/components/recipe-detail.js
@@ -1,23 +1,22 @@
 import { state, t, toggleFavorite, productName, unitName } from '../helpers.js';
 
 function renderRecipeDetail(r) {
-  const nameTr = t(r.name);
-  const title = nameTr && nameTr.trim() !== '' ? nameTr : r.name;
+  const title = r.names?.[state.currentLang] || r.names?.en || r.id;
 
   const meta = [];
   if (r.time) {
     meta.push(`<div class="flex items-center gap-1"><i class="fa-regular fa-clock"></i><span>${r.time}</span></div>`);
   }
-  if (r.portions != null) {
-    meta.push(`<div class="flex items-center gap-1"><i class="fa-solid fa-users"></i><span>${r.portions}</span></div>`);
+  if (r.servings != null) {
+    meta.push(`<div class="flex items-center gap-1"><i class="fa-solid fa-users"></i><span>${r.servings}</span></div>`);
   }
   const metaHtml = meta.length ? `<div class="flex gap-4 text-sm mb-4">${meta.join('')}</div>` : '';
 
   const ingRows = (r.ingredients || [])
     .map(i => {
-      const name = productName(i.product);
-      const qty = (i.quantity ?? '').toString();
-      const unit = i.unit ? unitName(i.unit) : '';
+      const name = i.productName || productName(i.productId) || t('unknown');
+      const qty = (i.qty ?? '').toString();
+      const unit = i.unitName || (i.unitId ? unitName(i.unitId) : '');
       const qtyStr = [qty, unit].filter(Boolean).join(' ');
       const unknown = name === t('unknown') ? ' opacity-60' : '';
       return `<tr><td class="pr-4${unknown}">${name}</td><td class="text-right">${qtyStr}</td></tr>`;
@@ -26,7 +25,7 @@ function renderRecipeDetail(r) {
 
   const steps = (r.steps || []).map(s => `<li class="mb-2">${s}</li>`).join('');
 
-  const favIcon = state.favoriteRecipes.has(r.name)
+  const favIcon = state.favoriteRecipes.has(r.id)
     ? '<i class="fa-solid fa-heart"></i>'
     : '<i class="fa-regular fa-heart"></i>';
 
@@ -63,8 +62,8 @@ export function openRecipeDetails(r) {
     const prev = favBtn.innerHTML;
     favBtn.innerHTML = '<i class="fa-solid fa-spinner fa-spin"></i>';
     try {
-      await toggleFavorite(r.name);
-      favBtn.innerHTML = state.favoriteRecipes.has(r.name)
+      await toggleFavorite(r.id);
+      favBtn.innerHTML = state.favoriteRecipes.has(r.id)
         ? '<i class="fa-solid fa-heart"></i>'
         : '<i class="fa-regular fa-heart"></i>';
       favChanged = true;
@@ -85,4 +84,3 @@ export function openRecipeDetails(r) {
 
   modal.showModal();
 }
-

--- a/app/static/js/helpers.js
+++ b/app/static/js/helpers.js
@@ -90,7 +90,7 @@ export const state = {
   favoriteRecipes: new Set(storedFavs),
   currentLang: localStorage.getItem('lang') || 'pl',
   uiTranslations: { pl: {}, en: {} },
-  domain: { products: {}, categories: {}, units: {}, aliases: {} },
+  domain: { products: {}, categories: {}, units: {}, aliases: {}, recipes: [] },
   units: {},
   lowStockToastShown: false
 };
@@ -263,7 +263,7 @@ export async function loadDomain() {
     const data = await fetchJson('/api/domain');
     window.__domain = data;
     const domainData = data.domain || data;
-    state.domain = { products: {}, categories: {}, units: {}, aliases: {} };
+    state.domain = { products: {}, categories: {}, units: {}, aliases: {}, recipes: [] };
     (domainData.products || []).forEach(p => {
       state.domain.products[p.id] = p;
       (p.aliases || []).forEach(a => {
@@ -300,7 +300,7 @@ export async function loadDomain() {
     window.trace?.('loadDomain:ok');
   } catch (err) {
     console.error('Failed to load domain', err);
-    state.domain = { products: {}, categories: {}, units: {}, aliases: {} };
+    state.domain = { products: {}, categories: {}, units: {}, aliases: {}, recipes: [] };
     showTopBanner('Failed to load domain', {
       actionLabel: t('retry'),
       onAction: loadDomain
@@ -383,13 +383,13 @@ export async function loadFavorites() {
   }
 }
 
-export async function toggleFavorite(name) {
-  if (!name) throw new Error('invalid name');
-  const had = state.favoriteRecipes.has(name);
+export async function toggleFavorite(id) {
+  if (!id) throw new Error('invalid id');
+  const had = state.favoriteRecipes.has(id);
   if (had) {
-    state.favoriteRecipes.delete(name);
+    state.favoriteRecipes.delete(id);
   } else {
-    state.favoriteRecipes.add(name);
+    state.favoriteRecipes.add(id);
   }
   const arr = Array.from(state.favoriteRecipes);
   localStorage.setItem('favoriteRecipes', JSON.stringify(arr));
@@ -400,8 +400,8 @@ export async function toggleFavorite(name) {
     });
   } catch (err) {
     // revert change on failure
-    if (had) state.favoriteRecipes.add(name);
-    else state.favoriteRecipes.delete(name);
+    if (had) state.favoriteRecipes.add(id);
+    else state.favoriteRecipes.delete(id);
     localStorage.setItem('favoriteRecipes', JSON.stringify(Array.from(state.favoriteRecipes)));
     throw err;
   }

--- a/tests/test_recipes_adapter.py
+++ b/tests/test_recipes_adapter.py
@@ -6,12 +6,19 @@ sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 from app import create_app
 
 
-def test_recipes_endpoint_returns_mapped_items():
+def test_recipes_endpoint_returns_normalized_items():
     app = create_app()
     client = app.test_client()
-    resp = client.get('/api/recipes')
+    resp = client.get('/api/recipes?locale=en')
     assert resp.status_code == 200
     data = resp.get_json()
     assert isinstance(data, list)
     assert len(data) > 0
-    assert any(len(r.get('ingredients', [])) >= 1 for r in data)
+    sample = data[0]
+    assert 'id' in sample and 'names' in sample and 'servings' in sample
+    assert isinstance(sample.get('ingredients'), list)
+    assert sample['ingredients'], 'ingredients should not be empty'
+    first_ing = sample['ingredients'][0]
+    assert 'productId' in first_ing
+    assert 'unitId' in first_ing
+    assert 'productName' in first_ing


### PR DESCRIPTION
## Summary
- expose `/api/recipes` returning normalized recipes with product/unit names resolved for the requested locale
- render recipe list from loaded domain recipes and handle favorites by id
- show ingredient names/quantities in recipe detail with graceful fallback for unknown refs

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689926d66158832aa29bed17e01883bb