### PR TITLE
harden adapters with defaults and warnings

### DIFF
--- a/app/utils/logging.py
+++ b/app/utils/logging.py
@@ -17,3 +17,18 @@ def log_error_with_trace(exc: Exception, context: Dict[str, Any]) -> str:
     trace_id = uuid.uuid4().hex[:8]
     logger.error("trace %s context=%s", trace_id, context, exc_info=exc)
     return trace_id
+
+
+def log_warning_with_trace(message: str, context: Dict[str, Any]) -> str:
+    """Log a warning with a short trace identifier.
+
+    Args:
+        message: Warning message to log.
+        context: Additional context such as endpoint and request args.
+
+    Returns:
+        str: Generated trace identifier (first 8 chars of UUID4).
+    """
+    trace_id = uuid.uuid4().hex[:8]
+    logger.warning("trace %s context=%s %s", trace_id, context, message)
+    return trace_id

--- a/tests/test_products_adapter.py
+++ b/tests/test_products_adapter.py
@@ -16,3 +16,8 @@ def test_products_endpoint_returns_mapped_items():
     first = data[0]
     # ensure legacy fields exist
     assert 'id' in first and 'name_pl' in first and 'unit' in first
+    # stable shape defaults
+    assert first['amount'] == 0
+    assert first['threshold'] == 0
+    assert first['storage'] == 'pantry'
+    assert first['flags'] is False

--- a/tests/test_recipes_adapter.py
+++ b/tests/test_recipes_adapter.py
@@ -16,6 +16,11 @@ def test_recipes_endpoint_returns_normalized_items():
     assert len(data) > 0
     sample = data[0]
     assert 'id' in sample and 'names' in sample and 'servings' in sample
+    # stable shape defaults on recipe
+    assert sample['amount'] == 0
+    assert sample['threshold'] == 0
+    assert sample['storage'] == 'pantry'
+    assert sample['flags'] is False
     assert isinstance(sample.get('ingredients'), list)
     assert sample['ingredients'], 'ingredients should not be empty'
     first_ing = sample['ingredients'][0]


### PR DESCRIPTION
## Summary
- ensure `/api/products` returns stable items with defaulted amount, threshold, storage and flags fields and logs traceable warnings for invalid entries
- load recipes fail-soft while adding the same defaults and warning with trace IDs for skipped items
- introduce `log_warning_with_trace` utility and tighten adapter tests for stable shapes

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689a496a3128832aa934bbdccfa117d3