### PR TITLE
feat: restore stock highlighting

### DIFF
--- a/app/static/js/components/product-table.js
+++ b/app/static/js/components/product-table.js
@@ -7,7 +7,7 @@ import {
   CATEGORY_ORDER,
   STORAGE_KEYS,
   matchesFilter,
-  stockLevel,
+  getStockState,
   normalizeProduct,
   fetchJson,
   isSpice,
@@ -134,15 +134,16 @@ function highlightRow(tr, p) {
     "opacity-60",
     "font-semibold",
   );
-  const level = stockLevel(p);
+  const stockState = getStockState(p);
   if (p.main) {
-    if (level === "none")
+    if (stockState === "zero")
       tr.classList.add("text-error", "bg-error/10", "font-semibold");
-    else if (level === "low") tr.classList.add("text-warning", "bg-warning/10");
+    else if (stockState === "low")
+      tr.classList.add("text-warning", "bg-warning/10");
   } else {
-    if (level === "none")
+    if (stockState === "zero")
       tr.classList.add("text-error", "bg-error/10", "opacity-60");
-    else if (level === "low")
+    else if (stockState === "low")
       tr.classList.add("text-warning", "bg-warning/10", "opacity-60");
   }
 }
@@ -391,7 +392,7 @@ export function renderProducts() {
       unitLabel: labelUnit(merged.unit, state.currentLang),
       categoryLabel: labelCategory(merged.category, state.currentLang),
       storageLabel: t(STORAGE_KEYS[merged.storage] || merged.storage),
-      status: stockLevel(merged),
+      status: getStockState(merged),
     };
   });
   APP.state.products = data;
@@ -577,8 +578,24 @@ export function renderProducts() {
                     ];
                 headers.forEach((txt, i) => {
                   const th = document.createElement("th");
-                  th.textContent = txt;
-                  if (editing && i === 0) th.className = "checkbox-cell";
+                  if (editing && i === 0) {
+                    th.className = "checkbox-cell";
+                    th.textContent = txt;
+                  } else if (i === headers.length - 1) {
+                    th.className = "status-header text-center";
+                    const tip = document.createElement("span");
+                    tip.className = "tooltip tooltip-bottom";
+                    tip.dataset.i18nTip = "status_legend";
+                    tip.dataset.tip = t("status_legend");
+                    tip.innerHTML = '<i class="fa-solid fa-circle-info"></i>';
+                    const lbl = document.createElement("span");
+                    lbl.className = "status-label";
+                    lbl.dataset.i18n = "table_header_status";
+                    lbl.textContent = t("table_header_status");
+                    th.append(tip, " ", lbl);
+                  } else {
+                    th.textContent = txt;
+                  }
                   hr.appendChild(th);
                 });
                 thead.appendChild(hr);

--- a/app/static/js/components/shopping-list.js
+++ b/app/static/js/components/shopping-list.js
@@ -2,7 +2,7 @@ import {
   t,
   state,
   isSpice,
-  stockLevel,
+  getStockState,
   fetchJson,
   debounce,
   labelProduct,
@@ -79,9 +79,9 @@ function renderShoppingItem(item, idx) {
     (p) => p.name === item.name,
   );
   if (stock) {
-    const level = stockLevel(stock);
-    if (level === "low") row.classList.add("product-low");
-    if (level === "none") row.classList.add("product-missing");
+    const stockState = getStockState(stock);
+    if (stockState === "low") row.classList.add("product-low");
+    if (stockState === "zero") row.classList.add("product-missing");
   }
 
   const nameWrap = document.createElement("div");
@@ -255,9 +255,9 @@ export function renderSuggestions() {
     const row = document.createElement("div");
     row.className =
       "suggestion-item flex items-center gap-2 h-11 hover:bg-base-200 transition-colors";
-    const level = stockLevel(p);
-    if (level === "low") row.classList.add("product-low");
-    if (level === "none") row.classList.add("product-missing");
+    const stockState = getStockState(p);
+    if (stockState === "low") row.classList.add("product-low");
+    if (stockState === "zero") row.classList.add("product-missing");
 
     const nameWrap = document.createElement("div");
     nameWrap.className = "flex items-center gap-1 flex-1 overflow-hidden";

--- a/app/static/translations/en.json
+++ b/app/static/translations/en.json
@@ -163,6 +163,7 @@
   "state_filter_missing": "Out of stock",
   "status_low": "Low stock",
   "status_missing": "Out of stock",
+  "status_legend": "Legend: yellow – low stock; red – out of stock",
   "storage.freezer": "Freezer",
   "storage.fridge": "Fridge",
   "storage.pantry": "Pantry",

--- a/app/static/translations/pl.json
+++ b/app/static/translations/pl.json
@@ -163,6 +163,7 @@
   "state_filter_missing": "Brak produktu",
   "status_low": "Końcówka",
   "status_missing": "Brak produktu",
+  "status_legend": "Legenda: żółty – końcówka; czerwony – brak",
   "storage.freezer": "Zamrażarka",
   "storage.fridge": "Lodówka",
   "storage.pantry": "Spiżarka",

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -133,7 +133,7 @@
                             <th data-i18n="table_header_unit">Jednostka</th>
                             <th data-i18n="table_header_category">Kategoria</th>
                             <th data-i18n="table_header_storage">Miejsce</th>
-                            <th class="status-header text-center"><i class="fa-solid fa-circle-info"></i> <span class="status-label" data-i18n="table_header_status">Status</span></th>
+                            <th class="status-header text-center"><span class="tooltip tooltip-bottom" data-tip="" data-i18n-tip="status_legend"><i class="fa-solid fa-circle-info"></i></span> <span class="status-label" data-i18n="table_header_status">Status</span></th>
                         </tr>
                     </thead>
                     <tbody></tbody>


### PR DESCRIPTION
## Summary
- add getStockState helper and use it for filtering, icons, and row styles
- reapply low/zero stock highlighting in product and shopping tables
- document status colors via translated tooltip

## Testing
- `npx eslint app/static/js`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689cc992901c832a886c8d6d3a141053