### PR TITLE
feat: add desktop keyboard shortcuts

### DIFF
--- a/app/static/js/components/product-table.js
+++ b/app/static/js/components/product-table.js
@@ -39,6 +39,7 @@ let storageFilter,
 
 // --- bulk selection handling
 const selectedProducts = new Set();
+APP.selectedProducts = selectedProducts;
 let bulkBar;
 let bulkCount;
 let bulkButtons = [];

--- a/app/static/js/helpers.js
+++ b/app/static/js/helpers.js
@@ -734,6 +734,79 @@ export function saveShoppingCollapsed() {
   } catch {}
 }
 
+function updateAddShortcutTooltip() {
+  const btn = document.querySelector('#add-form button[type="submit"]');
+  if (!btn) return;
+  const line =
+    state.currentLang === 'pl' ? 'Ctrl+Enter – Zapisz' : 'Ctrl+Enter – Save';
+  const parts = btn.title ? btn.title.split('\n') : [];
+  const idx = parts.findIndex((p) => p.startsWith('Ctrl+Enter'));
+  if (idx >= 0) parts[idx] = line;
+  else parts.push(line);
+  btn.title = parts.join('\n');
+}
+
+function isFormInput(el) {
+  if (!el) return false;
+  return (
+    el.tagName === 'INPUT' ||
+    el.tagName === 'TEXTAREA' ||
+    el.tagName === 'SELECT' ||
+    el.isContentEditable
+  );
+}
+
+document.addEventListener('keydown', (e) => {
+  if (state.displayMode !== 'desktop') return;
+  const active = document.activeElement;
+  const inInput = isFormInput(active);
+  if (e.key === 'Enter' && e.ctrlKey) {
+    const form = document.getElementById('add-form');
+    if (form && form.checkValidity()) {
+      e.preventDefault();
+      const submitBtn = form.querySelector('button[type="submit"]');
+      form.requestSubmit(submitBtn);
+    }
+    return;
+  }
+  if (inInput) return;
+  const app = window.APP || {};
+  if (e.key === '/' && app.activeTab === 'tab-products') {
+    e.preventDefault();
+    document.getElementById('product-search-input')?.focus();
+    return;
+  }
+  if ((e.key === 'n' || e.key === 'N') && app.activeTab === 'tab-products') {
+    e.preventDefault();
+    document.getElementById('add-product-btn')?.click();
+    return;
+  }
+  if (e.key === 'Delete' && app.activeTab === 'tab-products') {
+    const count = app.selectedProducts
+      ? app.selectedProducts.size
+      : document.querySelectorAll('.product-select:checked').length;
+    if (count > 0) {
+      e.preventDefault();
+      document.getElementById('delete-selected')?.click();
+    }
+    return;
+  }
+  if (e.altKey && !e.ctrlKey && !e.shiftKey) {
+    const map = {
+      '1': 'tab-products',
+      '2': 'tab-recipes',
+      '3': 'tab-shopping',
+      '4': 'tab-history',
+      '5': 'tab-settings',
+    };
+    const tab = map[e.key];
+    if (tab) {
+      e.preventDefault();
+      document.querySelector(`[data-tab-target="${tab}"]`)?.click();
+    }
+  }
+});
+
 // Desktop tab accessibility and toolbar handling
 document.addEventListener("DOMContentLoaded", () => {
   const tablist = document.querySelector(".desktop-nav");
@@ -804,5 +877,10 @@ document.addEventListener("DOMContentLoaded", () => {
 
   document.getElementById("edit-json-header")?.addEventListener("click", () => {
     document.getElementById("edit-json")?.scrollIntoView({ behavior: "smooth" });
+  });
+
+  updateAddShortcutTooltip();
+  document.getElementById('lang-toggle')?.addEventListener('click', () => {
+    setTimeout(updateAddShortcutTooltip, 0);
   });
 });

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -106,6 +106,7 @@
             aria-selected="true"
             data-tab-target="tab-products"
             data-i18n="tab_products"
+            title="Alt+1"
             >Products</a
           >
           <a
@@ -115,6 +116,7 @@
             aria-selected="false"
             data-tab-target="tab-recipes"
             data-i18n="tab_recipes"
+            title="Alt+2"
             >Recipes</a
           >
           <a
@@ -124,6 +126,7 @@
             aria-selected="false"
             data-tab-target="tab-shopping"
             data-i18n="tab_shopping"
+            title="Alt+3"
             >Shopping</a
           >
           <a
@@ -133,6 +136,7 @@
             aria-selected="false"
             data-tab-target="tab-history"
             data-i18n="tab_history"
+            title="Alt+4"
             >History</a
           >
           <a
@@ -142,6 +146,7 @@
             aria-selected="false"
             data-tab-target="tab-settings"
             data-i18n="tab_settings"
+            title="Alt+5"
             >Settings</a
           >
         </div>
@@ -153,6 +158,7 @@
             data-action-tab="tab-products"
             class="btn btn-primary btn-sm"
             data-i18n="heading_add_product"
+            title="Add product (N)"
             type="button"
             style="display: none"
           >
@@ -289,6 +295,7 @@
               placeholder="Search products"
               data-i18n="search_placeholder"
               class="input input-sm input-bordered pr-8"
+              title="Search (/)"
             />
             <button
               id="search-clear"
@@ -346,6 +353,7 @@
               <button
                 id="delete-selected"
                 class="btn btn-error btn-sm flex items-center gap-1"
+                title="Delete selected (Del)"
                 disabled
                 type="button"
               >
@@ -611,7 +619,7 @@
               type="submit"
               class="btn btn-primary btn-sm"
               data-i18n="save_button"
-              title="Enter – Save\nShift+Enter – Save and add another\nEsc – Cancel"
+              title="Enter – Save\nShift+Enter – Save and add another\nCtrl+Enter – Save\nEsc – Cancel"
             >
               Save
             </button>


### PR DESCRIPTION
## Summary
- add global keyboard shortcuts for search, add product, bulk delete and tab navigation
- document shortcuts in UI tooltips and expose selected products globally

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689da5f43ef8832a93e5a47a7d9c3108