### PR TITLE
feat: add desktop product filters and search persistence

### DIFF
--- a/app/static/js/helpers.js
+++ b/app/static/js/helpers.js
@@ -165,6 +165,22 @@ export function throttle(fn, delay = 200) {
   };
 }
 
+export function loadProductFilters() {
+  if (state.displayMode !== "desktop") return {};
+  try {
+    return JSON.parse(localStorage.getItem("productFilters") || "{}");
+  } catch {
+    return {};
+  }
+}
+
+export function saveProductFilters(filters = {}) {
+  if (state.displayMode !== "desktop") return;
+  try {
+    localStorage.setItem("productFilters", JSON.stringify(filters));
+  } catch {}
+}
+
 export function setFieldError(el, msg) {
   let err = el.nextElementSibling;
   if (!err || !err.classList.contains("form-error")) {
@@ -656,18 +672,17 @@ export function getStockState(p = {}) {
   return "ok";
 }
 
-export function matchesFilter(p = {}, filter = "all") {
-  const state = getStockState(p);
-  switch (filter) {
-    case "available":
-      return state === "ok";
-    case "low":
-      return state === "low";
-    case "missing":
-      return state === "zero";
-    default:
-      return true;
+export function matchesFilter(p = {}, filters = {}) {
+  const { status, storage, category } = filters;
+  const st = getStockState(p);
+  if (status) {
+    if (status === "available" && st !== "ok") return false;
+    if (status === "low" && st !== "low") return false;
+    if (status === "missing" && st !== "zero") return false;
   }
+  if (storage && p.storage !== storage) return false;
+  if (category && p.category !== category) return false;
+  return true;
 }
 
 // Desktop tab accessibility and toolbar handling

--- a/app/static/styles.css
+++ b/app/static/styles.css
@@ -158,6 +158,10 @@ html[data-layout="mobile"] #product-table .status-label {
   padding-right: 0;
 }
 
+.filter-chip {
+  cursor: pointer;
+}
+
 .field-group {
   display: flex;
   flex-wrap: wrap;

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -248,38 +248,41 @@
         >
           Produkty
         </h1>
-        <div id="controls" class="flex flex-wrap items-center gap-4 mb-4">
-          <div
-            class="flex flex-col md:flex-row gap-2 items-start md:items-center flex-1"
-          >
+        <div id="product-filters" class="flex flex-wrap items-center gap-2 mb-2">
+          <select id="storage-filter" class="select select-sm select-bordered">
+            <option value="">All storages</option>
+            <option value="fridge">Fridge</option>
+            <option value="freezer">Freezer</option>
+            <option value="pantry">Pantry</option>
+          </select>
+          <select id="status-filter" class="select select-sm select-bordered">
+            <option value="">All status</option>
+            <option value="available">Available</option>
+            <option value="low">Low</option>
+            <option value="missing">Missing</option>
+          </select>
+          <select id="category-filter" class="select select-sm select-bordered">
+            <option value="">All categories</option>
+          </select>
+          <div class="relative">
             <input
-              id="product-search"
-              placeholder="Szukaj produktu"
+              id="product-search-input"
+              placeholder="Search products"
               data-i18n="search_placeholder"
-              class="input input-bordered flex-1 min-w-[200px]"
+              class="input input-sm input-bordered pr-8"
             />
-            <select
-              id="state-filter"
-              class="select select-bordered w-full md:w-auto"
+            <button
+              id="search-clear"
+              class="btn btn-ghost btn-xs absolute right-1 top-1/2 -translate-y-1/2 hidden"
+              aria-label="Clear search"
+              type="button"
             >
-              <option value="all" data-i18n="state_filter_all">
-                Wszystkie
-              </option>
-              <option
-                value="available"
-                data-i18n="state_filter_available"
-                selected
-              >
-                Dostępne
-              </option>
-              <option value="missing" data-i18n="state_filter_missing">
-                Brakujące
-              </option>
-              <option value="low" data-i18n="state_filter_low">
-                Kończące się
-              </option>
-            </select>
+              <i class="fa-solid fa-xmark"></i>
+            </button>
           </div>
+        </div>
+        <div id="active-filters" class="flex flex-wrap gap-2 mb-4"></div>
+        <div id="controls" class="flex flex-wrap items-center gap-4 mb-4">
           <button
             id="view-toggle"
             class="btn btn-outline btn-primary btn-sm min-h-11 justify-center"


### PR DESCRIPTION
## Summary
- add compact storage, status, and category filters with debounced search and clear control
- show active filter chips and persist selections in localStorage
- extend helper utilities for filter persistence and multi-key matching

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689d93f3476c832ab38a9a9bf6510c87