### PR TITLE
Improve edit mode workflow

### DIFF
--- a/app/static/translations/en.json
+++ b/app/static/translations/en.json
@@ -152,6 +152,7 @@
   "save_button": "Save",
   "save_failed": "Save failed",
   "save_success": "Saved",
+  "save_changes_prompt": "Save changes?",
   "search_placeholder": "Search product",
   "settings_unit_code": "Code",
   "settings_unit_en": "English",

--- a/app/static/translations/pl.json
+++ b/app/static/translations/pl.json
@@ -152,6 +152,7 @@
   "save_button": "Zapisz",
   "save_failed": "Nie udało się zapisać",
   "save_success": "Zapisano",
+  "save_changes_prompt": "Zapisać zmiany?",
   "search_placeholder": "Szukaj produktu",
   "settings_unit_code": "Kod",
   "settings_unit_en": "Angielski",


### PR DESCRIPTION
## Summary
- Disable filters and prompt to save or cancel when navigating away from edit mode
- Keep edit mode active after deletions and reset delete button
- Add translation for save confirmation prompt

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689cc9870e54832a891545d68d1556c0