### PR TITLE
Improve translation fallback with namespaces

### DIFF
--- a/app/static/js/components/ocr-modal.js
+++ b/app/static/js/components/ocr-modal.js
@@ -1,4 +1,4 @@
-import { t, state, fetchJson, labelProduct } from "../helpers.js";
+import { t, state, fetchJson } from "../helpers.js";
 import { addToShoppingList, renderShoppingList } from "./shopping-list.js";
 import { toast } from "./toast.js";
 
@@ -68,9 +68,7 @@ export async function handleReceiptUpload(file) {
     const nameInput = document.createElement("input");
     nameInput.type = "text";
     const firstMatch = item.matches[0];
-    nameInput.value = firstMatch
-      ? labelProduct(firstMatch.name, state.currentLang)
-      : item.original;
+    nameInput.value = firstMatch ? t(`prod.${firstMatch.name}`) : item.original;
     if (firstMatch) nameInput.dataset.key = firstMatch.name;
     nameInput.className = "input input-bordered w-full";
     nameTd.appendChild(nameInput);
@@ -90,11 +88,11 @@ export async function handleReceiptUpload(file) {
       item.matches.forEach((m) => {
         const opt = document.createElement("option");
         opt.value = m.name;
-        opt.textContent = labelProduct(m.name, state.currentLang);
+        opt.textContent = t(`prod.${m.name}`);
         select.appendChild(opt);
       });
       select.addEventListener("change", () => {
-        nameInput.value = labelProduct(select.value, state.currentLang);
+        nameInput.value = t(`prod.${select.value}`);
         nameInput.dataset.key = select.value;
       });
       statusTd.appendChild(select);

--- a/app/static/js/components/product-table.js
+++ b/app/static/js/components/product-table.js
@@ -13,9 +13,6 @@ import {
   isSpice,
   debounce,
   dlog,
-  labelProduct,
-  labelCategory,
-  labelUnit,
   getProduct,
   DEBUG,
 } from "../helpers.js";
@@ -271,7 +268,7 @@ function createFlatRow(p, idx, editable) {
     // name
     const nameTd = document.createElement("td");
     nameTd.className = "name-cell";
-    nameTd.textContent = labelProduct(p.id, state.currentLang);
+    nameTd.textContent = t(`prod.${p.id}`);
     if (!getProduct(p.id)) nameTd.classList.add("opacity-60");
     tr.appendChild(nameTd);
     // quantity with steppers
@@ -288,7 +285,7 @@ function createFlatRow(p, idx, editable) {
       Object.keys(state.units).forEach((u) => {
         const opt = document.createElement("option");
         opt.value = u;
-        opt.textContent = labelUnit(u, state.currentLang);
+        opt.textContent = t(`unit.${u}`);
         if (u === p.unit) opt.selected = true;
         unitSel.appendChild(opt);
       });
@@ -303,7 +300,7 @@ function createFlatRow(p, idx, editable) {
     Object.keys(state.domain.categories).forEach((c) => {
       const opt = document.createElement("option");
       opt.value = c;
-      opt.textContent = labelCategory(c, state.currentLang);
+      opt.textContent = t(`category.${c}`);
       if (c === (p.category || "")) opt.selected = true;
       catSel.appendChild(opt);
     });
@@ -334,17 +331,17 @@ function createFlatRow(p, idx, editable) {
     tr.appendChild(statusTd);
   } else {
     const nameTd = document.createElement("td");
-    nameTd.textContent = labelProduct(p.id, state.currentLang);
+    nameTd.textContent = t(`prod.${p.id}`);
     if (!getProduct(p.id)) nameTd.classList.add("opacity-60");
     tr.appendChild(nameTd);
     const qtyTd = document.createElement("td");
     qtyTd.textContent = formatPackQuantity(p);
     tr.appendChild(qtyTd);
     const unitTd = document.createElement("td");
-    unitTd.textContent = isSpice(p) ? "" : labelUnit(p.unit, state.currentLang);
+    unitTd.textContent = isSpice(p) ? "" : t(`unit.${p.unit}`);
     tr.appendChild(unitTd);
     const catTd = document.createElement("td");
-    catTd.textContent = labelCategory(p.category, state.currentLang);
+    catTd.textContent = t(`category.${p.category}`);
     if (!state.domain.categories[p.category]) catTd.classList.add("opacity-60");
     tr.appendChild(catTd);
     const storTd = document.createElement("td");
@@ -384,12 +381,12 @@ export function renderProducts() {
       ...dp,
       ...existing,
       id: dp.id,
-      name: labelProduct(dp.id, state.currentLang),
+      name: t(`prod.${dp.id}`),
     });
     return {
       ...merged,
-      unitLabel: labelUnit(merged.unit, state.currentLang),
-      categoryLabel: labelCategory(merged.category, state.currentLang),
+      unitLabel: t(`unit.${merged.unit}`),
+      categoryLabel: t(`category.${merged.category}`),
       storageLabel: t(STORAGE_KEYS[merged.storage] || merged.storage),
       status: stockLevel(merged),
     };
@@ -401,7 +398,7 @@ export function renderProducts() {
     (p) =>
       matchesFilter(p, filter) &&
       (!term ||
-        labelProduct(p.id, state.currentLang).toLowerCase().includes(term) ||
+        t(`prod.${p.id}`).toLowerCase().includes(term) ||
         p.name.toLowerCase().includes(term)),
   );
 
@@ -503,9 +500,7 @@ export function renderProducts() {
               .sort(
                 (a, b) =>
                   (CATEGORY_ORDER[a] || 0) - (CATEGORY_ORDER[b] || 0) ||
-                  labelCategory(a, state.currentLang).localeCompare(
-                    labelCategory(b, state.currentLang),
-                  ),
+                  t(`category.${a}`).localeCompare(t(`category.${b}`)),
               )
               .forEach((cat) => {
                 const catBlock = document.createElement("div");
@@ -519,7 +514,7 @@ export function renderProducts() {
                   catHeader.classList.add("cursor-pointer");
                 const catSpan = document.createElement("span");
                 catSpan.className = "font-medium";
-                catSpan.textContent = labelCategory(cat, state.currentLang);
+                catSpan.textContent = t(`category.${cat}`);
                 if (!state.domain.categories[cat])
                   catSpan.classList.add("opacity-60");
                 const catBtn = document.createElement("button");
@@ -599,13 +594,13 @@ export function renderProducts() {
                     cbTd.appendChild(cb);
                     tr.appendChild(cbTd);
                     const n = document.createElement("td");
-                    n.textContent = labelProduct(p.id, state.currentLang);
+                    n.textContent = t(`prod.${p.id}`);
                     if (!getProduct(p.id)) n.classList.add("opacity-60");
                     tr.appendChild(n);
                     const q = buildQtyCell(p, tr);
                     tr.appendChild(q);
                     const u = document.createElement("td");
-                    u.textContent = labelUnit(p.unit, state.currentLang);
+                    u.textContent = t(`unit.${p.unit}`);
                     tr.appendChild(u);
                     const s = document.createElement("td");
                     const ic = getStatusIcon(p);
@@ -616,12 +611,12 @@ export function renderProducts() {
                     tr.appendChild(s);
                   } else {
                     const n = document.createElement("td");
-                    n.textContent = labelProduct(p.id, state.currentLang);
+                    n.textContent = t(`prod.${p.id}`);
                     if (!getProduct(p.id)) n.classList.add("opacity-60");
                     const q = document.createElement("td");
                     q.textContent = formatPackQuantity(p);
                     const u = document.createElement("td");
-                    u.textContent = labelUnit(p.unit, state.currentLang);
+                    u.textContent = t(`unit.${p.unit}`);
                     const s = document.createElement("td");
                     const ic = getStatusIcon(p);
                     if (ic) {

--- a/app/static/js/components/recipe-detail.js
+++ b/app/static/js/components/recipe-detail.js
@@ -1,10 +1,4 @@
-import {
-  state,
-  t,
-  toggleFavorite,
-  labelProduct,
-  labelUnit,
-} from "../helpers.js";
+import { state, t, toggleFavorite } from "../helpers.js";
 
 function renderRecipeDetail(r) {
   const title = r.names?.[state.currentLang] || r.names?.en || r.id;
@@ -26,14 +20,12 @@ function renderRecipeDetail(r) {
 
   const ingRows = (r.ingredients || [])
     .map((i) => {
-      const name =
-        i.productName || labelProduct(i.productId, state.currentLang);
+      const key = `prod.${i.productId}`;
+      const name = i.productName || t(key);
       const qty = (i.qty ?? "").toString();
-      const unit =
-        i.unitName || (i.unitId ? labelUnit(i.unitId, state.currentLang) : "");
+      const unit = i.unitName || (i.unitId ? t(`unit.${i.unitId}`) : "");
       const qtyStr = [qty, unit].filter(Boolean).join(" ");
-      const unknownLabel = state.currentLang === "pl" ? "Nieznane" : "Unknown";
-      const unknown = name === unknownLabel ? " opacity-60" : "";
+      const unknown = name === key ? " opacity-60" : "";
       return `<tr><td class="pr-4${unknown}">${name}</td><td class="text-right">${qtyStr}</td></tr>`;
     })
     .join("");

--- a/app/static/js/components/shopping-list.js
+++ b/app/static/js/components/shopping-list.js
@@ -1,12 +1,4 @@
-import {
-  t,
-  state,
-  isSpice,
-  stockLevel,
-  fetchJson,
-  debounce,
-  labelProduct,
-} from "../helpers.js";
+import { t, state, isSpice, stockLevel, fetchJson, debounce } from "../helpers.js";
 import { toast } from "./toast.js";
 
 function saveShoppingList() {
@@ -61,9 +53,7 @@ function sortShoppingList() {
   state.shoppingList.sort((a, b) => {
     if (a.inCart && b.inCart) return (a.cartTime || 0) - (b.cartTime || 0);
     if (a.inCart !== b.inCart) return a.inCart ? 1 : -1;
-    return labelProduct(a.name, state.currentLang).localeCompare(
-      labelProduct(b.name, state.currentLang),
-    );
+    return t(`prod.${a.name}`).localeCompare(t(`prod.${b.name}`));
   });
 }
 
@@ -88,11 +78,11 @@ function renderShoppingItem(item, idx) {
   nameWrap.className = "flex items-center gap-1 flex-1 overflow-hidden";
   const nameEl = document.createElement("span");
   nameEl.className = "truncate";
-  const lbl = labelProduct(item.name, state.currentLang);
+  const key = `prod.${item.name}`;
+  const lbl = t(key);
   nameEl.textContent = lbl;
   nameEl.title = lbl;
-  const unknownLabel = state.currentLang === "pl" ? "Nieznane" : "Unknown";
-  if (lbl === unknownLabel) nameEl.classList.add("opacity-60");
+  if (lbl === key) nameEl.classList.add("opacity-60");
   if (item.inCart) nameEl.classList.add("line-through");
   nameWrap.appendChild(nameEl);
   row.appendChild(nameWrap);
@@ -245,9 +235,7 @@ export function renderSuggestions() {
     })
     .filter((p) => !state.dismissedSuggestions.has(p.name))
     .sort((a, b) =>
-      labelProduct(a.id, state.currentLang).localeCompare(
-        labelProduct(b.id, state.currentLang),
-      ),
+      t(`prod.${a.id}`).localeCompare(t(`prod.${b.id}`)),
     );
   const frag = document.createDocumentFragment();
   suggestions.forEach((p) => {
@@ -263,11 +251,11 @@ export function renderSuggestions() {
     nameWrap.className = "flex items-center gap-1 flex-1 overflow-hidden";
     const nameEl = document.createElement("span");
     nameEl.className = "truncate";
-    const lbl = labelProduct(p.id, state.currentLang);
+    const key = `prod.${p.id}`;
+    const lbl = t(key);
     nameEl.textContent = lbl;
     nameEl.title = lbl;
-    const unknownLabel = state.currentLang === "pl" ? "Nieznane" : "Unknown";
-    if (!lbl || lbl === unknownLabel) nameEl.classList.add("opacity-60");
+    if (lbl === key) nameEl.classList.add("opacity-60");
     nameWrap.appendChild(nameEl);
     row.appendChild(nameWrap);
 

--- a/app/static/js/helpers.js
+++ b/app/static/js/helpers.js
@@ -113,6 +113,18 @@ export function throttle(fn, delay = 200) {
 
 export function t(key) {
   if (!key) return key;
+  if (key.startsWith("prod.")) {
+    const id = key.slice(5);
+    return labelProduct(id);
+  }
+  if (key.startsWith("unit.")) {
+    const id = key.slice(5);
+    return labelUnit(id);
+  }
+  if (key.startsWith("category.")) {
+    const id = key.slice(9);
+    return labelCategory(id);
+  }
   return (
     state.uiTranslations[state.currentLang]?.[key] ??
     state.uiTranslations.en?.[key] ??
@@ -344,16 +356,11 @@ export function getProduct(id) {
   return resolveProduct(id);
 }
 
-const UNKNOWN_LABELS = { pl: "Nieznane", en: "Unknown" };
 const warnedIds = {
   products: new Set(),
   units: new Set(),
   categories: new Set(),
 };
-
-function unknownLabel(locale = state.currentLang) {
-  return UNKNOWN_LABELS[locale] || UNKNOWN_LABELS.en;
-}
 
 function warnOnce(type, id) {
   if (!id) return;
@@ -367,40 +374,40 @@ function warnOnce(type, id) {
 export function labelProduct(id, locale = state.currentLang) {
   if (!id) {
     warnOnce("products", id);
-    return unknownLabel(locale);
+    return id;
   }
   const p = resolveProduct(id);
   if (!p) {
     warnOnce("products", id);
-    return unknownLabel(locale);
+    return id;
   }
-  return p.names[locale] ?? p.names.en ?? unknownLabel(locale);
+  return p.names[locale] ?? p.names.en ?? id;
 }
 
 export function labelCategory(id, locale = state.currentLang) {
   if (!id) {
     warnOnce("categories", id);
-    return unknownLabel(locale);
+    return id;
   }
   const c = state.domain.categories[id];
   if (!c) {
     warnOnce("categories", id);
-    return unknownLabel(locale);
+    return id;
   }
-  return c.names[locale] ?? c.names.en ?? unknownLabel(locale);
+  return c.names[locale] ?? c.names.en ?? id;
 }
 
 export function labelUnit(id, locale = state.currentLang) {
   if (!id) {
     warnOnce("units", id);
-    return unknownLabel(locale);
+    return id;
   }
   const u = state.domain.units[id];
   if (!u) {
     warnOnce("units", id);
-    return unknownLabel(locale);
+    return id;
   }
-  return u.names[locale] ?? u.names.en ?? unknownLabel(locale);
+  return u.names[locale] ?? u.names.en ?? id;
 }
 
 export async function searchProducts(query) {

--- a/app/static/script.js
+++ b/app/static/script.js
@@ -238,7 +238,7 @@ function initAddForm() {
   Object.keys(state.units).forEach((u) => {
     const opt = document.createElement("option");
     opt.value = u;
-    opt.textContent = t(u);
+    opt.textContent = t(`unit.${u}`);
     unitSel.appendChild(opt);
   });
   qtyInput.insertAdjacentElement("afterend", unitSel);
@@ -435,7 +435,7 @@ function initNavigationAndEvents() {
     const unitSel = document.querySelector('#add-form select[name="unit"]');
     if (unitSel) {
       Array.from(unitSel.options).forEach((opt) => {
-        opt.textContent = t(opt.value);
+        opt.textContent = t(`unit.${opt.value}`);
       });
     }
     window.scrollTo(0, scroll);

--- a/app/static/translations/en.json
+++ b/app/static/translations/en.json
@@ -1,6 +1,7 @@
 {
   "accept": "accept",
   "accept_action": "Add",
+  "app_title": "Food App",
   "add_form_name_placeholder": "name",
   "add_form_pack_size_placeholder": "pack",
   "add_form_package_size_placeholder": "in package",

--- a/app/static/translations/pl.json
+++ b/app/static/translations/pl.json
@@ -1,6 +1,7 @@
 {
   "accept": "dodaj",
   "accept_action": "Dodaj",
+  "app_title": "Food App",
   "add_form_name_placeholder": "nazwa",
   "add_form_pack_size_placeholder": "paczka",
   "add_form_package_size_placeholder": "w opak.",

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -4,7 +4,7 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>Food App</title>
+    <title data-i18n="app_title">Food App</title>
     <link rel="manifest" href="/manifest.json">
     <meta name="theme-color" content="#ffffff">
     <link rel="apple-touch-icon" href="/static/icons/icon-192x192.png">
@@ -64,7 +64,7 @@
 <div id="top-banner-container" class="sticky top-0 z-30"></div>
 <header class="app-bar bg-base-100">
   <div class="left flex items-center gap-2">
-    <span class="app-title font-bold text-lg">Food App</span>
+    <span class="app-title font-bold text-lg" data-i18n="app_title">Food App</span>
     <span id="locale-chip" class="badge">PL</span>
   </div>
   <div class="tabs-wrap">


### PR DESCRIPTION
## Summary
- Refactor translation helper to fall back to English and render missing keys
- Add product, unit and category namespaces and remove unknown placeholders
- Use t() for product/unit labels across UI and localize app title

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689cc99e5460832aae5635994304c3d5