### PR TITLE
Reset product filters on tab change

### DIFF
--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -103,8 +103,8 @@
                 <div class="flex flex-col md:flex-row gap-2 items-start md:items-center flex-1">
                     <input id="product-search" placeholder="Szukaj produktu" data-i18n="search_placeholder" class="input input-bordered flex-1 min-w-[200px]" />
                     <select id="state-filter" class="select select-bordered w-full md:w-auto">
-                        <option value="all" data-i18n="state_filter_all" selected>Wszystkie</option>
-                        <option value="available" data-i18n="state_filter_available">Dostępne</option>
+                        <option value="all" data-i18n="state_filter_all">Wszystkie</option>
+                        <option value="available" data-i18n="state_filter_available" selected>Dostępne</option>
                         <option value="missing" data-i18n="state_filter_missing">Brakujące</option>
                         <option value="low" data-i18n="state_filter_low">Kończące się</option>
                     </select>


### PR DESCRIPTION
## Summary
- Reset product filter to default when leaving Products tab and on re-entry
- Preserve per-tab search text and set default filter to Available

## Testing
- `pre-commit run --files app/static/script.js app/templates/index.html` *(failed: pre-commit missing and installation blocked)*

------
https://chatgpt.com/codex/tasks/task_e_689cc996dbd4832aa1e1530b70611b23