### PR TITLE
Ensure strict JSON validation across stack

### DIFF
--- a/tests/test_minimal_valid.py
+++ b/tests/test_minimal_valid.py
@@ -1,0 +1,50 @@
+import json
+import os
+import sys
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from app.utils import validate_file, normalize_product, normalize_recipe
+from app.routes import PRODUCTS_SCHEMA, RECIPES_SCHEMA
+
+
+def test_minimal_product_and_recipe_validate(tmp_path):
+    products = [
+        {
+            "name": "prod.test",
+            "quantity": 1,
+            "unit": "szt",
+            "category": "uncategorized",
+            "storage": "pantry",
+        }
+    ]
+    recipes = [
+        {
+            "id": "recipe.test",
+            "names": {"pl": "T", "en": "T"},
+            "portions": 1,
+            "time": "",
+            "ingredients": [
+                {
+                    "productId": "prod.test",
+                    "qty": 1,
+                    "unitId": "unit.szt",
+                    "optional": False,
+                }
+            ],
+            "steps": [],
+            "tags": [],
+        }
+    ]
+    prod_path = tmp_path / "products.json"
+    rec_path = tmp_path / "recipes.json"
+    prod_path.write_text(json.dumps(products))
+    rec_path.write_text(json.dumps(recipes))
+
+    count, errors = validate_file(str(prod_path), [], PRODUCTS_SCHEMA, normalize_product)
+    assert count == 1
+    assert errors == []
+
+    count, errors = validate_file(str(rec_path), [], RECIPES_SCHEMA, normalize_recipe)
+    assert count == 1
+    assert errors == []


### PR DESCRIPTION
## Summary
- validate domain product data on startup and in `/api/validate`
- prevent rendering invalid domain data by validating products and recipes in the browser
- add regression test with minimal valid product and recipe fixtures

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689cd4d1d940832a95698e640c07a885