### PR TITLE
feat: highlight low and missing stock

### DIFF
--- a/app/static/js/components/product-table.js
+++ b/app/static/js/components/product-table.js
@@ -7,7 +7,7 @@ import {
   CATEGORY_ORDER,
   STORAGE_KEYS,
   matchesFilter,
-  stockLevel,
+  getStockState,
   normalizeProduct,
   fetchJson,
   isSpice,
@@ -141,13 +141,13 @@ function highlightRow(tr, p) {
     "opacity-60",
     "font-semibold",
   );
-  const level = stockLevel(p);
+  const level = getStockState(p);
   if (p.main) {
-    if (level === "none")
+    if (level === "zero")
       tr.classList.add("text-error", "bg-error/10", "font-semibold");
     else if (level === "low") tr.classList.add("text-warning", "bg-warning/10");
   } else {
-    if (level === "none")
+    if (level === "zero")
       tr.classList.add("text-error", "bg-error/10", "opacity-60");
     else if (level === "low")
       tr.classList.add("text-warning", "bg-warning/10", "opacity-60");
@@ -398,7 +398,7 @@ export function renderProducts() {
       unitLabel: t(merged.unit, "units"),
       categoryLabel: t(merged.category, "categories"),
       storageLabel: t(STORAGE_KEYS[merged.storage] || merged.storage),
-      status: stockLevel(merged),
+      status: getStockState(merged),
     };
   });
   APP.state.products = data;

