### PR TITLE
Add opt-in structured logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,9 @@
+# Food
+
+Run the application with structured JSON request logging by setting `APP_JSON_LOGS=1`:
+
+```bash
+APP_JSON_LOGS=1 flask run
+```
+
+Logs are written to `logs/app.log`.

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,15 +1,59 @@
 """Application factory and global error handling."""
 
-from flask import Flask, request
+import json
+import logging
+import os
+from datetime import datetime
+
+from flask import Flask, g, request
 from werkzeug.exceptions import HTTPException
 
 from .errors import DomainError, error_response
 from .utils.logging import log_error_with_trace, log_warning_with_trace
 
 
+class JSONFormatter(logging.Formatter):
+    def format(self, record: logging.LogRecord) -> str:  # pragma: no cover - simple
+        data = {
+            "timestamp": datetime.utcfromtimestamp(record.created).isoformat(),
+            "level": record.levelname,
+        }
+        if isinstance(record.msg, dict):
+            data.update(record.msg)
+        else:
+            data["message"] = record.getMessage()
+        if record.exc_info:
+            data["stack"] = self.formatException(record.exc_info)
+        return json.dumps(data)
+
+
 def create_app() -> Flask:
     """Application factory for the Food project."""
     app = Flask(__name__, static_folder="static", template_folder="templates")
+
+    if os.environ.get("APP_JSON_LOGS") == "1":
+        log_dir = os.path.join(os.path.dirname(__file__), "..", "logs")
+        os.makedirs(log_dir, exist_ok=True)
+        handler = logging.FileHandler(os.path.join(log_dir, "app.log"))
+        handler.setFormatter(JSONFormatter())
+        root_logger = logging.getLogger()
+        root_logger.setLevel(logging.INFO)
+        root_logger.handlers = [handler]
+
+        @app.after_request
+        def _log_request(response):
+            record = {
+                "method": request.method,
+                "path": request.path,
+                "status": response.status_code,
+            }
+            trace_id = getattr(g, "trace_id", None)
+            if trace_id:
+                record["traceId"] = trace_id
+            root_logger.info(record)
+            return response
+    else:  # pragma: no cover - no-op configuration
+        logging.getLogger().addHandler(logging.NullHandler())
 
     from .routes import bp, run_initial_validation
 
@@ -25,6 +69,7 @@ def create_app() -> Flask:
         trace_id = log_warning_with_trace(
             str(error), {"path": request.path, "args": request.args.to_dict()}
         )
+        g.trace_id = trace_id
         return error_response(str(error), 400, trace_id)
 
     @app.errorhandler(HTTPException)
@@ -36,6 +81,7 @@ def create_app() -> Flask:
         trace_id = log_error_with_trace(
             error, {"path": request.path, "args": request.args.to_dict()}
         )
+        g.trace_id = trace_id
         return error_response("Internal Server Error", 500, trace_id)
 
     return app

--- a/app/utils/logging.py
+++ b/app/utils/logging.py
@@ -16,7 +16,7 @@ def log_error_with_trace(exc: Exception, context: Dict[str, Any]) -> str:
         str: Generated trace identifier (first 8 chars of UUID4).
     """
     trace_id = uuid.uuid4().hex[:8]
-    logger.error("trace %s context=%s", trace_id, context, exc_info=exc)
+    logger.error({"error": str(exc), "context": context, "traceId": trace_id}, exc_info=exc)
     return trace_id
 
 
@@ -31,5 +31,5 @@ def log_warning_with_trace(message: str, context: Dict[str, Any]) -> str:
         str: Generated trace identifier (first 8 chars of UUID4).
     """
     trace_id = uuid.uuid4().hex[:8]
-    logger.warning("trace %s context=%s %s", trace_id, context, message)
+    logger.warning({"message": message, "context": context, "traceId": trace_id})
     return trace_id


### PR DESCRIPTION
## Summary
- configure JSON access log written to `logs/app.log` when `APP_JSON_LOGS=1`
- propagate trace IDs to error responses and logs
- document enabling structured logging in README

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689d01c69a00832a98dc4324bd882790