### PR TITLE
Use hash-based tab routing

### DIFF
--- a/app/static/js/components/product-table.js
+++ b/app/static/js/components/product-table.js
@@ -238,9 +238,12 @@ export async function saveProduct(payload) {
     toast.success(t('save_success'), '', {
       label: t('toast_go_products'),
       onClick: () => {
-        window.activateTab('tab-products');
-        localStorage.setItem('activeTab', 'tab-products');
-        history.pushState({ tab: 'tab-products' }, '');
+        const hash = '#products';
+        if (location.hash === hash) {
+          window.activateTab('tab-products');
+        } else {
+          location.hash = hash;
+        }
       }
     });
   } catch (err) {

--- a/app/static/js/components/shopping-list.js
+++ b/app/static/js/components/shopping-list.js
@@ -37,9 +37,12 @@ export function addToShoppingList(name, quantity = 1) {
   toast.success(t('manual_add_success'), '', {
     label: t('toast_go_shopping'),
     onClick: () => {
-      window.activateTab('tab-shopping');
-      localStorage.setItem('activeTab', 'tab-shopping');
-      history.pushState({ tab: 'tab-shopping' }, '');
+      const hash = '#shopping';
+      if (location.hash === hash) {
+        window.activateTab('tab-shopping');
+      } else {
+        location.hash = hash;
+      }
       renderSuggestions();
       renderShoppingList();
     }

--- a/app/static/js/components/toast.js
+++ b/app/static/js/components/toast.js
@@ -86,9 +86,12 @@ export function showLowStockToast(activateTab, renderSuggestions, renderShopping
   btn.dataset.action = 'shopping';
   btn.textContent = t('toast_go_shopping');
   btn.addEventListener('click', () => {
-    activateTab('tab-shopping');
-    localStorage.setItem('activeTab', 'tab-shopping');
-    history.pushState({ tab: 'tab-shopping' }, '');
+    const hash = '#shopping';
+    if (location.hash === hash) {
+      activateTab('tab-shopping');
+    } else {
+      location.hash = hash;
+    }
     renderSuggestions();
     renderShoppingList();
     alert.remove();


### PR DESCRIPTION
## Summary
- replace history API with hash-based routing and listen to `hashchange` for tab navigation
- read and set `location.hash` on boot to restore the correct tab
- update toast helpers to switch tabs by setting the hash instead of reloading

## Testing
- `pre-commit run --files app/static/script.js app/static/js/components/toast.js app/static/js/components/product-table.js app/static/js/components/shopping-list.js` *(fails: command not found)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689a4b188ab0832a9b3ccb2868be793a