### PR TITLE
feat: prompt reload on service worker update

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -250,7 +250,7 @@ def remove_used_products(used_ingredients):
         safe_write(PRODUCTS_PATH, products)
 
 
-APP_VERSION = "3"
+APP_VERSION = "4"
 
 
 @bp.route("/")

--- a/app/static/script.js
+++ b/app/static/script.js
@@ -108,11 +108,13 @@ async function checkHealth() {
 
 function registerServiceWorker() {
   if ('serviceWorker' in navigator) {
-    let refreshing;
-    navigator.serviceWorker.addEventListener('controllerchange', () => {
-      if (refreshing) return;
-      refreshing = true;
-      window.location.reload();
+    navigator.serviceWorker.addEventListener('message', event => {
+      if (event.data && event.data.type === 'RELOAD_PROMPT') {
+        toast.info(t('reload_to_update'), '', {
+          label: t('reload'),
+          onClick: () => window.location.reload()
+        });
+      }
     });
     window.addEventListener('load', () => {
       const v = window.APP_VERSION || '0';

--- a/app/static/service-worker.js
+++ b/app/static/service-worker.js
@@ -1,4 +1,4 @@
-const APP_VERSION = '3';
+const APP_VERSION = '4';
 const CACHE_NAME = `food-cache-${APP_VERSION}`;
 const OFFLINE_URL = '/offline';
 const OFFLINE_HTML = `<!DOCTYPE html><html lang="en"><head><meta charset="utf-8"><title>Offline</title></head><body><h1>You're offline</h1></body></html>`;
@@ -16,10 +16,21 @@ const PRECACHE_URLS = [
 
 self.addEventListener('install', event => {
   event.waitUntil(
-    caches.open(CACHE_NAME).then(cache => {
-      cache.addAll(PRECACHE_URLS);
-      cache.put(OFFLINE_URL, new Response(OFFLINE_HTML, { headers: { 'Content-Type': 'text/html' } }));
-    }).then(() => self.skipWaiting())
+    caches
+      .open(CACHE_NAME)
+      .then(cache => {
+        cache.addAll(PRECACHE_URLS);
+        cache.put(OFFLINE_URL, new Response(OFFLINE_HTML, { headers: { 'Content-Type': 'text/html' } }));
+      })
+      .then(() => {
+        if (self.registration.active) {
+          return self.clients
+            .matchAll({ type: 'window', includeUncontrolled: true })
+            .then(clients => {
+              clients.forEach(client => client.postMessage({ type: 'RELOAD_PROMPT' }));
+            });
+        }
+      })
   );
 });
 

--- a/app/static/translations/en.json
+++ b/app/static/translations/en.json
@@ -143,6 +143,8 @@
   "Note": "Note",
   "reject": "reject",
   "reject_action": "Reject",
+  "reload": "Reload",
+  "reload_to_update": "Reload to update",
   "remove": "Remove",
   "resolve": "Resolve",
   "retry": "Retry",

--- a/app/static/translations/pl.json
+++ b/app/static/translations/pl.json
@@ -143,6 +143,8 @@
   "Note": "Notatka",
   "reject": "ukryj",
   "reject_action": "Odrzuć",
+  "reload": "Przeładuj",
+  "reload_to_update": "Przeładuj, aby zaktualizować",
   "remove": "Usuń",
   "resolve": "Rozwiąż",
   "retry": "Ponów",


### PR DESCRIPTION
## Summary
- broadcast update prompt when new service worker waits
- listen for reload prompt in client and expose translations
- bump app version and clean old caches

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689a4d2b4394832aa264512223c28979