### PR TITLE
Refactor frontend filters and layout

### DIFF
--- a/app/static/script.js
+++ b/app/static/script.js
@@ -110,10 +110,8 @@ function registerServiceWorker() {
 
 function resetProductFilters() {
   APP.state.filter = "available";
-  const sel = document.getElementById("state-filter");
+  const sel = document.getElementById("status-filter");
   if (sel) sel.value = "available";
-  const selMobile = document.getElementById("state-filter-mobile");
-  if (selMobile) selMobile.value = "available";
 }
 
 function resetRecipeFilters() {
@@ -154,10 +152,8 @@ async function activateTab(targetId) {
   if (targetId === "tab-products") {
     resetProductFilters();
     const val = APP.searches["tab-products"] || "";
-    const search = document.getElementById("product-search");
+    const search = document.getElementById("product-search-input");
     if (search) search.value = val;
-    const searchMobile = document.getElementById("product-search-mobile");
-    if (searchMobile) searchMobile.value = val;
     APP.state.search = val;
     if (!APP.state.products || APP.state.products.length === 0) {
       try {
@@ -557,10 +553,8 @@ function initNavigationAndEvents() {
   const deleteBtn = document.getElementById("delete-selected");
   const selectHeader = document.getElementById("select-header");
   const addSection = document.getElementById("add-section");
-  const filterSel = document.getElementById("state-filter");
-  const filterSelMobile = document.getElementById("state-filter-mobile");
-  const searchInput = document.getElementById("product-search");
-  const searchInputMobile = document.getElementById("product-search-mobile");
+  const filterSel = document.getElementById("status-filter");
+  const searchInput = document.getElementById("product-search-input");
   function enterEditMode() {
     APP.editBackup = JSON.parse(JSON.stringify(APP.state.products));
     APP.state.editing = true;
@@ -572,9 +566,7 @@ function initNavigationAndEvents() {
     selectHeader.style.display = "";
     if (addSection) addSection.style.display = "";
     filterSel?.setAttribute("disabled", "true");
-    filterSelMobile?.setAttribute("disabled", "true");
     searchInput?.setAttribute("disabled", "true");
-    searchInputMobile?.setAttribute("disabled", "true");
     ProductTable.renderProducts();
     updateAriaLabels();
   }
@@ -593,9 +585,7 @@ function initNavigationAndEvents() {
     selectHeader.style.display = "none";
     if (addSection) addSection.style.display = "none";
     filterSel?.removeAttribute("disabled");
-    filterSelMobile?.removeAttribute("disabled");
     searchInput?.removeAttribute("disabled");
-    searchInputMobile?.removeAttribute("disabled");
     ProductTable.renderProducts();
     updateAriaLabels();
   }
@@ -661,25 +651,10 @@ function initNavigationAndEvents() {
     APP.state.filter = filterSel.value;
     ProductTable.renderProducts();
   });
-  filterSelMobile?.addEventListener("change", () => {
-    APP.state.filter = filterSelMobile.value;
-    ProductTable.renderProducts();
-  });
   searchInput?.addEventListener(
     "input",
     debounce(() => {
       const val = searchInput.value.trim().toLowerCase();
-      APP.searches["tab-products"] = val;
-      if (APP.activeTab === "tab-products") {
-        APP.state.search = val;
-        ProductTable.renderProducts();
-      }
-    }, 150),
-  );
-  searchInputMobile?.addEventListener(
-    "input",
-    debounce(() => {
-      const val = searchInputMobile.value.trim().toLowerCase();
       APP.searches["tab-products"] = val;
       if (APP.activeTab === "tab-products") {
         APP.state.search = val;

--- a/app/static/styles.css
+++ b/app/static/styles.css
@@ -39,6 +39,15 @@ html[data-layout="mobile"] {
   height: 3rem;
 }
 
+/* layout helpers */
+.main-content {
+  padding-bottom: calc(env(safe-area-inset-bottom) + 6rem);
+}
+
+.bottom-nav {
+  padding-bottom: env(safe-area-inset-bottom);
+}
+
 /* removed header and main layout in favor of Tailwind */
 /* Edit mode table layout */
 #product-table.edit-mode thead th,

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -265,7 +265,7 @@
         </div>
       </div>
     </header>
-    <main class="max-w-screen-xl mx-auto p-4 md:p-6 pb-24" style="padding-bottom: calc(env(safe-area-inset-bottom)+6rem)">
+    <main class="max-w-screen-xl mx-auto p-4 md:p-6 pb-24 main-content">
       <div id="tab-products" class="tab-panel">
         <h1
           class="text-xl md:text-2xl font-semibold mb-4 md:mb-6"
@@ -718,7 +718,6 @@
             <div
               id="recipe-sort-desktop-container"
               class="flex items-center gap-2"
-              style="display: flex"
             >
               <select
                 id="recipe-sort-field"
@@ -1314,7 +1313,7 @@
       </div>
     </main>
 
-    <nav class="fixed bottom-0 left-0 w-full z-50 bg-base-100 flex border-t border-base-300" style="padding-bottom: env(safe-area-inset-bottom)">
+    <nav class="fixed bottom-0 left-0 w-full z-50 bg-base-100 flex border-t border-base-300 bottom-nav">
       <a
         class="tab tab-active font-bold flex flex-col items-center justify-center flex-1 py-3 px-2 border-r border-base-300 min-h-11 text-center"
         data-tab-target="tab-products"


### PR DESCRIPTION
## Summary
- align script with `status-filter` and `product-search-input` IDs and drop unused mobile bindings
- move safe-area padding into CSS classes and remove redundant inline styles

## Testing
- `pytest -q`
- `python3 scripts/validate_data.py`
- `flask --app app:create_app run -p 5005`

------
https://chatgpt.com/codex/tasks/task_e_689dad40020c832a8dbcd10bd61b20c6