### PR TITLE
Remove debug overlay and gate logs behind flag

### DIFF
--- a/app/static/js/components/product-table.js
+++ b/app/static/js/components/product-table.js
@@ -17,7 +17,8 @@ import {
   productName,
   categoryName,
   unitName,
-  getProduct
+  getProduct,
+  DEBUG
 } from '../helpers.js';
 import { toast } from './toast.js';
 
@@ -594,7 +595,7 @@ export function renderProducts() {
     }
     updateDeleteButton();
     const summaryIds = data.slice(0, 3).map(p => p.id);
-    console.debug('renderProducts', data.length, summaryIds);
+    if (DEBUG) console.debug('renderProducts', data.length, summaryIds);
   });
 }
 

--- a/app/static/js/helpers.js
+++ b/app/static/js/helpers.js
@@ -53,7 +53,7 @@ export const STORAGE_ICONS = {
   freezer: '❄️'
 };
 
-export const DEBUG = false;
+export const DEBUG = Boolean(window.DEBUG);
 export function dlog(...args) {
   if (DEBUG) console.warn(...args);
 }
@@ -292,10 +292,11 @@ export async function loadDomain() {
     });
     state.recipesLoaded = true;
     state.domainLoaded = true;
-    console.debug('domain:ready', {
-      products: APP.state.products.length,
-      recipes: state.recipesData.length
-    });
+    if (DEBUG)
+      console.debug('domain:ready', {
+        products: APP.state.products.length,
+        recipes: state.recipesData.length
+      });
     document.dispatchEvent(new Event('domain:ready'));
     window.trace?.('loadDomain:ok');
   } catch (err) {
@@ -319,12 +320,12 @@ export function getProduct(id) {
 
 export function productName(id) {
   if (!id) {
-    console.warn('Missing product id');
+    if (DEBUG) console.warn('Missing product id');
     return t('unknown');
   }
   const p = resolveProduct(id);
   if (!p) {
-    console.warn('Unknown product', id);
+    if (DEBUG) console.warn('Unknown product', id);
     return t('unknown');
   }
   return p.names[state.currentLang] ?? p.names.en ?? t('unknown');
@@ -333,7 +334,7 @@ export function productName(id) {
 export function categoryName(id) {
   const c = state.domain.categories[id];
   if (!c) {
-    console.warn('Unknown category', id);
+    if (DEBUG) console.warn('Unknown category', id);
     return t('unknown');
   }
   return c.names[state.currentLang] ?? c.names.en ?? t('unknown');
@@ -342,7 +343,7 @@ export function categoryName(id) {
 export function unitName(id) {
   const u = state.domain.units[id];
   if (!u) {
-    console.warn('Unknown unit', id);
+    if (DEBUG) console.warn('Unknown unit', id);
     return t('unknown');
   }
   return u.names[state.currentLang] ?? u.names.en ?? t('unknown');

--- a/app/static/script.js
+++ b/app/static/script.js
@@ -10,7 +10,8 @@ import {
   normalizeProduct,
   applyTranslations,
   isSpice,
-  debounce
+  debounce,
+  DEBUG
 } from './js/helpers.js';
 import * as ProductTable from './js/components/product-table.js';
 import * as Shopping from './js/components/shopping-list.js';
@@ -19,12 +20,8 @@ import { initReceiptImport } from './js/components/ocr-modal.js';
 import { toast, showNotification, checkLowStockToast } from './js/components/toast.js';
 import './js/components/recipe-detail.js';
 
-window.__BOOT_TRACE = [];
 function trace(p){
-  window.__BOOT_TRACE.push(p);
-  console.info('[BOOT]', p);
-  const el=document.getElementById('boot-trace');
-  if(el){ el.textContent = window.__BOOT_TRACE.join(' › ');} 
+  if (DEBUG) console.info('[BOOT]', p);
 }
 window.trace = trace;
 
@@ -54,10 +51,10 @@ async function loadProducts() {
     ProductTable.renderProducts();
     Shopping.renderSuggestions();
     checkLowStockToast(APP.state.products, activateTab, Shopping.renderSuggestions, Shopping.renderShoppingList);
-    if (!APP._productsLoaded) {
-      console.info('Products loaded:', APP.state.products.length);
-      APP._productsLoaded = true;
-    }
+      if (!APP._productsLoaded) {
+        if (DEBUG) console.info('Products loaded:', APP.state.products.length);
+        APP._productsLoaded = true;
+      }
     trace('loadProducts:ok');
   } catch (e) {
     console.error(e);

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -12,6 +12,7 @@
     <meta name="apple-mobile-web-app-status-bar-style" content="default">
     <meta name="apple-mobile-web-app-title" content="Food App">
       <script>
+        window.DEBUG = false;
         (() => {
           const key = 'theme';
           const mql = window.matchMedia('(prefers-color-scheme: dark)');
@@ -24,19 +25,19 @@
             return stored === 'system' ? (mql.matches ? 'dark' : 'light') : stored;
           };
           apply(resolve());
-          console.info('theme:', resolve());
+          if (window.DEBUG) console.info('theme:', resolve());
           mql.addEventListener('change', e => {
             if ((localStorage.getItem(key) || 'system') === 'system') {
               const t = e.matches ? 'dark' : 'light';
               apply(t);
-              console.info('theme:', t);
+              if (window.DEBUG) console.info('theme:', t);
             }
           });
           window.setTheme = v => {
             localStorage.setItem(key, v);
             const t = v === 'system' ? (mql.matches ? 'dark' : 'light') : v;
             apply(t);
-            console.info('theme:', t);
+            if (window.DEBUG) console.info('theme:', t);
           };
         })();
       </script>
@@ -67,7 +68,6 @@
 </div>
 <div id="notification-container" class="toast toast-end top-auto bottom-[4.5rem] z-40" aria-live="polite"></div>
 <div id="top-banner-container" class="sticky top-0 z-20"></div>
-<div id="boot-trace" style="position:fixed;left:.5rem;top:.5rem;z-index:9999;font:12px/1.2 ui-monospace,monospace;background:#111;color:#fff;padding:.25rem .5rem;border-radius:.25rem;opacity:.7;"></div>
 <div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 pt-4 md:pt-6 space-y-4 main-container">
     <div class="tabs tabs-bordered flex-nowrap overflow-x-auto whitespace-nowrap mb-6 desktop-nav">
         <a class="tab tab-active font-bold" data-tab-target="tab-products" data-i18n="tab_products">Produkty</a>


### PR DESCRIPTION
## Summary
- Remove `boot-trace` overlay and switch boot breadcrumbs to console behind a `DEBUG` flag
- Guard diagnostic console output throughout helpers and product table modules
- Add global `DEBUG` flag initialization in HTML and suppress theme logs when disabled

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689a30c2dc0c832a9567deb686b7c022