### PR TITLE
utils: harden normalize_product with domain-derived fallbacks (name/unit/category) and safe defaults

### DIFF
--- a/tests/test_normalize_product_fallbacks.py
+++ b/tests/test_normalize_product_fallbacks.py
@@ -1,0 +1,32 @@
+import os
+import sys
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from app.utils import normalize_product
+
+
+def test_normalize_product_derive_from_id():
+    data = {"productId": "prod.allspice"}
+    res = normalize_product(data)
+    assert res["name"] == "Ziele angielskie"
+    assert res["unit"] == "lvl"
+    assert res["category"] == "spices"
+
+
+def test_normalize_product_resolves_alias():
+    data = {"alias": "product.basil"}
+    res = normalize_product(data)
+    assert res["name"] == "Bazylia"
+    assert res["category"] == "spices"
+
+
+def test_normalize_product_defaults_and_coercion():
+    data = {"name": "", "unit": "PCS", "category": "", "quantity": "2", "threshold": "", "main": "false"}
+    res = normalize_product(data)
+    assert res["name"] == "Unknown"
+    assert res["unit"] == "szt"
+    assert res["category"] == "uncategorized"
+    assert res["quantity"] == 2
+    assert res["threshold"] == 0
+    assert res["main"] is False


### PR DESCRIPTION
## Summary
- derive missing product name/unit/category from bundled domain data and sensible defaults
- coerce numeric and boolean fields while mapping free-text units to codes
- test normalization fallbacks for productId, alias and default handling

## Testing
- `pytest -q`
- `python scripts/validate_data.py`
- `flask --app app run -p 5002` (then `curl -sSf http://localhost:5002/api/products?page_size=1 | head -c 200` and `curl -sSf http://localhost:5002/ | head -n 5`)


------
https://chatgpt.com/codex/tasks/task_e_689d7742129c832a9828932c1bd326f6