### PR TITLE
Improve data normalization and UI button semantics

### DIFF
--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -74,7 +74,7 @@
     <div id="top-sentinel"></div>
     <div id="health-banner" class="alert alert-error hidden justify-between">
       <span data-i18n="error">Error</span>
-      <button id="health-retry" class="btn btn-sm" data-i18n="retry">
+      <button id="health-retry" class="btn btn-sm" data-i18n="retry" type="button">
         Retry
       </button>
     </div>
@@ -115,6 +115,7 @@
           id="layout-toggle"
           aria-label="Toggle layout"
           class="text-xl p-2 bg-transparent border-0"
+          type="button"
         >
           <i id="layout-icon" class="fa-solid fa-mobile-screen-button"></i>
         </button>
@@ -122,6 +123,7 @@
           id="lang-toggle"
           aria-label="Toggle language"
           class="flex items-center gap-1 text-xl p-2 bg-transparent border-0"
+          type="button"
         >
           <i class="fa-solid fa-language"></i>
           <span class="action-label hidden md:inline" data-i18n="language"
@@ -132,6 +134,7 @@
           id="theme-toggle"
           aria-label="Toggle theme"
           class="flex items-center gap-1 text-xl p-2 bg-transparent border-0"
+          type="button"
         >
           <i id="theme-icon" class="fa-solid fa-desktop"></i>
           <span class="action-label hidden md:inline" data-i18n="theme"
@@ -143,6 +146,7 @@
           aria-label="Install app"
           class="text-xl p-2 bg-transparent border-0"
           style="display: none"
+          type="button"
         >
           <i class="fa-solid fa-download"></i>
         </button>
@@ -150,6 +154,7 @@
           id="settings-btn"
           aria-label="Settings"
           class="flex items-center gap-1 text-xl p-2 bg-transparent border-0"
+          type="button"
         >
           <i class="fa-solid fa-gear"></i>
           <span class="action-label hidden md:inline" data-i18n="tab_settings"


### PR DESCRIPTION
## Summary
- make product normalization resilient to domain dataset fields
- add explicit `type="button"` to header controls for better accessibility

## Testing
- `pytest -q`
- `python - <<'PY'
from app.utils import validate_file, normalize_product, normalize_recipe
from app.routes import _validate_products_file
import json, jsonschema, glob
print('products', _validate_products_file())
print('recipes', validate_file('app/data/recipes.json', [], 'app/schemas/recipe.schema.json', normalize_recipe))
for name in ['units.json','favorites.json','history.json','recipes_unresolved.json']:
    with open(f'app/data/{name}','r',encoding='utf-8') as f:
        json.load(f)
print('additional data files parsed')
for schema_file in glob.glob('app/schemas/*.json'):
    with open(schema_file) as f:
        jsonschema.Draft7Validator.check_schema(json.load(f))
print('schemas valid')
PY`
- `python - <<'PY'
from app import create_app
app=create_app()
with app.test_client() as c:
    print('index', c.get('/').status_code)
    print('manifest', c.get('/manifest.json').status_code)
    print('validate', c.get('/api/validate').status_code)
PY`
- `flask --app app:create_app run -p 5005 &
kill %1`

------
https://chatgpt.com/codex/tasks/task_e_689d0f45decc832aa261b9dadde952d5