### PR TITLE
feat: add global spacing tokens and container

### DIFF
--- a/app/static/styles.css
+++ b/app/static/styles.css
@@ -8,6 +8,27 @@ html[data-theme='dark'] {
   color-scheme: dark;
 }
 
+/* Spacing variables */
+:root {
+  --space-xs: 0.25rem;
+  --space-sm: 0.5rem;
+  --space-md: 1rem;
+  --space-lg: 1.5rem;
+  --space-xl: 2rem;
+
+  --page-padding: var(--space-md);
+  --section-margin: var(--space-lg);
+  --cell-padding-y: var(--space-sm);
+  --cell-padding-x: var(--space-md);
+  --tab-gap: var(--space-sm);
+  --container-max-width: 80rem;
+}
+
+html[data-layout="mobile"] {
+  --cell-padding-y: var(--space-xs);
+  --cell-padding-x: var(--space-sm);
+}
+
 #top-sentinel {
   height: 3rem;
 }
@@ -20,7 +41,11 @@ html[data-theme='dark'] {
   display: grid;
   grid-template-columns: auto 1fr auto;
   align-items: center;
-  gap: 0.5rem;
+  gap: var(--tab-gap);
+  padding: var(--space-sm) var(--page-padding);
+  max-width: var(--container-max-width);
+  margin-left: auto;
+  margin-right: auto;
 }
 
 .app-bar .tabs-wrap {
@@ -31,9 +56,42 @@ html[data-theme='dark'] {
   display: flex;
   align-items: center;
   justify-content: flex-end;
-  gap: 0.5rem;
+  gap: var(--tab-gap);
   pointer-events: auto;
   z-index: 10;
+}
+
+.app-bar .tabs {
+  gap: var(--tab-gap);
+}
+
+.main-container {
+  max-width: var(--container-max-width);
+  margin-left: auto;
+  margin-right: auto;
+  padding: var(--page-padding);
+}
+
+.main-container > * + * {
+  margin-top: var(--section-margin);
+}
+
+#product-table {
+  table-layout: fixed;
+  width: 100%;
+  border-collapse: collapse;
+}
+
+#product-table th,
+#product-table td {
+  padding: var(--cell-padding-y) var(--cell-padding-x);
+}
+
+#product-table thead th {
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  background-color: hsl(var(--b1));
 }
 
 html[data-layout="mobile"] #controls {
@@ -99,14 +157,6 @@ html[data-layout="mobile"] #history-list {
   font-size: 1em;
 }
 
-html[data-layout="mobile"] #product-table th,
-html[data-layout="mobile"] #product-table td {
-  padding-top: 0.25rem;
-  padding-bottom: 0.25rem;
-  padding-left: 0.5rem;
-  padding-right: 0.5rem;
-}
-
 html[data-layout="mobile"] button,
 html[data-layout="mobile"] .btn {
   font-size: 1em;
@@ -118,16 +168,10 @@ html[data-layout="mobile"] .btn {
 }
 
 /* Edit mode table layout */
-#product-table thead th {
-  position: sticky;
-  top: 0;
-  z-index: 10;
-}
-
 #product-table.edit-mode thead th,
 #product-table.edit-mode tbody td {
-  padding-top: 0.25rem;
-  padding-bottom: 0.25rem;
+  padding-top: var(--cell-padding-y);
+  padding-bottom: var(--cell-padding-y);
   min-height: 2.5rem;
 }
 
@@ -303,17 +347,12 @@ html[data-layout="mobile"] #product-table .status-label {
 
 #products-by-category .grouped-table th,
 #products-by-category .grouped-table td {
-  padding: 0.5rem 1rem;
+  padding: var(--cell-padding-y) var(--cell-padding-x);
 }
 
 #products-by-category .grouped-table th:first-child,
 #products-by-category .grouped-table td:first-child {
   padding-left: 0;
-}
-
-html[data-layout="mobile"] #products-by-category .grouped-table th,
-html[data-layout="mobile"] #products-by-category .grouped-table td {
-  padding: 0.25rem 0.25rem;
 }
 
 /* Navigation positioning for mobile view */

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -53,7 +53,7 @@
 </div>
 <div id="notification-container" class="toast toast-end top-auto bottom-[4.5rem] z-40" aria-live="polite"></div>
 <div id="top-banner-container" class="sticky top-0 z-30"></div>
-<header class="app-bar bg-base-100 px-4 sm:px-6 lg:px-8">
+<header class="app-bar bg-base-100">
   <div class="left flex items-center gap-2">
     <span class="app-title font-bold text-lg">Food App</span>
     <span id="locale-chip" class="badge">PL</span>
@@ -66,7 +66,7 @@
         <a class="tab" data-tab-target="tab-shopping" data-i18n="tab_shopping">Lista zakupów</a>
     </div>
   </div>
-  <div class="actions flex justify-end gap-2 md:gap-3 pointer-events-auto">
+  <div class="actions">
     <button id="layout-toggle" aria-label="Toggle layout" class="text-xl p-2 bg-transparent border-0">
         <i id="layout-icon" class="fa-solid fa-mobile-screen-button"></i>
     </button>
@@ -87,7 +87,7 @@
     </button>
   </div>
 </header>
-<div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 pt-4 md:pt-6 space-y-4 main-container">
+  <main class="main-container">
         <div id="tab-products" class="tab-panel">
             <h1 class="text-xl md:text-2xl font-semibold mb-3 md:mb-4" data-i18n="heading_products">Produkty</h1>
             <div id="controls" class="flex flex-wrap items-center gap-4 mb-4">
@@ -441,7 +441,7 @@
             <button id="units-save" class="btn btn-primary btn-sm mt-4" data-i18n="save_button">Zapisz</button>
         </div>
 
-    </div>
+  </main>
 
     <dialog id="recipe-detail-modal" class="modal">
         <form method="dialog" class="modal-box max-w-2xl">


### PR DESCRIPTION
## Summary
- add CSS spacing scale and reuse for page padding, table cells and sticky tab bar gaps
- wrap app content in a centered max-width container
- make table headers sticky with aligned cells

## Testing
- `pre-commit run --files app/static/styles.css app/templates/index.html` *(fails: command not found)*
- `pip install pre-commit` *(fails: Could not find a version that satisfies the requirement pre-commit)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689a3de1b984832aaa11f13805178c17