### PR TITLE
Add pagination and sorting to product and recipe listings

### DIFF
--- a/tests/test_http_caching.py
+++ b/tests/test_http_caching.py
@@ -22,7 +22,7 @@ def test_products_etag_and_conditional_headers():
     assert resp.status_code == 200
     etag = resp.headers.get("ETag")
     last_mod = resp.headers.get("Last-Modified")
-    first = resp.get_json()
+    first = resp.get_json()["items"]
 
     # Subsequent request with matching ETag should yield 304
     resp2 = client.get("/api/products", headers={"If-None-Match": etag})
@@ -44,7 +44,7 @@ def test_products_etag_and_conditional_headers():
         resp4 = client.get("/api/products")
         assert resp4.status_code == 200
         assert resp4.headers.get("ETag") != etag
-        data4 = resp4.get_json()
+        data4 = resp4.get_json()["items"]
         assert data4 != first
     finally:
         with open(PRODUCTS_PATH, "w", encoding="utf-8") as fh:
@@ -59,7 +59,7 @@ def test_recipes_etag_and_conditional_headers():
     assert resp.status_code == 200
     etag = resp.headers.get("ETag")
     last_mod = resp.headers.get("Last-Modified")
-    first = resp.get_json()
+    first = resp.get_json()["items"]
 
     resp2 = client.get(
         "/api/recipes?locale=en", headers={"If-None-Match": etag}
@@ -81,7 +81,7 @@ def test_recipes_etag_and_conditional_headers():
         resp4 = client.get("/api/recipes?locale=en")
         assert resp4.status_code == 200
         assert resp4.headers.get("ETag") != etag
-        data4 = resp4.get_json()
+        data4 = resp4.get_json()["items"]
         assert data4 != first
     finally:
         with open(RECIPES_PATH, "w", encoding="utf-8") as fh:

--- a/tests/test_minimal_valid.py
+++ b/tests/test_minimal_valid.py
@@ -1,11 +1,13 @@
 import json
 import os
 import sys
+import math
 
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 
 from app.utils import validate_file, normalize_product, normalize_recipe
 from app.routes import PRODUCTS_SCHEMA, RECIPES_SCHEMA
+from app import create_app
 
 
 def test_minimal_product_and_recipe_validate(tmp_path):
@@ -48,3 +50,58 @@ def test_minimal_product_and_recipe_validate(tmp_path):
     count, errors = validate_file(str(rec_path), [], RECIPES_SCHEMA, normalize_recipe)
     assert count == 1
     assert errors == []
+
+
+def test_products_pagination_and_sorting():
+    app = create_app()
+    client = app.test_client()
+
+    resp = client.get("/api/products?page_size=5&sort_by=name&order=asc")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["page"] == 1
+    assert data["page_size"] == 5
+    items = data["items"]
+    names = [p["name"] for p in items]
+    assert names == sorted(names, key=str.lower)
+
+    total = data["total"]
+    last_page = math.ceil(total / 5)
+    resp_last = client.get(
+        f"/api/products?page_size=5&page={last_page}&sort_by=name&order=desc"
+    )
+    data_last = resp_last.get_json()
+    expected = total - 5 * (last_page - 1)
+    assert len(data_last["items"]) == expected
+    names_desc = [p["name"] for p in data_last["items"]]
+    assert names_desc == sorted(names_desc, key=str.lower, reverse=True)
+
+
+def test_recipes_pagination_and_sorting():
+    app = create_app()
+    client = app.test_client()
+
+    resp = client.get("/api/recipes?page_size=5&sort_by=name&order=asc")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["page"] == 1
+    assert data["page_size"] == 5
+    names = [
+        r["names"].get("pl") or r["names"].get("en") or r["id"]
+        for r in data["items"]
+    ]
+    assert names == sorted(names, key=str.lower)
+
+    total = data["total"]
+    last_page = math.ceil(total / 5)
+    resp_last = client.get(
+        f"/api/recipes?page_size=5&page={last_page}&sort_by=name&order=desc"
+    )
+    data_last = resp_last.get_json()
+    expected = total - 5 * (last_page - 1)
+    assert len(data_last["items"]) == expected
+    names_desc = [
+        r["names"].get("pl") or r["names"].get("en") or r["id"]
+        for r in data_last["items"]
+    ]
+    assert names_desc == sorted(names_desc, key=str.lower, reverse=True)

--- a/tests/test_products_adapter.py
+++ b/tests/test_products_adapter.py
@@ -12,9 +12,11 @@ def test_products_endpoint_returns_mapped_items():
     resp = client.get("/api/products")
     assert resp.status_code == 200
     data = resp.get_json()
-    assert isinstance(data, list)
-    assert len(data) > 0
-    first = data[0]
+    assert isinstance(data, dict)
+    items = data.get("items", [])
+    assert isinstance(items, list)
+    assert len(items) > 0
+    first = items[0]
     # ensure legacy fields exist
     assert "id" in first and "name_pl" in first and "unit" in first
     # stable shape defaults

--- a/tests/test_recipes_adapter.py
+++ b/tests/test_recipes_adapter.py
@@ -12,9 +12,11 @@ def test_recipes_endpoint_returns_normalized_items():
     resp = client.get("/api/recipes?locale=en")
     assert resp.status_code == 200
     data = resp.get_json()
-    assert isinstance(data, list)
-    assert len(data) > 0
-    sample = data[0]
+    assert isinstance(data, dict)
+    items = data.get("items", [])
+    assert isinstance(items, list)
+    assert len(items) > 0
+    sample = items[0]
     assert "id" in sample and "names" in sample and "servings" in sample
     # stable shape defaults on recipe
     assert sample["amount"] == 0


### PR DESCRIPTION
## Summary
- paginate and sort `/api/products` and `/api/recipes` responses with consistent envelope
- update product and recipe list components to request pages and add navigation controls
- extend tests for API pagination/sorting and update existing checks for new response shape

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689cf5d219f0832a9d0edb526e91a6e7