### PR TITLE
Implement HTTP caching for products and recipes

### DIFF
--- a/app/utils/__init__.py
+++ b/app/utils/__init__.py
@@ -10,6 +10,9 @@ import logging
 import math
 import os
 import threading
+import hashlib
+from datetime import datetime, timezone
+from email.utils import format_datetime
 from typing import Any, Callable, Dict, List, Optional, Tuple
 
 import jsonschema
@@ -17,6 +20,26 @@ import jsonschema
 DEFAULT_UNIT = "szt"
 
 logger = logging.getLogger(__name__)
+
+
+def file_etag(path: str) -> str:
+    """Return SHA256 hex digest for the file at ``path``.
+
+    The ETag is stable for a given file content and can be used for HTTP
+    caching. The file is read in binary mode to ensure the hash reflects the
+    exact bytes served.
+    """
+
+    with open(path, "rb") as fh:
+        return hashlib.sha256(fh.read()).hexdigest()
+
+
+def file_mtime_rfc1123(path: str) -> str:
+    """Return the file modification time formatted per RFC1123."""
+
+    ts = os.path.getmtime(path)
+    dt = datetime.fromtimestamp(ts, tz=timezone.utc)
+    return format_datetime(dt, usegmt=True)
 
 
 def _safe_float(value: Any, default: float = 0.0) -> float:

--- a/tests/test_http_caching.py
+++ b/tests/test_http_caching.py
@@ -1,0 +1,89 @@
+import json
+
+from app import create_app
+from app.routes import PRODUCTS_PATH, RECIPES_PATH
+
+
+def _modify_file(path, mutate):
+    with open(path, "r", encoding="utf-8") as fh:
+        original = fh.read()
+    data = json.loads(original)
+    mutate(data)
+    with open(path, "w", encoding="utf-8") as fh:
+        json.dump(data, fh)
+    return original
+
+
+def test_products_etag_and_conditional_headers():
+    app = create_app()
+    client = app.test_client()
+
+    resp = client.get("/api/products")
+    assert resp.status_code == 200
+    etag = resp.headers.get("ETag")
+    last_mod = resp.headers.get("Last-Modified")
+    first = resp.get_json()
+
+    # Subsequent request with matching ETag should yield 304
+    resp2 = client.get("/api/products", headers={"If-None-Match": etag})
+    assert resp2.status_code == 304
+
+    # Also respect If-Modified-Since
+    resp3 = client.get(
+        "/api/products", headers={"If-Modified-Since": last_mod}
+    )
+    assert resp3.status_code == 304
+
+    # Modify underlying file and ensure ETag changes
+    def mutate(data):
+        prod = data["products"][0]
+        prod["names"]["en"] = prod["names"].get("en", "") + " X"
+
+    original = _modify_file(PRODUCTS_PATH, mutate)
+    try:
+        resp4 = client.get("/api/products")
+        assert resp4.status_code == 200
+        assert resp4.headers.get("ETag") != etag
+        data4 = resp4.get_json()
+        assert data4 != first
+    finally:
+        with open(PRODUCTS_PATH, "w", encoding="utf-8") as fh:
+            fh.write(original)
+
+
+def test_recipes_etag_and_conditional_headers():
+    app = create_app()
+    client = app.test_client()
+
+    resp = client.get("/api/recipes?locale=en")
+    assert resp.status_code == 200
+    etag = resp.headers.get("ETag")
+    last_mod = resp.headers.get("Last-Modified")
+    first = resp.get_json()
+
+    resp2 = client.get(
+        "/api/recipes?locale=en", headers={"If-None-Match": etag}
+    )
+    assert resp2.status_code == 304
+
+    resp3 = client.get(
+        "/api/recipes?locale=en", headers={"If-Modified-Since": last_mod}
+    )
+    assert resp3.status_code == 304
+
+    def mutate(data):
+        rec = data[0]
+        rec.setdefault("names", {})
+        rec["names"]["en"] = rec["names"].get("en", "") + " X"
+
+    original = _modify_file(RECIPES_PATH, mutate)
+    try:
+        resp4 = client.get("/api/recipes?locale=en")
+        assert resp4.status_code == 200
+        assert resp4.headers.get("ETag") != etag
+        data4 = resp4.get_json()
+        assert data4 != first
+    finally:
+        with open(RECIPES_PATH, "w", encoding="utf-8") as fh:
+            fh.write(original)
+


### PR DESCRIPTION
## Summary
- add utilities to compute file ETag and modification time
- return ETag/Last-Modified headers for products and recipes APIs with 304 handling
- cache conditional requests in frontend and tests for caching behaviour

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_689cf326c220832abb4586e4a5df3640