### PR TITLE
Refactor shopping list and suggestions layout

### DIFF
--- a/app/static/styles.css
+++ b/app/static/styles.css
@@ -440,6 +440,13 @@ html[data-layout="mobile"] .touch-btn {
   opacity: 0.6;
 }
 
+.shopping-item,
+.suggestion-item {
+  display: grid;
+  grid-template-columns: 1fr auto auto auto;
+  align-items: center;
+}
+
 .owned-info {
   font-size: 0.75rem;
   color: hsl(var(--bc));


### PR DESCRIPTION
## Summary
- Rebuild shopping list rows into a 4-column grid with quantity controls, in-cart toggle and modal removal
- Render suggestion rows in a matching grid with accept/reject actions and show owned quantities
- Define shared grid styles for suggestion and shopping items

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689cc98cf814832aa2cad32312974ae3