### PR TITLE
Add minimal CI workflow for pytest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,18 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+          cache: 'pip'
+      - run: pip install -r requirements.txt
+      - run: pip install pytest
+      - run: pytest -q


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to run pytest with Python 3.12

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689d08553838832aac618aae4a04ff9c