### PR TITLE
feat: improve translation fallbacks

### DIFF
--- a/app/static/js/components/ocr-modal.js
+++ b/app/static/js/components/ocr-modal.js
@@ -1,4 +1,4 @@
-import { t, state, fetchJson, labelProduct } from "../helpers.js";
+import { t, state, fetchJson } from "../helpers.js";
 import { addToShoppingList, renderShoppingList } from "./shopping-list.js";
 import { toast } from "./toast.js";
 
@@ -69,7 +69,7 @@ export async function handleReceiptUpload(file) {
     nameInput.type = "text";
     const firstMatch = item.matches[0];
     nameInput.value = firstMatch
-      ? labelProduct(firstMatch.name, state.currentLang)
+      ? t(firstMatch.name, "products")
       : item.original;
     if (firstMatch) nameInput.dataset.key = firstMatch.name;
     nameInput.className = "input input-bordered w-full";
@@ -90,11 +90,11 @@ export async function handleReceiptUpload(file) {
       item.matches.forEach((m) => {
         const opt = document.createElement("option");
         opt.value = m.name;
-        opt.textContent = labelProduct(m.name, state.currentLang);
+        opt.textContent = t(m.name, "products");
         select.appendChild(opt);
       });
       select.addEventListener("change", () => {
-        nameInput.value = labelProduct(select.value, state.currentLang);
+        nameInput.value = t(select.value, "products");
         nameInput.dataset.key = select.value;
       });
       statusTd.appendChild(select);

--- a/app/static/js/components/product-table.js
+++ b/app/static/js/components/product-table.js
@@ -13,9 +13,6 @@ import {
   isSpice,
   debounce,
   dlog,
-  labelProduct,
-  labelCategory,
-  labelUnit,
   getProduct,
   DEBUG,
 } from "../helpers.js";
@@ -281,7 +278,7 @@ function createFlatRow(p, idx, editable) {
     // name
     const nameTd = document.createElement("td");
     nameTd.className = "name-cell";
-    nameTd.textContent = labelProduct(p.id, state.currentLang);
+    nameTd.textContent = t(p.id, "products");
     if (!getProduct(p.id)) nameTd.classList.add("opacity-60");
     tr.appendChild(nameTd);
     // quantity with steppers
@@ -298,7 +295,7 @@ function createFlatRow(p, idx, editable) {
       Object.keys(state.units).forEach((u) => {
         const opt = document.createElement("option");
         opt.value = u;
-        opt.textContent = labelUnit(u, state.currentLang);
+        opt.textContent = t(u, "units");
         if (u === p.unit) opt.selected = true;
         unitSel.appendChild(opt);
       });
@@ -313,7 +310,7 @@ function createFlatRow(p, idx, editable) {
     Object.keys(state.domain.categories).forEach((c) => {
       const opt = document.createElement("option");
       opt.value = c;
-      opt.textContent = labelCategory(c, state.currentLang);
+      opt.textContent = t(c, "categories");
       if (c === (p.category || "")) opt.selected = true;
       catSel.appendChild(opt);
     });
@@ -344,17 +341,17 @@ function createFlatRow(p, idx, editable) {
     tr.appendChild(statusTd);
   } else {
     const nameTd = document.createElement("td");
-    nameTd.textContent = labelProduct(p.id, state.currentLang);
+    nameTd.textContent = t(p.id, "products");
     if (!getProduct(p.id)) nameTd.classList.add("opacity-60");
     tr.appendChild(nameTd);
     const qtyTd = document.createElement("td");
     qtyTd.textContent = formatPackQuantity(p);
     tr.appendChild(qtyTd);
     const unitTd = document.createElement("td");
-    unitTd.textContent = isSpice(p) ? "" : labelUnit(p.unit, state.currentLang);
+    unitTd.textContent = isSpice(p) ? "" : t(p.unit, "units");
     tr.appendChild(unitTd);
     const catTd = document.createElement("td");
-    catTd.textContent = labelCategory(p.category, state.currentLang);
+    catTd.textContent = t(p.category, "categories");
     if (!state.domain.categories[p.category]) catTd.classList.add("opacity-60");
     tr.appendChild(catTd);
     const storTd = document.createElement("td");
@@ -394,12 +391,12 @@ export function renderProducts() {
       ...dp,
       ...existing,
       id: dp.id,
-      name: labelProduct(dp.id, state.currentLang),
+      name: t(dp.id, "products"),
     });
     return {
       ...merged,
-      unitLabel: labelUnit(merged.unit, state.currentLang),
-      categoryLabel: labelCategory(merged.category, state.currentLang),
+      unitLabel: t(merged.unit, "units"),
+      categoryLabel: t(merged.category, "categories"),
       storageLabel: t(STORAGE_KEYS[merged.storage] || merged.storage),
       status: stockLevel(merged),
     };
@@ -411,7 +408,7 @@ export function renderProducts() {
     (p) =>
       matchesFilter(p, filter) &&
       (!term ||
-        labelProduct(p.id, state.currentLang).toLowerCase().includes(term) ||
+        t(p.id, "products").toLowerCase().includes(term) ||
         p.name.toLowerCase().includes(term)),
   );
 
@@ -513,9 +510,7 @@ export function renderProducts() {
               .sort(
                 (a, b) =>
                   (CATEGORY_ORDER[a] || 0) - (CATEGORY_ORDER[b] || 0) ||
-                  labelCategory(a, state.currentLang).localeCompare(
-                    labelCategory(b, state.currentLang),
-                  ),
+                  t(a, "categories").localeCompare(t(b, "categories")),
               )
               .forEach((cat) => {
                 const catBlock = document.createElement("div");
@@ -529,7 +524,7 @@ export function renderProducts() {
                   catHeader.classList.add("cursor-pointer");
                 const catSpan = document.createElement("span");
                 catSpan.className = "font-medium";
-                catSpan.textContent = labelCategory(cat, state.currentLang);
+                catSpan.textContent = t(cat, "categories");
                 if (!state.domain.categories[cat])
                   catSpan.classList.add("opacity-60");
                 const catBtn = document.createElement("button");
@@ -609,13 +604,13 @@ export function renderProducts() {
                     cbTd.appendChild(cb);
                     tr.appendChild(cbTd);
                     const n = document.createElement("td");
-                    n.textContent = labelProduct(p.id, state.currentLang);
+                    n.textContent = t(p.id, "products");
                     if (!getProduct(p.id)) n.classList.add("opacity-60");
                     tr.appendChild(n);
                     const q = buildQtyCell(p, tr);
                     tr.appendChild(q);
                     const u = document.createElement("td");
-                    u.textContent = labelUnit(p.unit, state.currentLang);
+                    u.textContent = t(p.unit, "units");
                     tr.appendChild(u);
                     const s = document.createElement("td");
                     const ic = getStatusIcon(p);
@@ -626,12 +621,12 @@ export function renderProducts() {
                     tr.appendChild(s);
                   } else {
                     const n = document.createElement("td");
-                    n.textContent = labelProduct(p.id, state.currentLang);
+                    n.textContent = t(p.id, "products");
                     if (!getProduct(p.id)) n.classList.add("opacity-60");
                     const q = document.createElement("td");
                     q.textContent = formatPackQuantity(p);
                     const u = document.createElement("td");
-                    u.textContent = labelUnit(p.unit, state.currentLang);
+                    u.textContent = t(p.unit, "units");
                     const s = document.createElement("td");
                     const ic = getStatusIcon(p);
                     if (ic) {

--- a/app/static/js/components/recipe-detail.js
+++ b/app/static/js/components/recipe-detail.js
@@ -1,10 +1,4 @@
-import {
-  state,
-  t,
-  toggleFavorite,
-  labelProduct,
-  labelUnit,
-} from "../helpers.js";
+import { state, t, toggleFavorite } from "../helpers.js";
 
 function renderRecipeDetail(r) {
   const title = r.names?.[state.currentLang] || r.names?.en || r.id;
@@ -26,14 +20,11 @@ function renderRecipeDetail(r) {
 
   const ingRows = (r.ingredients || [])
     .map((i) => {
-      const name =
-        i.productName || labelProduct(i.productId, state.currentLang);
+      const name = i.productName || t(i.productId, "products");
       const qty = (i.qty ?? "").toString();
-      const unit =
-        i.unitName || (i.unitId ? labelUnit(i.unitId, state.currentLang) : "");
+      const unit = i.unitName || (i.unitId ? t(i.unitId, "units") : "");
       const qtyStr = [qty, unit].filter(Boolean).join(" ");
-      const unknownLabel = state.currentLang === "pl" ? "Nieznane" : "Unknown";
-      const unknown = name === unknownLabel ? " opacity-60" : "";
+      const unknown = name === i.productId ? " opacity-60" : "";
       return `<tr><td class="pr-4${unknown}">${name}</td><td class="text-right">${qtyStr}</td></tr>`;
     })
     .join("");

--- a/app/static/js/components/shopping-list.js
+++ b/app/static/js/components/shopping-list.js
@@ -1,11 +1,4 @@
-import {
-  t,
-  state,
-  isSpice,
-  stockLevel,
-  fetchJson,
-  labelProduct,
-} from "../helpers.js";
+import { t, state, isSpice, stockLevel, fetchJson } from "../helpers.js";
 import { toast } from "./toast.js";
 
 function saveShoppingList() {
@@ -60,9 +53,7 @@ function sortShoppingList() {
   state.shoppingList.sort((a, b) => {
     if (a.inCart && b.inCart) return (a.cartTime || 0) - (b.cartTime || 0);
     if (a.inCart !== b.inCart) return a.inCart ? 1 : -1;
-    return labelProduct(a.name, state.currentLang).localeCompare(
-      labelProduct(b.name, state.currentLang),
-    );
+    return t(a.name, "products").localeCompare(t(b.name, "products"));
   });
 }
 
@@ -87,11 +78,10 @@ function renderShoppingItem(item, idx) {
   nameWrap.className = "flex items-center gap-1 overflow-hidden";
   const nameEl = document.createElement("span");
   nameEl.className = "truncate";
-  const lbl = labelProduct(item.name, state.currentLang);
+  const lbl = t(item.name, "products");
   nameEl.textContent = lbl;
   nameEl.title = lbl;
-  const unknownLabel = state.currentLang === "pl" ? "Nieznane" : "Unknown";
-  if (lbl === unknownLabel) nameEl.classList.add("opacity-60");
+  if (lbl === item.name) nameEl.classList.add("opacity-60");
   if (item.inCart) nameEl.classList.add("line-through");
   nameWrap.appendChild(nameEl);
   if (stock && stock.quantity > 0) {
@@ -244,9 +234,7 @@ export function renderSuggestions() {
     })
     .filter((p) => !state.dismissedSuggestions.has(p.name))
     .sort((a, b) =>
-      labelProduct(a.id, state.currentLang).localeCompare(
-        labelProduct(b.id, state.currentLang),
-      ),
+      t(a.id, "products").localeCompare(t(b.id, "products")),
     );
   const frag = document.createDocumentFragment();
   suggestions.forEach((p) => {
@@ -262,11 +250,10 @@ export function renderSuggestions() {
     nameWrap.className = "flex items-center gap-1 overflow-hidden";
     const nameEl = document.createElement("span");
     nameEl.className = "truncate";
-    const lbl = labelProduct(p.id, state.currentLang);
+    const lbl = t(p.id, "products");
     nameEl.textContent = lbl;
     nameEl.title = lbl;
-    const unknownLabel = state.currentLang === "pl" ? "Nieznane" : "Unknown";
-    if (!lbl || lbl === unknownLabel) nameEl.classList.add("opacity-60");
+    if (lbl === p.id) nameEl.classList.add("opacity-60");
     nameWrap.appendChild(nameEl);
     if (p.quantity > 0) {
       const owned = document.createElement("span");

--- a/app/static/js/helpers.js
+++ b/app/static/js/helpers.js
@@ -111,8 +111,34 @@ export function throttle(fn, delay = 200) {
   };
 }
 
-export function t(key) {
+export function t(key, ns = "ui") {
   if (!key) return key;
+  if (ns === "products") {
+    const p =
+      state.domain.products[key] ||
+      state.domain.products[state.domain.aliases[key]];
+    if (!p) {
+      warnOnce("products", key);
+      return key;
+    }
+    return p.names[state.currentLang] ?? p.names.en ?? key;
+  }
+  if (ns === "categories") {
+    const c = state.domain.categories[key];
+    if (!c) {
+      warnOnce("categories", key);
+      return key;
+    }
+    return c.names[state.currentLang] ?? c.names.en ?? key;
+  }
+  if (ns === "units") {
+    const u = state.domain.units[key];
+    if (!u) {
+      warnOnce("units", key);
+      return key;
+    }
+    return u.names[state.currentLang] ?? u.names.en ?? key;
+  }
   return (
     state.uiTranslations[state.currentLang]?.[key] ??
     state.uiTranslations.en?.[key] ??
@@ -344,16 +370,11 @@ export function getProduct(id) {
   return resolveProduct(id);
 }
 
-const UNKNOWN_LABELS = { pl: "Nieznane", en: "Unknown" };
 const warnedIds = {
   products: new Set(),
   units: new Set(),
   categories: new Set(),
 };
-
-function unknownLabel(locale = state.currentLang) {
-  return UNKNOWN_LABELS[locale] || UNKNOWN_LABELS.en;
-}
 
 function warnOnce(type, id) {
   if (!id) return;
@@ -362,45 +383,6 @@ function warnOnce(type, id) {
     set.add(id);
     console.warn(`Unknown ${type.slice(0, -1)} id`, id);
   }
-}
-
-export function labelProduct(id, locale = state.currentLang) {
-  if (!id) {
-    warnOnce("products", id);
-    return unknownLabel(locale);
-  }
-  const p = resolveProduct(id);
-  if (!p) {
-    warnOnce("products", id);
-    return unknownLabel(locale);
-  }
-  return p.names[locale] ?? p.names.en ?? unknownLabel(locale);
-}
-
-export function labelCategory(id, locale = state.currentLang) {
-  if (!id) {
-    warnOnce("categories", id);
-    return unknownLabel(locale);
-  }
-  const c = state.domain.categories[id];
-  if (!c) {
-    warnOnce("categories", id);
-    return unknownLabel(locale);
-  }
-  return c.names[locale] ?? c.names.en ?? unknownLabel(locale);
-}
-
-export function labelUnit(id, locale = state.currentLang) {
-  if (!id) {
-    warnOnce("units", id);
-    return unknownLabel(locale);
-  }
-  const u = state.domain.units[id];
-  if (!u) {
-    warnOnce("units", id);
-    return unknownLabel(locale);
-  }
-  return u.names[locale] ?? u.names.en ?? unknownLabel(locale);
 }
 
 export async function searchProducts(query) {


### PR DESCRIPTION
## Summary
- add namespaced `t` helper with en fallback and key display
- use `t` for product, unit, and category labels across UI
- drop custom label helpers and placeholder logic

## Testing
- `pytest`
- `pre-commit run --files app/static/js/helpers.js app/static/js/components/product-table.js app/static/js/components/shopping-list.js app/static/js/components/recipe-detail.js app/static/js/components/ocr-modal.js` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689ccc024a30832aa9d794d77d79b726