### PR TITLE
Add consistent JSON error responses with trace IDs

### DIFF
--- a/app/errors.py
+++ b/app/errors.py
@@ -1,0 +1,13 @@
+import uuid
+from typing import Optional
+
+from flask import jsonify
+
+
+def error_response(message: str, status: int, trace_id: Optional[str] = None):
+    payload = {"error": message}
+    if status >= 500:
+        payload["traceId"] = trace_id or uuid.uuid4().hex[:8]
+    response = jsonify(payload)
+    response.status_code = status
+    return response

--- a/tests/test_error_and_health.py
+++ b/tests/test_error_and_health.py
@@ -16,9 +16,19 @@ def test_products_error_returns_traceid(monkeypatch):
     monkeypatch.setattr(routes, "_load_products_compat", boom)
     resp = client.get("/api/products")
     assert resp.status_code == 500
+    assert resp.mimetype == "application/json"
     data = resp.get_json()
     assert data["error"] == "Internal Server Error"
     assert "traceId" in data and len(data["traceId"]) == 8
+
+
+def test_404_returns_json_message():
+    app = create_app()
+    client = app.test_client()
+    resp = client.get("/missing")
+    assert resp.status_code == 404
+    assert resp.mimetype == "application/json"
+    assert resp.get_json() == {"error": "not found"}
 
 
 def test_health_endpoint_returns_counts():


### PR DESCRIPTION
## Summary
- Introduce reusable `error_response` helper and global handlers for 404, HTTP exceptions, and unexpected errors with `traceId`
- Update routes to use helper for all error paths and return consistent status codes
- Expand tests to check JSON content type, not-found messages, and `traceId` on server errors

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689cf16fcf04832a998a5aa0b7733828