### PR TITLE
feat: add cache versioning

### DIFF
--- a/app/static/service-worker.js
+++ b/app/static/service-worker.js
@@ -1,44 +1,62 @@
-const APP_VERSION = '4';
-const CACHE_NAME = `food-cache-${APP_VERSION}`;
+const CACHE_PREFIX = 'food-cache';
+let CACHE_VERSION = '0';
 const OFFLINE_URL = '/offline';
 const OFFLINE_HTML = `<!DOCTYPE html><html lang="en"><head><meta charset="utf-8"><title>Offline</title></head><body><h1>You're offline</h1></body></html>`;
 
-const PRECACHE_URLS = [
-  '/',
-  `/static/styles.css?v=${APP_VERSION}`,
-  `/static/script.js?v=${APP_VERSION}`,
-  '/api/ui/en',
-  '/api/ui/pl',
-  '/static/icons/icon-192x192.png',
-  '/static/icons/icon-512x512.png',
-  '/manifest.json'
-];
+async function fetchVersion() {
+  if (CACHE_VERSION !== '0') return CACHE_VERSION;
+  try {
+    const res = await fetch('/version.txt', { cache: 'no-store' });
+    if (res.ok) {
+      CACHE_VERSION = (await res.text()).trim();
+    }
+  } catch (e) {
+    // ignore, keep default
+  }
+  return CACHE_VERSION;
+}
+
+function cacheName() {
+  return `${CACHE_PREFIX}-${CACHE_VERSION}`;
+}
+
+function precacheUrls(v) {
+  return [
+    '/',
+    `/static/styles.css?v=${v}`,
+    `/static/script.js?v=${v}`,
+    '/api/ui/en',
+    '/api/ui/pl',
+    '/static/icons/icon-192x192.png',
+    '/static/icons/icon-512x512.png',
+    '/manifest.json'
+  ];
+}
 
 self.addEventListener('install', event => {
   event.waitUntil(
-    caches
-      .open(CACHE_NAME)
-      .then(cache => {
-        cache.addAll(PRECACHE_URLS);
+    fetchVersion().then(v =>
+      caches.open(cacheName()).then(cache => {
+        cache.addAll(precacheUrls(v));
         cache.put(OFFLINE_URL, new Response(OFFLINE_HTML, { headers: { 'Content-Type': 'text/html' } }));
-      })
-      .then(() => {
+      }).then(() => {
         if (self.registration.active) {
-          return self.clients
-            .matchAll({ type: 'window', includeUncontrolled: true })
-            .then(clients => {
-              clients.forEach(client => client.postMessage({ type: 'RELOAD_PROMPT' }));
-            });
+          return self.clients.matchAll({ type: 'window', includeUncontrolled: true }).then(clients => {
+            clients.forEach(client => client.postMessage({ type: 'RELOAD_PROMPT' }));
+          });
         }
       })
+    )
   );
 });
 
 self.addEventListener('activate', event => {
   event.waitUntil(
-    caches.keys().then(keys => Promise.all(
-      keys.filter(key => key !== CACHE_NAME).map(key => caches.delete(key))
-    )).then(() => self.clients.claim())
+    fetchVersion().then(() =>
+      caches.keys().then(keys => Promise.all(
+        keys.filter(key => key.startsWith(`${CACHE_PREFIX}-`) && key !== cacheName()).map(key => caches.delete(key))
+      )).then(() => self.clients.claim())
+    )
   );
 });
 
@@ -58,11 +76,12 @@ self.addEventListener('fetch', event => {
   event.respondWith(
     caches.match(event.request).then(cached => {
       const fetchPromise = fetch(event.request).then(networkResponse => {
-        caches.open(CACHE_NAME).then(cache => cache.put(event.request, networkResponse.clone()));
-        return networkResponse;
+        return caches.open(cacheName()).then(cache => {
+          cache.put(event.request, networkResponse.clone());
+          return networkResponse;
+        });
       }).catch(() => cached);
       return cached || fetchPromise;
     })
   );
 });
-


### PR DESCRIPTION
## Summary
- derive app version from static and data file mtimes
- expose /version.txt and use it to version service worker caches

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689d007a26e4832a98794eb2c80faf92