--- a/app/static/js/components/shopping-list.js
+++ b/app/static/js/components/shopping-list.js
@@ -1,4 +1,4 @@
-import { t, state, isSpice, stockLevel, fetchJson } from "../helpers.js";
+import { t, state, isSpice, getStockState, fetchJson } from "../helpers.js";
 import { toast } from "./toast.js";
 
 function saveShoppingList() {
@@ -69,9 +69,9 @@ function renderShoppingItem(item, idx) {
     (p) => p.name === item.name,
   );
   if (stock) {
-    const level = stockLevel(stock);
+    const level = getStockState(stock);
     if (level === "low") row.classList.add("product-low");
-    if (level === "none") row.classList.add("product-missing");
+    if (level === "zero") row.classList.add("product-missing");
   }
 
   const nameWrap = document.createElement("div");
@@ -225,7 +225,7 @@ export function renderSuggestions() {
   const suggestions = products
     .filter((p) => {
       if (isSpice(p)) {
-        return ["none", "low"].includes(p.level);
+        return ["low", "zero"].includes(getStockState(p));
       }
       return (
         p.main &&
@@ -233,18 +233,16 @@ export function renderSuggestions() {
       );
     })
     .filter((p) => !state.dismissedSuggestions.has(p.name))
-    .sort((a, b) =>
-      t(a.id, "products").localeCompare(t(b.id, "products")),
-    );
+    .sort((a, b) => t(a.id, "products").localeCompare(t(b.id, "products")));
   const frag = document.createDocumentFragment();
   suggestions.forEach((p) => {
     let qty = p.threshold != null ? p.threshold : 1;
     const row = document.createElement("div");
     row.className =
       "suggestion-item gap-2 h-11 hover:bg-base-200 transition-colors";
-    const level = stockLevel(p);
+    const level = getStockState(p);
     if (level === "low") row.classList.add("product-low");
-    if (level === "none") row.classList.add("product-missing");
+    if (level === "zero") row.classList.add("product-missing");
 
     const nameWrap = document.createElement("div");
     nameWrap.className = "flex items-center gap-1 overflow-hidden";

--- a/app/static/js/helpers.js
+++ b/app/static/js/helpers.js
@@ -156,6 +156,14 @@ export function applyTranslations() {
       el.textContent = txt;
     }
   });
+  document.querySelectorAll("[data-i18n-title]").forEach((el) => {
+    const key = el.getAttribute("data-i18n-title");
+    el.title = t(key);
+  });
+  document.querySelectorAll("[data-i18n-tip]").forEach((el) => {
+    const key = el.getAttribute("data-i18n-tip");
+    el.setAttribute("data-tip", t(key));
+  });
 }
 
 export function parseTimeToMinutes(value) {
@@ -244,8 +252,8 @@ export function formatPackQuantity(p) {
 }
 
 export function getStatusIcon(p) {
-  const level = stockLevel(p);
-  if (level === "none") {
+  const level = getStockState(p);
+  if (level === "zero") {
     return {
       html: '<i class="fa-regular fa-circle-exclamation text-red-600"></i>',
       title: t("status_missing"),
@@ -502,28 +510,27 @@ export function isSpice(p = {}) {
   return p.category === "spices" || p.is_spice === true;
 }
 
-export function stockLevel(p = {}) {
+export function getStockState(p = {}) {
   if (isSpice(p)) {
     const lvl = String(p.level || "").toLowerCase();
-    if (lvl === "brak" || lvl === "none") return "none";
+    if (lvl === "brak" || lvl === "none" || lvl === "zero") return "zero";
     if (lvl === "malo" || lvl === "low") return "low";
     return "ok";
   }
-  if (p.quantity === 0) return "none";
+  if (p.quantity === 0) return "zero";
   if (p.threshold != null && p.quantity <= p.threshold) return "low";
   return "ok";
 }
 
 export function matchesFilter(p = {}, filter = "all") {
-  const level = stockLevel(p);
+  const state = getStockState(p);
   switch (filter) {
     case "available":
-      if (p.quantity == null || p.quantity === 0) return true;
-      return level === "ok";
+      return state === "ok";
     case "low":
-      return level === "low";
+      return state === "low";
     case "missing":
-      return level === "none";
+      return state === "zero";
     default:
       return true;
   }

--- a/app/static/translations/en.json
+++ b/app/static/translations/en.json
@@ -164,6 +164,7 @@
   "state_filter_missing": "Out of stock",
   "status_low": "Low stock",
   "status_missing": "Out of stock",
+  "stock_legend": "Low stock highlighted in orange; out of stock in red",
   "storage.freezer": "Freezer",
   "storage.fridge": "Fridge",
   "storage.pantry": "Pantry",

--- a/app/static/translations/pl.json
+++ b/app/static/translations/pl.json
@@ -164,6 +164,7 @@
   "state_filter_missing": "Brak produktu",
   "status_low": "Końcówka",
   "status_missing": "Brak produktu",
+  "stock_legend": "Legenda: końcówka (pomarańczowy), brak produktu (czerwony)",
   "storage.freezer": "Zamrażarka",
   "storage.fridge": "Lodówka",
   "storage.pantry": "Spiżarka",

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -2,484 +2,1114 @@
 <!-- FIX: Render & responsive boot (2025-08-09) -->
 <html lang="pl" data-layout="desktop">
   <head>
-    <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Food App</title>
-    <link rel="manifest" href="/manifest.json">
-    <meta name="theme-color" content="#ffffff">
-    <link rel="apple-touch-icon" href="/static/icons/icon-192x192.png">
-    <meta name="apple-mobile-web-app-capable" content="yes">
-    <meta name="apple-mobile-web-app-status-bar-style" content="default">
-    <meta name="apple-mobile-web-app-title" content="Food App">
-      <script>
-        window.DEBUG = false;
-        (() => {
-          const key = 'theme';
-          const mql = window.matchMedia('(prefers-color-scheme: dark)');
-          const apply = t => {
-            document.documentElement.setAttribute('data-theme', t);
-            document.documentElement.style.colorScheme = t;
-            const meta = document.querySelector('meta[name="theme-color"]');
-            if (meta) {
-              const update = () => {
-                const color = getComputedStyle(document.documentElement).getPropertyValue('--theme-color').trim();
-                if (color) meta.setAttribute('content', color);
-              };
-              update();
-              window.addEventListener('load', update, { once: true });
-            }
-          };
-          const resolve = () => {
-            const stored = localStorage.getItem(key) || 'system';
-            return stored === 'system' ? (mql.matches ? 'dark' : 'light') : stored;
-          };
-          apply(resolve());
-          if (window.DEBUG) console.info('theme:', resolve());
-          mql.addEventListener('change', e => {
-            if ((localStorage.getItem(key) || 'system') === 'system') {
-              const t = e.matches ? 'dark' : 'light';
-              apply(t);
-              if (window.DEBUG) console.info('theme:', t);
-            }
-          });
-          window.setTheme = v => {
-            localStorage.setItem(key, v);
-            const t = v === 'system' ? (mql.matches ? 'dark' : 'light') : v;
+    <link rel="manifest" href="/manifest.json" />
+    <meta name="theme-color" content="#ffffff" />
+    <link rel="apple-touch-icon" href="/static/icons/icon-192x192.png" />
+    <meta name="apple-mobile-web-app-capable" content="yes" />
+    <meta name="apple-mobile-web-app-status-bar-style" content="default" />
+    <meta name="apple-mobile-web-app-title" content="Food App" />
+    <script>
+      window.DEBUG = false;
+      (() => {
+        const key = "theme";
+        const mql = window.matchMedia("(prefers-color-scheme: dark)");
+        const apply = (t) => {
+          document.documentElement.setAttribute("data-theme", t);
+          document.documentElement.style.colorScheme = t;
+          const meta = document.querySelector('meta[name="theme-color"]');
+          if (meta) {
+            const update = () => {
+              const color = getComputedStyle(document.documentElement)
+                .getPropertyValue("--theme-color")
+                .trim();
+              if (color) meta.setAttribute("content", color);
+            };
+            update();
+            window.addEventListener("load", update, { once: true });
+          }
+        };
+        const resolve = () => {
+          const stored = localStorage.getItem(key) || "system";
+          return stored === "system"
+            ? mql.matches
+              ? "dark"
+              : "light"
+            : stored;
+        };
+        apply(resolve());
+        if (window.DEBUG) console.info("theme:", resolve());
+        mql.addEventListener("change", (e) => {
+          if ((localStorage.getItem(key) || "system") === "system") {
+            const t = e.matches ? "dark" : "light";
             apply(t);
-            if (window.DEBUG) console.info('theme:', t);
-          };
-        })();
-      </script>
-      <link href="https://cdn.jsdelivr.net/npm/daisyui@4.10.2/dist/full.min.css" rel="stylesheet" type="text/css" />
-      <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css">
-      <link rel="stylesheet" href="{{ url_for('static', filename='styles.css') }}?v={{ app_version }}">
-      </head>
-<body class="min-h-screen bg-base-100">
-<div id="top-sentinel"></div>
-<div id="health-banner" class="alert alert-error hidden justify-between">
-    <span data-i18n="error">Error</span>
-    <button id="health-retry" class="btn btn-sm" data-i18n="retry">Retry</button>
-</div>
-<div id="notification-container" class="toast toast-end top-auto bottom-[4.5rem] z-40" aria-live="polite"></div>
-<div id="top-banner-container" class="sticky top-0 z-30"></div>
-<header class="app-bar bg-base-100">
-  <div class="left flex items-center gap-2">
-    <span class="app-title font-bold text-lg">Food App</span>
-    <span id="locale-chip" class="badge">PL</span>
-  </div>
-  <div class="tabs-wrap">
-    <div class="tabs tabs-bordered flex-nowrap overflow-x-auto whitespace-nowrap desktop-nav">
-        <a class="tab tab-active font-bold" data-tab-target="tab-products" data-i18n="tab_products">Produkty</a>
-        <a class="tab" data-tab-target="tab-recipes" data-i18n="tab_recipes">Przepisy</a>
-        <a class="tab" data-tab-target="tab-history" data-i18n="tab_history">Historia dań</a>
-        <a class="tab" data-tab-target="tab-shopping" data-i18n="tab_shopping">Lista zakupów</a>
-    </div>
-  </div>
-  <div class="actions">
-    <button id="layout-toggle" aria-label="Toggle layout" class="text-xl p-2 bg-transparent border-0">
-        <i id="layout-icon" class="fa-solid fa-mobile-screen-button"></i>
-    </button>
-    <button id="lang-toggle" aria-label="Toggle language" class="flex items-center gap-1 text-xl p-2 bg-transparent border-0">
-        <i class="fa-solid fa-language"></i>
-        <span class="action-label hidden md:inline" data-i18n="language">Language</span>
-    </button>
-      <button id="theme-toggle" aria-label="Toggle theme" class="flex items-center gap-1 text-xl p-2 bg-transparent border-0">
-          <i id="theme-icon" class="fa-solid fa-desktop"></i>
-          <span class="action-label hidden md:inline" data-i18n="theme">Theme</span>
+            if (window.DEBUG) console.info("theme:", t);
+          }
+        });
+        window.setTheme = (v) => {
+          localStorage.setItem(key, v);
+          const t = v === "system" ? (mql.matches ? "dark" : "light") : v;
+          apply(t);
+          if (window.DEBUG) console.info("theme:", t);
+        };
+      })();
+    </script>
+    <link
+      href="https://cdn.jsdelivr.net/npm/daisyui@4.10.2/dist/full.min.css"
+      rel="stylesheet"
+      type="text/css"
+    />
+    <link
+      rel="stylesheet"
+      href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css"
+    />
+    <link
+      rel="stylesheet"
+      href="{{ url_for('static', filename='styles.css') }}?v={{ app_version }}"
+    />
+  </head>
+  <body class="min-h-screen bg-base-100">
+    <div id="top-sentinel"></div>
+    <div id="health-banner" class="alert alert-error hidden justify-between">
+      <span data-i18n="error">Error</span>
+      <button id="health-retry" class="btn btn-sm" data-i18n="retry">
+        Retry
       </button>
-    <button id="install-btn" aria-label="Install app" class="text-xl p-2 bg-transparent border-0" style="display:none;">
-        <i class="fa-solid fa-download"></i>
-    </button>
-    <button id="settings-btn" aria-label="Settings" class="flex items-center gap-1 text-xl p-2 bg-transparent border-0">
-        <i class="fa-solid fa-gear"></i>
-        <span class="action-label hidden md:inline" data-i18n="tab_settings">Settings</span>
-    </button>
-  </div>
-</header>
-  <main class="main-container">
-        <div id="tab-products" class="tab-panel">
-            <h1 class="text-xl md:text-2xl font-semibold mb-3 md:mb-4" data-i18n="heading_products">Produkty</h1>
-            <div id="controls" class="flex flex-wrap items-center gap-4 mb-4">
-                <div class="flex flex-col md:flex-row gap-2 items-start md:items-center flex-1">
-                    <input id="product-search" placeholder="Szukaj produktu" data-i18n="search_placeholder" class="input input-bordered flex-1 min-w-[200px]" />
-                    <select id="state-filter" class="select select-bordered w-full md:w-auto">
-                        <option value="all" data-i18n="state_filter_all">Wszystkie</option>
-                        <option value="available" data-i18n="state_filter_available" selected>Dostępne</option>
-                        <option value="missing" data-i18n="state_filter_missing">Brakujące</option>
-                        <option value="low" data-i18n="state_filter_low">Kończące się</option>
-                    </select>
-                </div>
-                <button id="view-toggle" class="btn btn-outline btn-primary btn-sm" role="switch" aria-pressed="false" aria-label="Widok z podziałem" data-i18n="change_view_toggle_grouped">Widok z podziałem</button>
-                <button id="edit-toggle" class="btn btn-outline btn-warning btn-sm" role="switch" aria-pressed="false" aria-label="Tryb edycji" data-i18n="edit_mode_button_on">Tryb edycji</button>
-                <button id="save-btn" style="display:none;" class="btn btn-success btn-sm" aria-label="Zapisz" data-i18n="save_button">Zapisz</button>
-                <button id="delete-selected" style="display:none;" class="btn btn-error btn-sm" disabled aria-label="Usuń zaznaczone" data-i18n="delete_selected_button">Usuń zaznaczone</button>
+    </div>
+    <div
+      id="notification-container"
+      class="toast toast-end top-auto bottom-[4.5rem] z-40"
+      aria-live="polite"
+    ></div>
+    <div id="top-banner-container" class="sticky top-0 z-30"></div>
+    <header class="app-bar bg-base-100">
+      <div class="left flex items-center gap-2">
+        <span class="app-title font-bold text-lg">Food App</span>
+        <span id="locale-chip" class="badge">PL</span>
+      </div>
+      <div class="tabs-wrap">
+        <div
+          class="tabs tabs-bordered flex-nowrap overflow-x-auto whitespace-nowrap desktop-nav"
+        >
+          <a
+            class="tab tab-active font-bold"
+            data-tab-target="tab-products"
+            data-i18n="tab_products"
+            >Produkty</a
+          >
+          <a class="tab" data-tab-target="tab-recipes" data-i18n="tab_recipes"
+            >Przepisy</a
+          >
+          <a class="tab" data-tab-target="tab-history" data-i18n="tab_history"
+            >Historia dań</a
+          >
+          <a class="tab" data-tab-target="tab-shopping" data-i18n="tab_shopping"
+            >Lista zakupów</a
+          >
+        </div>
+      </div>
+      <div class="actions">
+        <button
+          id="layout-toggle"
+          aria-label="Toggle layout"
+          class="text-xl p-2 bg-transparent border-0"
+        >
+          <i id="layout-icon" class="fa-solid fa-mobile-screen-button"></i>
+        </button>
+        <button
+          id="lang-toggle"
+          aria-label="Toggle language"
+          class="flex items-center gap-1 text-xl p-2 bg-transparent border-0"
+        >
+          <i class="fa-solid fa-language"></i>
+          <span class="action-label hidden md:inline" data-i18n="language"
+            >Language</span
+          >
+        </button>
+        <button
+          id="theme-toggle"
+          aria-label="Toggle theme"
+          class="flex items-center gap-1 text-xl p-2 bg-transparent border-0"
+        >
+          <i id="theme-icon" class="fa-solid fa-desktop"></i>
+          <span class="action-label hidden md:inline" data-i18n="theme"
+            >Theme</span
+          >
+        </button>
+        <button
+          id="install-btn"
+          aria-label="Install app"
+          class="text-xl p-2 bg-transparent border-0"
+          style="display: none"
+        >
+          <i class="fa-solid fa-download"></i>
+        </button>
+        <button
+          id="settings-btn"
+          aria-label="Settings"
+          class="flex items-center gap-1 text-xl p-2 bg-transparent border-0"
+        >
+          <i class="fa-solid fa-gear"></i>
+          <span class="action-label hidden md:inline" data-i18n="tab_settings"
+            >Settings</span
+          >
+        </button>
+      </div>
+    </header>
+    <main class="main-container">
+      <div id="tab-products" class="tab-panel">
+        <h1
+          class="text-xl md:text-2xl font-semibold mb-3 md:mb-4"
+          data-i18n="heading_products"
+        >
+          Produkty
+        </h1>
+        <div id="controls" class="flex flex-wrap items-center gap-4 mb-4">
+          <div
+            class="flex flex-col md:flex-row gap-2 items-start md:items-center flex-1"
+          >
+            <input
+              id="product-search"
+              placeholder="Szukaj produktu"
+              data-i18n="search_placeholder"
+              class="input input-bordered flex-1 min-w-[200px]"
+            />
+            <select
+              id="state-filter"
+              class="select select-bordered w-full md:w-auto"
+            >
+              <option value="all" data-i18n="state_filter_all">
+                Wszystkie
+              </option>
+              <option
+                value="available"
+                data-i18n="state_filter_available"
+                selected
+              >
+                Dostępne
+              </option>
+              <option value="missing" data-i18n="state_filter_missing">
+                Brakujące
+              </option>
+              <option value="low" data-i18n="state_filter_low">
+                Kończące się
+              </option>
+            </select>
+          </div>
+          <button
+            id="view-toggle"
+            class="btn btn-outline btn-primary btn-sm"
+            role="switch"
+            aria-pressed="false"
+            aria-label="Widok z podziałem"
+            data-i18n="change_view_toggle_grouped"
+          >
+            Widok z podziałem
+          </button>
+          <button
+            id="edit-toggle"
+            class="btn btn-outline btn-warning btn-sm"
+            role="switch"
+            aria-pressed="false"
+            aria-label="Tryb edycji"
+            data-i18n="edit_mode_button_on"
+          >
+            Tryb edycji
+          </button>
+          <button
+            id="save-btn"
+            style="display: none"
+            class="btn btn-success btn-sm"
+            aria-label="Zapisz"
+            data-i18n="save_button"
+          >
+            Zapisz
+          </button>
+          <button
+            id="delete-selected"
+            style="display: none"
+            class="btn btn-error btn-sm"
+            disabled
+            aria-label="Usuń zaznaczone"
+            data-i18n="delete_selected_button"
+          >
+            Usuń zaznaczone
+          </button>
+        </div>
+        <div class="overflow-x-auto">
+          <table
+            id="product-table"
+            class="table table-zebra table-fixed w-full text-sm"
+          >
+            <colgroup>
+              <col style="width: 6%" />
+              <col style="width: 24%" />
+              <col style="width: 12%" />
+              <col style="width: 12%" />
+              <col style="width: 17%" />
+              <col style="width: 17%" />
+              <col style="width: 12%" />
+            </colgroup>
+            <thead>
+              <tr>
+                <th id="select-header" style="display: none"></th>
+                <th data-i18n="table_header_name">Nazwa</th>
+                <th data-i18n="table_header_quantity">Ilość</th>
+                <th data-i18n="table_header_unit">Jednostka</th>
+                <th data-i18n="table_header_category">Kategoria</th>
+                <th data-i18n="table_header_storage">Miejsce</th>
+                <th class="status-header text-center">
+                  <span class="tooltip" data-i18n-tip="stock_legend"
+                    ><i class="fa-solid fa-circle-info"></i
+                  ></span>
+                  <span class="status-label" data-i18n="table_header_status"
+                    >Status</span
+                  >
+                </th>
+              </tr>
+            </thead>
+            <tbody></tbody>
+          </table>
+          <div id="products-by-category" style="display: none"></div>
+        </div>
+
+        <dialog id="delete-modal" class="modal">
+          <form method="dialog" class="modal-box">
+            <h3 class="font-bold text-lg" data-i18n="delete_modal_title">
+              Potwierdź usunięcie
+            </h3>
+            <p class="py-4" data-i18n="delete_modal_question">
+              Czy na pewno chcesz usunąć zaznaczone produkty?
+            </p>
+            <div id="delete-summary" class="space-y-1"></div>
+            <div class="modal-action">
+              <button
+                id="confirm-delete"
+                class="btn btn-error btn-sm"
+                data-i18n="delete_confirm_button"
+                aria-label="Usuń"
+              >
+                Usuń
+              </button>
+              <button
+                id="cancel-delete"
+                class="btn btn-outline btn-sm"
+                data-i18n="delete_cancel_button"
+                aria-label="Anuluj"
+              >
+                Anuluj
+              </button>
             </div>
-            <div class="overflow-x-auto">
-                <table id="product-table" class="table table-zebra table-fixed w-full text-sm">
-                    <colgroup>
-                        <col style="width:6%">
-                        <col style="width:24%">
-                        <col style="width:12%">
-                        <col style="width:12%">
-                        <col style="width:17%">
-                        <col style="width:17%">
-                        <col style="width:12%">
-                    </colgroup>
-                    <thead>
-                        <tr>
-                            <th id="select-header" style="display:none;"></th>
-                            <th data-i18n="table_header_name">Nazwa</th>
-                            <th data-i18n="table_header_quantity">Ilość</th>
-                            <th data-i18n="table_header_unit">Jednostka</th>
-                            <th data-i18n="table_header_category">Kategoria</th>
-                            <th data-i18n="table_header_storage">Miejsce</th>
-                            <th class="status-header text-center"><i class="fa-solid fa-circle-info"></i> <span class="status-label" data-i18n="table_header_status">Status</span></th>
-                        </tr>
-                    </thead>
-                    <tbody></tbody>
-                </table>
-                <div id="products-by-category" style="display:none;"></div>
-            </div>
+          </form>
+        </dialog>
 
-            <dialog id="delete-modal" class="modal">
-                <form method="dialog" class="modal-box">
-                    <h3 class="font-bold text-lg" data-i18n="delete_modal_title">Potwierdź usunięcie</h3>
-                    <p class="py-4" data-i18n="delete_modal_question">Czy na pewno chcesz usunąć zaznaczone produkty?</p>
-                    <div id="delete-summary" class="space-y-1"></div>
-                    <div class="modal-action">
-                        <button id="confirm-delete" class="btn btn-error btn-sm" data-i18n="delete_confirm_button" aria-label="Usuń">Usuń</button>
-                        <button id="cancel-delete" class="btn btn-outline btn-sm" data-i18n="delete_cancel_button" aria-label="Anuluj">Anuluj</button>
-                    </div>
-                </form>
-            </dialog>
+        <div id="add-section" style="display: none">
+          <hr class="border-t border-base-300 my-6" />
 
-            <div id="add-section" style="display:none;">
-            <hr class="border-t border-base-300 my-6">
-
-            <h2 class="text-xl font-semibold mt-6 mb-4" data-i18n="heading_add_edit_product">Dodaj / edytuj produkt</h2>
-            <form id="add-form" class="grid grid-cols-1 sm:grid-cols-8 gap-2 mb-8 items-end">
-                <input name="name" placeholder="nazwa" data-i18n="add_form_name_placeholder" required class="input input-bordered w-full">
-                <input name="quantity" placeholder="ilość" data-i18n="add_form_quantity_placeholder" required class="input input-bordered w-full">
-                <input name="package_size" placeholder="w opak." data-i18n="add_form_package_size_placeholder" class="input input-bordered w-full" type="number" value="1">
-                <input name="pack_size" placeholder="paczka" data-i18n="add_form_pack_size_placeholder" class="input input-bordered w-full" type="number">
-                <input name="threshold" placeholder="próg" data-i18n="add_form_threshold_placeholder" class="input input-bordered w-full" type="number">
-                <div class="mb-4">
-                    <div id="category-checkboxes" class="flex flex-wrap gap-2 mb-2">
-                        <select name="category" required class="select select-bordered w-full">
-                            <option value="uncategorized" data-i18n="category_uncategorized">brak kategorii</option>
-                            <option value="fresh_veg" data-i18n="category_fresh_veg">Świeże warzywa</option>
-                            <option value="mushrooms" data-i18n="category_mushrooms">Grzyby</option>
-                            <option value="dairy_eggs" data-i18n="category_dairy_eggs">Nabiał i jajka</option>
-                            <option value="opened_preserves" data-i18n="category_opened_preserves">Otwarte konserwy i przetwory</option>
-                            <option value="ready_sauces" data-i18n="category_ready_sauces">Sosy</option>
-                            <option value="dry_veg" data-i18n="category_dry_veg">Warzywa suche</option>
-                            <option value="bread" data-i18n="category_bread">Pieczywo</option>
-                            <option value="pasta" data-i18n="category_pasta">Makarony</option>
-                            <option value="rice" data-i18n="category_rice">Ryże</option>
-                            <option value="grains" data-i18n="category_grains">Kasze</option>
-                            <option value="dried_legumes" data-i18n="category_dried_legumes">Suche rośliny strączkowe</option>
-                            <option value="sauces" data-i18n="category_sauces">Sosy i przyprawy płynne</option>
-                            <option value="oils" data-i18n="category_oils">Oleje</option>
-                            <option value="spreads" data-i18n="category_spreads">Smarowidła i pasty</option>
-                            <option value="spices" data-i18n="category_spices">Przyprawy</option>
-                            <option value="frozen_veg" data-i18n="category_frozen_veg">Mrożone warzywa</option>
-                            <option value="frozen_sauces" data-i18n="category_frozen_sauces">Mrożone sosy</option>
-                            <option value="frozen_meals" data-i18n="category_frozen_meals">Mrożone dania / zupy</option>
-                        </select>
-                        <label class="flex items-center gap-2 w-full">
-                            <input type="checkbox" name="main" class="checkbox">
-                            <span data-i18n="checkbox_main_label">Produkt podstawowy</span>
-                        </label>
-                    </div>
-                </div>
-                <select name="storage" required class="select select-bordered w-full">
-                    <option value="fridge" data-i18n="storage_fridge">Lodówka</option>
-                    <option value="pantry" selected data-i18n="storage_pantry">Szafka</option>
-                    <option value="freezer" data-i18n="storage_freezer">Zamrażarka</option>
+          <h2
+            class="text-xl font-semibold mt-6 mb-4"
+            data-i18n="heading_add_edit_product"
+          >
+            Dodaj / edytuj produkt
+          </h2>
+          <form
+            id="add-form"
+            class="grid grid-cols-1 sm:grid-cols-8 gap-2 mb-8 items-end"
+          >
+            <input
+              name="name"
+              placeholder="nazwa"
+              data-i18n="add_form_name_placeholder"
+              required
+              class="input input-bordered w-full"
+            />
+            <input
+              name="quantity"
+              placeholder="ilość"
+              data-i18n="add_form_quantity_placeholder"
+              required
+              class="input input-bordered w-full"
+            />
+            <input
+              name="package_size"
+              placeholder="w opak."
+              data-i18n="add_form_package_size_placeholder"
+              class="input input-bordered w-full"
+              type="number"
+              value="1"
+            />
+            <input
+              name="pack_size"
+              placeholder="paczka"
+              data-i18n="add_form_pack_size_placeholder"
+              class="input input-bordered w-full"
+              type="number"
+            />
+            <input
+              name="threshold"
+              placeholder="próg"
+              data-i18n="add_form_threshold_placeholder"
+              class="input input-bordered w-full"
+              type="number"
+            />
+            <div class="mb-4">
+              <div id="category-checkboxes" class="flex flex-wrap gap-2 mb-2">
+                <select
+                  name="category"
+                  required
+                  class="select select-bordered w-full"
+                >
+                  <option
+                    value="uncategorized"
+                    data-i18n="category_uncategorized"
+                  >
+                    brak kategorii
+                  </option>
+                  <option value="fresh_veg" data-i18n="category_fresh_veg">
+                    Świeże warzywa
+                  </option>
+                  <option value="mushrooms" data-i18n="category_mushrooms">
+                    Grzyby
+                  </option>
+                  <option value="dairy_eggs" data-i18n="category_dairy_eggs">
+                    Nabiał i jajka
+                  </option>
+                  <option
+                    value="opened_preserves"
+                    data-i18n="category_opened_preserves"
+                  >
+                    Otwarte konserwy i przetwory
+                  </option>
+                  <option
+                    value="ready_sauces"
+                    data-i18n="category_ready_sauces"
+                  >
+                    Sosy
+                  </option>
+                  <option value="dry_veg" data-i18n="category_dry_veg">
+                    Warzywa suche
+                  </option>
+                  <option value="bread" data-i18n="category_bread">
+                    Pieczywo
+                  </option>
+                  <option value="pasta" data-i18n="category_pasta">
+                    Makarony
+                  </option>
+                  <option value="rice" data-i18n="category_rice">Ryże</option>
+                  <option value="grains" data-i18n="category_grains">
+                    Kasze
+                  </option>
+                  <option
+                    value="dried_legumes"
+                    data-i18n="category_dried_legumes"
+                  >
+                    Suche rośliny strączkowe
+                  </option>
+                  <option value="sauces" data-i18n="category_sauces">
+                    Sosy i przyprawy płynne
+                  </option>
+                  <option value="oils" data-i18n="category_oils">Oleje</option>
+                  <option value="spreads" data-i18n="category_spreads">
+                    Smarowidła i pasty
+                  </option>
+                  <option value="spices" data-i18n="category_spices">
+                    Przyprawy
+                  </option>
+                  <option value="frozen_veg" data-i18n="category_frozen_veg">
+                    Mrożone warzywa
+                  </option>
+                  <option
+                    value="frozen_sauces"
+                    data-i18n="category_frozen_sauces"
+                  >
+                    Mrożone sosy
+                  </option>
+                  <option
+                    value="frozen_meals"
+                    data-i18n="category_frozen_meals"
+                  >
+                    Mrożone dania / zupy
+                  </option>
                 </select>
-                <button type="submit" class="btn btn-success btn-sm w-full sm:col-span-2" data-i18n="save_button">Zapisz</button>
-            </form>
-            <hr class="border-t border-base-300 my-6">
+                <label class="flex items-center gap-2 w-full">
+                  <input type="checkbox" name="main" class="checkbox" />
+                  <span data-i18n="checkbox_main_label"
+                    >Produkt podstawowy</span
+                  >
+                </label>
+              </div>
             </div>
-
-            <h3 class="text-lg font-semibold mt-6 mb-2" data-i18n="heading_edit_json">Edytuj produkty (JSON)</h3>
-            <textarea id="edit-json" rows="10" placeholder='JSON' data-i18n="edit_json_placeholder" class="textarea textarea-bordered w-full max-w-full mb-4 h-60 overflow-y-auto overflow-x-hidden resize-none p-4"></textarea>
-            <div class="flex flex-col sm:flex-row gap-2 mb-8">
-                <button id="edit-json-btn" class="btn btn-outline btn-primary btn-sm w-full sm:w-auto" data-i18n="edit_json_submit_button">Wyślij JSON</button>
-                <button id="copy-btn" class="btn btn-outline btn-sm w-full sm:w-auto" data-i18n="copy_structure_button">Pobierz strukturę</button>
-            </div>
+            <select
+              name="storage"
+              required
+              class="select select-bordered w-full"
+            >
+              <option value="fridge" data-i18n="storage_fridge">Lodówka</option>
+              <option value="pantry" selected data-i18n="storage_pantry">
+                Szafka
+              </option>
+              <option value="freezer" data-i18n="storage_freezer">
+                Zamrażarka
+              </option>
+            </select>
+            <button
+              type="submit"
+              class="btn btn-success btn-sm w-full sm:col-span-2"
+              data-i18n="save_button"
+            >
+              Zapisz
+            </button>
+          </form>
+          <hr class="border-t border-base-300 my-6" />
         </div>
 
-        <div id="tab-recipes" class="tab-panel" style="display:none;">
-            <h1 class="text-xl md:text-2xl font-semibold mb-3 md:mb-4" data-i18n="heading_recipes">Przepisy</h1>
-            <div id="recipe-controls" class="flex flex-col sm:flex-row flex-wrap gap-4 mb-4">
-                <div class="flex flex-col sm:flex-row items-start sm:items-center gap-2">
-                    <span data-i18n="recipe_sort_label">Sortuj według:</span>
-                    <div id="recipe-sort-mobile-container" class="w-full" style="display:none;">
-                        <select id="recipe-sort-mobile" class="select select-bordered select-sm w-full">
-                            <option value="name-asc" data-i18n="recipe_sort_mobile_name">Nazwy (A→Z)</option>
-                            <option value="time-asc" data-i18n="recipe_sort_mobile_time_asc">Czasu (rosnąco)</option>
-                            <option value="time-desc" data-i18n="recipe_sort_mobile_time_desc">Czasu (malejąco)</option>
-                            <option value="portions-asc" data-i18n="recipe_sort_mobile_portions_asc">Porcji (rosnąco)</option>
-                            <option value="portions-desc" data-i18n="recipe_sort_mobile_portions_desc">Porcji (malejąco)</option>
-                        </select>
-                    </div>
-                    <div id="recipe-sort-desktop-container" class="flex items-center gap-2" style="display:flex;">
-                        <select id="recipe-sort-field" class="select select-bordered select-sm w-full sm:w-auto">
-                            <option value="name" data-i18n="recipe_sort_name">Nazwy</option>
-                            <option value="time" data-i18n="recipe_sort_time">Czasu</option>
-                            <option value="portions" data-i18n="recipe_sort_portions">Porcji</option>
-                        </select>
-                        <div class="join">
-                            <button id="recipe-sort-dir-asc" type="button" class="btn btn-sm join-item" data-i18n="recipe_sort_dir_asc">Rosnąco</button>
-                            <button id="recipe-sort-dir-desc" type="button" class="btn btn-sm join-item" data-i18n="recipe_sort_dir_desc">Malejąco</button>
-                        </div>
-                    </div>
-                </div>
-                <div class="flex flex-col sm:flex-row items-start sm:items-center gap-2">
-                    <label for="recipe-time-filter" data-i18n="recipe_filter_time_label">Czas:</label>
-                    <select id="recipe-time-filter" class="select select-bordered w-full sm:w-auto">
-                        <option value="" data-i18n="filter_all">Wszystkie</option>
-                        <option value="lt30" data-i18n="recipe_filter_time_lt30">&lt;30min</option>
-                        <option value="30-60" data-i18n="recipe_filter_time_30_60">30–60min</option>
-                        <option value="gt60" data-i18n="recipe_filter_time_gt60">&gt;60min</option>
-                    </select>
-                </div>
-                <div class="flex flex-col sm:flex-row items-start sm:items-center gap-2">
-                    <label for="recipe-portions-filter" data-i18n="recipe_filter_portions_label">Porcje</label>
-                    <select id="recipe-portions-filter" class="select select-bordered w-full sm:w-auto">
-                        <option value="" data-i18n="filter_all">Wszystkie</option>
-                        <option value="1">1</option>
-                        <option value="2">2</option>
-                        <option value="3">3</option>
-                        <option value="4">4</option>
-                        <option value="5+">5+</option>
-                    </select>
-                </div>
-                <button id="recipe-favorites-toggle" class="btn btn-outline btn-sm self-start" data-i18n="recipe_filter_favorites">Ulubione przepisy</button>
-                <button id="recipe-clear-filters" class="btn btn-outline btn-sm self-start" data-i18n="recipe_clear_filters">Wyczyść filtry</button>
-            </div>
-            <div id="recipe-list" role="list" aria-live="polite" class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4 mb-8"></div>
+        <h3
+          class="text-lg font-semibold mt-6 mb-2"
+          data-i18n="heading_edit_json"
+        >
+          Edytuj produkty (JSON)
+        </h3>
+        <textarea
+          id="edit-json"
+          rows="10"
+          placeholder="JSON"
+          data-i18n="edit_json_placeholder"
+          class="textarea textarea-bordered w-full max-w-full mb-4 h-60 overflow-y-auto overflow-x-hidden resize-none p-4"
+        ></textarea>
+        <div class="flex flex-col sm:flex-row gap-2 mb-8">
+          <button
+            id="edit-json-btn"
+            class="btn btn-outline btn-primary btn-sm w-full sm:w-auto"
+            data-i18n="edit_json_submit_button"
+          >
+            Wyślij JSON
+          </button>
+          <button
+            id="copy-btn"
+            class="btn btn-outline btn-sm w-full sm:w-auto"
+            data-i18n="copy_structure_button"
+          >
+            Pobierz strukturę
+          </button>
         </div>
+      </div>
 
-        <div id="tab-history" class="tab-panel" style="display:none;">
-            <h1 class="text-xl md:text-2xl font-semibold mb-3 md:mb-4" data-i18n="heading_history">Historia dań</h1>
-            <ul id="history-list" class="list-disc pl-4"></ul>
-
-            <dialog id="rating-modal" class="modal">
-                <form method="dialog" id="rating-form" class="modal-box">
-                    <h3 id="rating-title" class="font-bold text-lg"></h3>
-                    <div class="py-4 space-y-4">
-                        <div>
-                            <span data-i18n="label_taste" class="block mb-2">Smak:</span>
-                            <div class="rating flex gap-1 text-2xl" data-name="taste">
-                                <i class="fa-regular fa-star star cursor-pointer text-base-300"></i>
-                                <i class="fa-regular fa-star star cursor-pointer text-base-300"></i>
-                                <i class="fa-regular fa-star star cursor-pointer text-base-300"></i>
-                                <i class="fa-regular fa-star star cursor-pointer text-base-300"></i>
-                                <i class="fa-regular fa-star star cursor-pointer text-base-300"></i>
-                            </div>
-                        </div>
-                        <div>
-                            <span data-i18n="label_prep_time" class="block mb-2">Czas przygotowania:</span>
-                            <div class="rating flex gap-1 text-2xl" data-name="time">
-                                <i class="fa-regular fa-star star cursor-pointer text-base-300"></i>
-                                <i class="fa-regular fa-star star cursor-pointer text-base-300"></i>
-                                <i class="fa-regular fa-star star cursor-pointer text-base-300"></i>
-                                <i class="fa-regular fa-star star cursor-pointer text-base-300"></i>
-                                <i class="fa-regular fa-star star cursor-pointer text-base-300"></i>
-                            </div>
-                        </div>
-                        <div>
-                            <textarea name="comment" placeholder="Komentarz" data-i18n="comment_placeholder" class="textarea textarea-bordered w-full"></textarea>
-                        </div>
-                    </div>
-                    <div class="modal-action">
-                        <button type="submit" class="btn btn-success btn-sm" data-i18n="save_button">Zapisz</button>
-                        <button type="button" id="rating-cancel" class="btn btn-outline btn-sm" data-i18n="delete_cancel_button">Anuluj</button>
-                    </div>
-                </form>
-            </dialog>
-
-            <dialog id="history-detail-modal" class="modal" aria-labelledby="history-detail-title">
-                <div class="modal-box max-w-lg">
-                    <h3 id="history-detail-title" class="font-bold text-lg mb-4"></h3>
-                    <div class="space-y-4">
-                        <div id="history-detail-ingredients-wrap">
-                            <h4 class="font-semibold mb-2" data-i18n="recipe_ingredients_header">Składniki</h4>
-                            <ul id="history-detail-ingredients" class="list-disc pl-4"></ul>
-                        </div>
-                        <div id="history-detail-rating-wrap" class="space-y-1">
-                            <div><span data-i18n="label_taste">Smak:</span> <span id="history-detail-taste"></span></div>
-                            <div><span data-i18n="label_prep_time">Czas przygotowania:</span> <span id="history-detail-prep"></span></div>
-                        </div>
-                        <div id="history-detail-comment-wrap">
-                            <h4 class="font-semibold mb-2"><span data-i18n="comment_placeholder">Komentarz</span>:</h4>
-                            <p id="history-detail-comment"></p>
-                        </div>
-                    </div>
-                    <div class="modal-action">
-                        <button id="history-detail-close" class="btn btn-sm" data-i18n="close" aria-label="Zamknij">Zamknij</button>
-                    </div>
-                </div>
-            </dialog>
-
-            <div id="cooking-overlay" class="fixed inset-0 bg-base-100 z-50 hidden flex flex-col items-center justify-center p-4">
-                <div id="cooking-step" class="text-xl text-center mb-6"></div>
-                <button id="cooking-next" class="btn btn-primary mb-4" data-i18n="next_step_button">Dalej</button>
-                <form id="cooking-form" class="w-full max-w-md space-y-4 hidden">
-                    <textarea name="comment" placeholder="Komentarz" data-i18n="comment_placeholder" class="textarea textarea-bordered w-full"></textarea>
-                    <div>
-                        <span data-i18n="label_taste" class="block mb-2">Smak:</span>
-                        <div class="rating flex gap-1 text-2xl" data-name="taste">
-                            <i class="fa-regular fa-star star cursor-pointer text-base-300"></i>
-                            <i class="fa-regular fa-star star cursor-pointer text-base-300"></i>
-                            <i class="fa-regular fa-star star cursor-pointer text-base-300"></i>
-                            <i class="fa-regular fa-star star cursor-pointer text-base-300"></i>
-                            <i class="fa-regular fa-star star cursor-pointer text-base-300"></i>
-                        </div>
-                    </div>
-                    <div>
-                        <span data-i18n="label_prep_time" class="block mb-2">Czas przygotowania:</span>
-                        <div class="rating flex gap-1 text-2xl" data-name="time">
-                            <i class="fa-regular fa-star star cursor-pointer text-base-300"></i>
-                            <i class="fa-regular fa-star star cursor-pointer text-base-300"></i>
-                            <i class="fa-regular fa-star star cursor-pointer text-base-300"></i>
-                            <i class="fa-regular fa-star star cursor-pointer text-base-300"></i>
-                            <i class="fa-regular fa-star star cursor-pointer text-base-300"></i>
-                        </div>
-                    </div>
-                    <button type="submit" class="btn btn-success" data-i18n="save_button">Zapisz</button>
-                </form>
+      <div id="tab-recipes" class="tab-panel" style="display: none">
+        <h1
+          class="text-xl md:text-2xl font-semibold mb-3 md:mb-4"
+          data-i18n="heading_recipes"
+        >
+          Przepisy
+        </h1>
+        <div
+          id="recipe-controls"
+          class="flex flex-col sm:flex-row flex-wrap gap-4 mb-4"
+        >
+          <div
+            class="flex flex-col sm:flex-row items-start sm:items-center gap-2"
+          >
+            <span data-i18n="recipe_sort_label">Sortuj według:</span>
+            <div
+              id="recipe-sort-mobile-container"
+              class="w-full"
+              style="display: none"
+            >
+              <select
+                id="recipe-sort-mobile"
+                class="select select-bordered select-sm w-full"
+              >
+                <option value="name-asc" data-i18n="recipe_sort_mobile_name">
+                  Nazwy (A→Z)
+                </option>
+                <option
+                  value="time-asc"
+                  data-i18n="recipe_sort_mobile_time_asc"
+                >
+                  Czasu (rosnąco)
+                </option>
+                <option
+                  value="time-desc"
+                  data-i18n="recipe_sort_mobile_time_desc"
+                >
+                  Czasu (malejąco)
+                </option>
+                <option
+                  value="portions-asc"
+                  data-i18n="recipe_sort_mobile_portions_asc"
+                >
+                  Porcji (rosnąco)
+                </option>
+                <option
+                  value="portions-desc"
+                  data-i18n="recipe_sort_mobile_portions_desc"
+                >
+                  Porcji (malejąco)
+                </option>
+              </select>
             </div>
+            <div
+              id="recipe-sort-desktop-container"
+              class="flex items-center gap-2"
+              style="display: flex"
+            >
+              <select
+                id="recipe-sort-field"
+                class="select select-bordered select-sm w-full sm:w-auto"
+              >
+                <option value="name" data-i18n="recipe_sort_name">Nazwy</option>
+                <option value="time" data-i18n="recipe_sort_time">Czasu</option>
+                <option value="portions" data-i18n="recipe_sort_portions">
+                  Porcji
+                </option>
+              </select>
+              <div class="join">
+                <button
+                  id="recipe-sort-dir-asc"
+                  type="button"
+                  class="btn btn-sm join-item"
+                  data-i18n="recipe_sort_dir_asc"
+                >
+                  Rosnąco
+                </button>
+                <button
+                  id="recipe-sort-dir-desc"
+                  type="button"
+                  class="btn btn-sm join-item"
+                  data-i18n="recipe_sort_dir_desc"
+                >
+                  Malejąco
+                </button>
+              </div>
+            </div>
+          </div>
+          <div
+            class="flex flex-col sm:flex-row items-start sm:items-center gap-2"
+          >
+            <label for="recipe-time-filter" data-i18n="recipe_filter_time_label"
+              >Czas:</label
+            >
+            <select
+              id="recipe-time-filter"
+              class="select select-bordered w-full sm:w-auto"
+            >
+              <option value="" data-i18n="filter_all">Wszystkie</option>
+              <option value="lt30" data-i18n="recipe_filter_time_lt30">
+                &lt;30min
+              </option>
+              <option value="30-60" data-i18n="recipe_filter_time_30_60">
+                30–60min
+              </option>
+              <option value="gt60" data-i18n="recipe_filter_time_gt60">
+                &gt;60min
+              </option>
+            </select>
+          </div>
+          <div
+            class="flex flex-col sm:flex-row items-start sm:items-center gap-2"
+          >
+            <label
+              for="recipe-portions-filter"
+              data-i18n="recipe_filter_portions_label"
+              >Porcje</label
+            >
+            <select
+              id="recipe-portions-filter"
+              class="select select-bordered w-full sm:w-auto"
+            >
+              <option value="" data-i18n="filter_all">Wszystkie</option>
+              <option value="1">1</option>
+              <option value="2">2</option>
+              <option value="3">3</option>
+              <option value="4">4</option>
+              <option value="5+">5+</option>
+            </select>
+          </div>
+          <button
+            id="recipe-favorites-toggle"
+            class="btn btn-outline btn-sm self-start"
+            data-i18n="recipe_filter_favorites"
+          >
+            Ulubione przepisy
+          </button>
+          <button
+            id="recipe-clear-filters"
+            class="btn btn-outline btn-sm self-start"
+            data-i18n="recipe_clear_filters"
+          >
+            Wyczyść filtry
+          </button>
         </div>
+        <div
+          id="recipe-list"
+          role="list"
+          aria-live="polite"
+          class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4 mb-8"
+        ></div>
+      </div>
 
-        <div id="tab-shopping" class="tab-panel" style="display:none;">
-            <h1 class="text-2xl font-bold mb-6" data-i18n="heading_shopping">Lista zakupów</h1>
-            <button id="receipt-btn" class="btn btn-secondary btn-sm mb-4" data-i18n="receipt_import">Dodaj z paragonu</button>
-            <input id="receipt-input" type="file" accept="image/*" class="hidden" />
-            <dialog id="receipt-sheet" class="modal modal-bottom sm:modal-middle">
-                <form method="dialog" class="modal-box">
-                    <button id="receipt-camera" class="btn w-full mb-2" data-i18n="camera">Aparat</button>
-                    <button id="receipt-upload" class="btn w-full" data-i18n="choose_file">Wybierz plik</button>
-                </form>
-            </dialog>
-            <dialog id="receipt-upload-modal" class="modal">
-                <form method="dialog" class="modal-box">
-                    <div id="receipt-drop-area" class="border-2 border-dashed rounded p-8 text-center">
-                        <button id="receipt-choose" class="btn" data-i18n="choose_file">Wybierz plik</button>
-                    </div>
-                </form>
-            </dialog>
-            <div id="suggestions-section" class="mb-8">
-                <h2 class="text-xl font-semibold mb-4" data-i18n="heading_suggestions">Propozycje</h2>
-                <div id="suggestion-list" class="border border-base-300 rounded-lg divide-y divide-base-300"></div>
-            </div>
-            <div id="shopping-list-section" class="mb-8">
-                <h2 class="text-xl font-semibold mb-4" data-i18n="heading_shopping_list">Lista zakupów</h2>
-                <div id="shopping-list" class="border border-base-300 rounded-lg divide-y divide-base-300"></div>
-            </div>
-            <hr class="border-t border-base-300 mt-6 mb-4">
-            <div id="manual-add-section" class="mb-8 p-4 shadow rounded bg-base-100">
-                <h2 class="text-xl font-bold mb-4" data-i18n="heading_add_product">Dodaj produkt</h2>
-                <div class="flex flex-wrap items-center gap-2">
-                    <input id="manual-name" list="product-datalist" class="input input-bordered flex-1" placeholder="nazwa" data-i18n="add_form_name_placeholder">
-                    <div class="flex items-center gap-2">
-                        <button id="manual-dec" type="button" class="text-xl touch-btn" aria-label="-"><i class="fa-solid fa-minus"></i></button>
-                        <span id="manual-qty" class="w-10 h-10 inline-flex items-center justify-center text-center mx-2">1</span>
-                        <button id="manual-inc" type="button" class="text-xl touch-btn" aria-label="+"><i class="fa-solid fa-plus"></i></button>
-                    </div>
-                    <button id="manual-add-btn" class="btn btn-primary btn-sm" data-i18n="save_button">Zapisz</button>
+      <div id="tab-history" class="tab-panel" style="display: none">
+        <h1
+          class="text-xl md:text-2xl font-semibold mb-3 md:mb-4"
+          data-i18n="heading_history"
+        >
+          Historia dań
+        </h1>
+        <ul id="history-list" class="list-disc pl-4"></ul>
+
+        <dialog id="rating-modal" class="modal">
+          <form method="dialog" id="rating-form" class="modal-box">
+            <h3 id="rating-title" class="font-bold text-lg"></h3>
+            <div class="py-4 space-y-4">
+              <div>
+                <span data-i18n="label_taste" class="block mb-2">Smak:</span>
+                <div class="rating flex gap-1 text-2xl" data-name="taste">
+                  <i
+                    class="fa-regular fa-star star cursor-pointer text-base-300"
+                  ></i>
+                  <i
+                    class="fa-regular fa-star star cursor-pointer text-base-300"
+                  ></i>
+                  <i
+                    class="fa-regular fa-star star cursor-pointer text-base-300"
+                  ></i>
+                  <i
+                    class="fa-regular fa-star star cursor-pointer text-base-300"
+                  ></i>
+                  <i
+                    class="fa-regular fa-star star cursor-pointer text-base-300"
+                  ></i>
                 </div>
-                <datalist id="product-datalist"></datalist>
+              </div>
+              <div>
+                <span data-i18n="label_prep_time" class="block mb-2"
+                  >Czas przygotowania:</span
+                >
+                <div class="rating flex gap-1 text-2xl" data-name="time">
+                  <i
+                    class="fa-regular fa-star star cursor-pointer text-base-300"
+                  ></i>
+                  <i
+                    class="fa-regular fa-star star cursor-pointer text-base-300"
+                  ></i>
+                  <i
+                    class="fa-regular fa-star star cursor-pointer text-base-300"
+                  ></i>
+                  <i
+                    class="fa-regular fa-star star cursor-pointer text-base-300"
+                  ></i>
+                  <i
+                    class="fa-regular fa-star star cursor-pointer text-base-300"
+                  ></i>
+                </div>
+              </div>
+              <div>
+                <textarea
+                  name="comment"
+                  placeholder="Komentarz"
+                  data-i18n="comment_placeholder"
+                  class="textarea textarea-bordered w-full"
+                ></textarea>
+              </div>
             </div>
-            <dialog id="receipt-modal" class="modal">
-                <form method="dialog" class="modal-box w-11/12 max-w-3xl">
-                    <h3 class="font-bold text-lg" data-i18n="receipt_import">Dodaj z paragonu</h3>
-                    <div class="overflow-x-auto">
-                        <table id="receipt-table" class="table w-full">
-                            <thead>
-                                <tr>
-                                    <th data-i18n="table_header_name">Nazwa</th>
-                                    <th data-i18n="table_header_quantity">Ilość</th>
-                                    <th></th>
-                                    <th></th>
-                                </tr>
-                            </thead>
-                            <tbody></tbody>
-                        </table>
-                    </div>
-                    <div class="modal-action">
-                        <button id="receipt-confirm" class="btn btn-primary" data-i18n="confirm_import">Zatwierdź import</button>
-                        <button class="btn btn-outline" data-i18n="delete_cancel_button">Anuluj</button>
-                    </div>
-                </form>
-            </dialog>
-            <dialog id="shopping-delete-modal" class="modal">
-                <form method="dialog" class="modal-box">
-                    <h3 class="font-bold text-lg" data-i18n="delete_modal_title">Potwierdź usunięcie</h3>
-                    <p class="py-4" data-i18n="delete_item_question">Czy na pewno chcesz usunąć ten produkt?</p>
-                    <div class="modal-action">
-                        <button id="confirm-remove-item" class="btn btn-error btn-sm" data-i18n="confirm_button" aria-label="Potwierdź">Potwierdź</button>
-                        <button class="btn btn-outline btn-sm" data-i18n="delete_cancel_button" aria-label="Anuluj">Anuluj</button>
-                    </div>
-                </form>
-            </dialog>
-        </div>
+            <div class="modal-action">
+              <button
+                type="submit"
+                class="btn btn-success btn-sm"
+                data-i18n="save_button"
+              >
+                Zapisz
+              </button>
+              <button
+                type="button"
+                id="rating-cancel"
+                class="btn btn-outline btn-sm"
+                data-i18n="delete_cancel_button"
+              >
+                Anuluj
+              </button>
+            </div>
+          </form>
+        </dialog>
 
-        <div id="tab-settings" class="tab-panel" style="display:none;">
-            <h1 class="text-xl md:text-2xl font-semibold mb-3 md:mb-4" data-i18n="heading_settings">Ustawienia</h1>
-            <h2 class="text-xl font-semibold mb-4" data-i18n="settings_units_header">Jednostki</h2>
+        <dialog
+          id="history-detail-modal"
+          class="modal"
+          aria-labelledby="history-detail-title"
+        >
+          <div class="modal-box max-w-lg">
+            <h3 id="history-detail-title" class="font-bold text-lg mb-4"></h3>
+            <div class="space-y-4">
+              <div id="history-detail-ingredients-wrap">
+                <h4
+                  class="font-semibold mb-2"
+                  data-i18n="recipe_ingredients_header"
+                >
+                  Składniki
+                </h4>
+                <ul id="history-detail-ingredients" class="list-disc pl-4"></ul>
+              </div>
+              <div id="history-detail-rating-wrap" class="space-y-1">
+                <div>
+                  <span data-i18n="label_taste">Smak:</span>
+                  <span id="history-detail-taste"></span>
+                </div>
+                <div>
+                  <span data-i18n="label_prep_time">Czas przygotowania:</span>
+                  <span id="history-detail-prep"></span>
+                </div>
+              </div>
+              <div id="history-detail-comment-wrap">
+                <h4 class="font-semibold mb-2">
+                  <span data-i18n="comment_placeholder">Komentarz</span>:
+                </h4>
+                <p id="history-detail-comment"></p>
+              </div>
+            </div>
+            <div class="modal-action">
+              <button
+                id="history-detail-close"
+                class="btn btn-sm"
+                data-i18n="close"
+                aria-label="Zamknij"
+              >
+                Zamknij
+              </button>
+            </div>
+          </div>
+        </dialog>
+
+        <div
+          id="cooking-overlay"
+          class="fixed inset-0 bg-base-100 z-50 hidden flex flex-col items-center justify-center p-4"
+        >
+          <div id="cooking-step" class="text-xl text-center mb-6"></div>
+          <button
+            id="cooking-next"
+            class="btn btn-primary mb-4"
+            data-i18n="next_step_button"
+          >
+            Dalej
+          </button>
+          <form id="cooking-form" class="w-full max-w-md space-y-4 hidden">
+            <textarea
+              name="comment"
+              placeholder="Komentarz"
+              data-i18n="comment_placeholder"
+              class="textarea textarea-bordered w-full"
+            ></textarea>
+            <div>
+              <span data-i18n="label_taste" class="block mb-2">Smak:</span>
+              <div class="rating flex gap-1 text-2xl" data-name="taste">
+                <i
+                  class="fa-regular fa-star star cursor-pointer text-base-300"
+                ></i>
+                <i
+                  class="fa-regular fa-star star cursor-pointer text-base-300"
+                ></i>
+                <i
+                  class="fa-regular fa-star star cursor-pointer text-base-300"
+                ></i>
+                <i
+                  class="fa-regular fa-star star cursor-pointer text-base-300"
+                ></i>
+                <i
+                  class="fa-regular fa-star star cursor-pointer text-base-300"
+                ></i>
+              </div>
+            </div>
+            <div>
+              <span data-i18n="label_prep_time" class="block mb-2"
+                >Czas przygotowania:</span
+              >
+              <div class="rating flex gap-1 text-2xl" data-name="time">
+                <i
+                  class="fa-regular fa-star star cursor-pointer text-base-300"
+                ></i>
+                <i
+                  class="fa-regular fa-star star cursor-pointer text-base-300"
+                ></i>
+                <i
+                  class="fa-regular fa-star star cursor-pointer text-base-300"
+                ></i>
+                <i
+                  class="fa-regular fa-star star cursor-pointer text-base-300"
+                ></i>
+                <i
+                  class="fa-regular fa-star star cursor-pointer text-base-300"
+                ></i>
+              </div>
+            </div>
+            <button
+              type="submit"
+              class="btn btn-success"
+              data-i18n="save_button"
+            >
+              Zapisz
+            </button>
+          </form>
+        </div>
+      </div>
+
+      <div id="tab-shopping" class="tab-panel" style="display: none">
+        <h1 class="text-2xl font-bold mb-6" data-i18n="heading_shopping">
+          Lista zakupów
+        </h1>
+        <button
+          id="receipt-btn"
+          class="btn btn-secondary btn-sm mb-4"
+          data-i18n="receipt_import"
+        >
+          Dodaj z paragonu
+        </button>
+        <input id="receipt-input" type="file" accept="image/*" class="hidden" />
+        <dialog id="receipt-sheet" class="modal modal-bottom sm:modal-middle">
+          <form method="dialog" class="modal-box">
+            <button
+              id="receipt-camera"
+              class="btn w-full mb-2"
+              data-i18n="camera"
+            >
+              Aparat
+            </button>
+            <button
+              id="receipt-upload"
+              class="btn w-full"
+              data-i18n="choose_file"
+            >
+              Wybierz plik
+            </button>
+          </form>
+        </dialog>
+        <dialog id="receipt-upload-modal" class="modal">
+          <form method="dialog" class="modal-box">
+            <div
+              id="receipt-drop-area"
+              class="border-2 border-dashed rounded p-8 text-center"
+            >
+              <button id="receipt-choose" class="btn" data-i18n="choose_file">
+                Wybierz plik
+              </button>
+            </div>
+          </form>
+        </dialog>
+        <div id="suggestions-section" class="mb-8">
+          <h2
+            class="text-xl font-semibold mb-4"
+            data-i18n="heading_suggestions"
+          >
+            Propozycje
+          </h2>
+          <div
+            id="suggestion-list"
+            class="border border-base-300 rounded-lg divide-y divide-base-300"
+          ></div>
+        </div>
+        <div id="shopping-list-section" class="mb-8">
+          <h2
+            class="text-xl font-semibold mb-4"
+            data-i18n="heading_shopping_list"
+          >
+            Lista zakupów
+          </h2>
+          <div
+            id="shopping-list"
+            class="border border-base-300 rounded-lg divide-y divide-base-300"
+          ></div>
+        </div>
+        <hr class="border-t border-base-300 mt-6 mb-4" />
+        <div
+          id="manual-add-section"
+          class="mb-8 p-4 shadow rounded bg-base-100"
+        >
+          <h2 class="text-xl font-bold mb-4" data-i18n="heading_add_product">
+            Dodaj produkt
+          </h2>
+          <div class="flex flex-wrap items-center gap-2">
+            <input
+              id="manual-name"
+              list="product-datalist"
+              class="input input-bordered flex-1"
+              placeholder="nazwa"
+              data-i18n="add_form_name_placeholder"
+            />
+            <div class="flex items-center gap-2">
+              <button
+                id="manual-dec"
+                type="button"
+                class="text-xl touch-btn"
+                aria-label="-"
+              >
+                <i class="fa-solid fa-minus"></i>
+              </button>
+              <span
+                id="manual-qty"
+                class="w-10 h-10 inline-flex items-center justify-center text-center mx-2"
+                >1</span
+              >
+              <button
+                id="manual-inc"
+                type="button"
+                class="text-xl touch-btn"
+                aria-label="+"
+              >
+                <i class="fa-solid fa-plus"></i>
+              </button>
+            </div>
+            <button
+              id="manual-add-btn"
+              class="btn btn-primary btn-sm"
+              data-i18n="save_button"
+            >
+              Zapisz
+            </button>
+          </div>
+          <datalist id="product-datalist"></datalist>
+        </div>
+        <dialog id="receipt-modal" class="modal">
+          <form method="dialog" class="modal-box w-11/12 max-w-3xl">
+            <h3 class="font-bold text-lg" data-i18n="receipt_import">
+              Dodaj z paragonu
+            </h3>
             <div class="overflow-x-auto">
-                <table id="units-table" class="table table-zebra w-full">
-                    <colgroup>
-                        <col class="w-1/3" />
-                        <col class="w-1/3" />
-                        <col class="w-1/3" />
-                    </colgroup>
-                    <thead>
-                        <tr class="text-center">
-                            <th class="w-1/3" data-i18n="settings_unit_code">Kod</th>
-                            <th class="w-1/3" data-i18n="settings_unit_pl">Polski</th>
-                            <th class="w-1/3" data-i18n="settings_unit_en">Angielski</th>
-                        </tr>
-                    </thead>
-                    <tbody></tbody>
-                </table>
+              <table id="receipt-table" class="table w-full">
+                <thead>
+                  <tr>
+                    <th data-i18n="table_header_name">Nazwa</th>
+                    <th data-i18n="table_header_quantity">Ilość</th>
+                    <th></th>
+                    <th></th>
+                  </tr>
+                </thead>
+                <tbody></tbody>
+              </table>
             </div>
-            <button id="units-save" class="btn btn-primary btn-sm mt-4" data-i18n="save_button">Zapisz</button>
-        </div>
+            <div class="modal-action">
+              <button
+                id="receipt-confirm"
+                class="btn btn-primary"
+                data-i18n="confirm_import"
+              >
+                Zatwierdź import
+              </button>
+              <button class="btn btn-outline" data-i18n="delete_cancel_button">
+                Anuluj
+              </button>
+            </div>
+          </form>
+        </dialog>
+        <dialog id="shopping-delete-modal" class="modal">
+          <form method="dialog" class="modal-box">
+            <h3 class="font-bold text-lg" data-i18n="delete_modal_title">
+              Potwierdź usunięcie
+            </h3>
+            <p class="py-4" data-i18n="delete_item_question">
+              Czy na pewno chcesz usunąć ten produkt?
+            </p>
+            <div class="modal-action">
+              <button
+                id="confirm-remove-item"
+                class="btn btn-error btn-sm"
+                data-i18n="confirm_button"
+                aria-label="Potwierdź"
+              >
+                Potwierdź
+              </button>
+              <button
+                class="btn btn-outline btn-sm"
+                data-i18n="delete_cancel_button"
+                aria-label="Anuluj"
+              >
+                Anuluj
+              </button>
+            </div>
+          </form>
+        </dialog>
+      </div>
 
-  </main>
+      <div id="tab-settings" class="tab-panel" style="display: none">
+        <h1
+          class="text-xl md:text-2xl font-semibold mb-3 md:mb-4"
+          data-i18n="heading_settings"
+        >
+          Ustawienia
+        </h1>
+        <h2
+          class="text-xl font-semibold mb-4"
+          data-i18n="settings_units_header"
+        >
+          Jednostki
+        </h2>
+        <div class="overflow-x-auto">
+          <table id="units-table" class="table table-zebra w-full">
+            <colgroup>
+              <col class="w-1/3" />
+              <col class="w-1/3" />
+              <col class="w-1/3" />
+            </colgroup>
+            <thead>
+              <tr class="text-center">
+                <th class="w-1/3" data-i18n="settings_unit_code">Kod</th>
+                <th class="w-1/3" data-i18n="settings_unit_pl">Polski</th>
+                <th class="w-1/3" data-i18n="settings_unit_en">Angielski</th>
+              </tr>
+            </thead>
+            <tbody></tbody>
+          </table>
+        </div>
+        <button
+          id="units-save"
+          class="btn btn-primary btn-sm mt-4"
+          data-i18n="save_button"
+        >
+          Zapisz
+        </button>
+      </div>
+    </main>
 
     <dialog id="recipe-detail-modal" class="modal">
-        <form method="dialog" class="modal-box max-w-2xl">
-            <div id="recipe-detail-content"></div>
-            <div class="modal-action">
-                <button class="btn" data-i18n="close">Zamknij</button>
-            </div>
-        </form>
+      <form method="dialog" class="modal-box max-w-2xl">
+        <div id="recipe-detail-content"></div>
+        <div class="modal-action">
+          <button class="btn" data-i18n="close">Zamknij</button>
+        </div>
+      </form>
     </dialog>
 
     <nav class="mobile-nav fixed bottom-0 left-0 w-full z-50 bg-base-100 flex">
-        <a class="tab tab-active font-bold flex flex-col items-center justify-center flex-1 py-3 px-2 border-r border-base-300" data-tab-target="tab-products">
-            <i class="fa-solid fa-box text-xl"></i>
-            <span class="text-xs" data-i18n="tab_products">Produkty</span>
-        </a>
-        <a class="tab flex flex-col items-center justify-center flex-1 py-3 px-2 border-r border-base-300" data-tab-target="tab-recipes">
-            <i class="fa-solid fa-utensils text-xl"></i>
-            <span class="text-xs" data-i18n="tab_recipes">Przepisy</span>
-        </a>
-        <a class="tab flex flex-col items-center justify-center flex-1 py-3 px-2 border-r border-base-300" data-tab-target="tab-history">
-            <i class="fa-solid fa-clock-rotate-left text-xl"></i>
-            <span class="text-xs" data-i18n="tab_history">Historia dań</span>
-        </a>
-        <a class="tab flex flex-col items-center justify-center flex-1 py-3 px-2" data-tab-target="tab-shopping">
-            <i class="fa-solid fa-cart-shopping text-xl"></i>
-            <span class="text-xs" data-i18n="tab_shopping">Lista zakupów</span>
-        </a>
+      <a
+        class="tab tab-active font-bold flex flex-col items-center justify-center flex-1 py-3 px-2 border-r border-base-300"
+        data-tab-target="tab-products"
+      >
+        <i class="fa-solid fa-box text-xl"></i>
+        <span class="text-xs" data-i18n="tab_products">Produkty</span>
+      </a>
+      <a
+        class="tab flex flex-col items-center justify-center flex-1 py-3 px-2 border-r border-base-300"
+        data-tab-target="tab-recipes"
+      >
+        <i class="fa-solid fa-utensils text-xl"></i>
+        <span class="text-xs" data-i18n="tab_recipes">Przepisy</span>
+      </a>
+      <a
+        class="tab flex flex-col items-center justify-center flex-1 py-3 px-2 border-r border-base-300"
+        data-tab-target="tab-history"
+      >
+        <i class="fa-solid fa-clock-rotate-left text-xl"></i>
+        <span class="text-xs" data-i18n="tab_history">Historia dań</span>
+      </a>
+      <a
+        class="tab flex flex-col items-center justify-center flex-1 py-3 px-2"
+        data-tab-target="tab-shopping"
+      >
+        <i class="fa-solid fa-cart-shopping text-xl"></i>
+        <span class="text-xs" data-i18n="tab_shopping">Lista zakupów</span>
+      </a>
     </nav>
-      <script>window.APP_VERSION = {{ app_version|tojson }};</script>
-      <script type="module" src="/static/script.js?v={{ app_version }}"></script>
-</body>
+    <script>
+      window.APP_VERSION = {{ app_version|tojson }};
+    </script>
+    <script type="module" src="/static/script.js?v={{ app_version }}"></script>
+  </body>
 </html>


### PR DESCRIPTION
## Summary
- use new `getStockState` helper for consistent stock state logic
- color rows and text for low or zero stock in both product views
- add status legend tooltip with translations

## Testing
- `npx prettier -c app/static/js/components/product-table.js app/static/js/components/shopping-list.js app/static/js/helpers.js app/static/translations/en.json app/static/translations/pl.json app/templates/index.html`
- `eslint app/static/js/components/product-table.js app/static/js/components/shopping-list.js app/static/js/helpers.js -f json`
- `pytest`
- `pre-commit run --files app/static/js/components/product-table.js app/static/js/components/shopping-list.js app/static/js/helpers.js app/static/translations/en.json app/static/translations/pl.json app/templates/index.html` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689cceace300832abdcdd9b3cd861f5f