### PR TITLE
Stabilize UI after desktop UX pass (bugfixes & regressions only)

### DIFF
--- a/app/static/js/components/product-table.js
+++ b/app/static/js/components/product-table.js
@@ -465,6 +465,7 @@ function renderProductPager() {
   }
   pager.innerHTML = "";
   const prev = document.createElement("button");
+  prev.type = "button";
   prev.className = "btn btn-sm";
   prev.textContent = t("prev");
   prev.disabled = productPager.page <= 1;
@@ -473,6 +474,7 @@ function renderProductPager() {
     refreshProducts();
   });
   const next = document.createElement("button");
+  next.type = "button";
   next.className = "btn btn-sm";
   next.textContent = t("next");
   const maxPage = Math.ceil(productPager.total / productPager.page_size);

--- a/app/static/js/components/recipe-list.js
+++ b/app/static/js/components/recipe-list.js
@@ -49,6 +49,7 @@ export function renderRecipes() {
       name.textContent = nameStr;
       row.appendChild(name);
       const favBtn = document.createElement("button");
+      favBtn.type = "button";
       favBtn.className = "btn btn-ghost btn-xs";
       favBtn.innerHTML = state.favoriteRecipes.has(r.id)
         ? '<i class="fa-solid fa-heart"></i>'
@@ -110,6 +111,7 @@ function renderRecipePager() {
   }
   pager.innerHTML = "";
   const prev = document.createElement("button");
+  prev.type = "button";
   prev.className = "btn btn-sm";
   prev.textContent = t("prev");
   prev.disabled = state.recipePage <= 1;
@@ -118,6 +120,7 @@ function renderRecipePager() {
     loadRecipes();
   });
   const next = document.createElement("button");
+  next.type = "button";
   next.className = "btn btn-sm";
   next.textContent = t("next");
   const maxPage = Math.ceil((state.recipesTotal || 0) / state.recipePageSize);

--- a/app/static/js/components/toast.js
+++ b/app/static/js/components/toast.js
@@ -51,6 +51,7 @@ function createToast({
   alert.appendChild(body);
   if (action) {
     const btn = document.createElement("button");
+    btn.type = "button";
     btn.className = "btn btn-sm ml-auto mr-8";
     btn.textContent = action.label;
     btn.addEventListener("click", () => {
@@ -60,6 +61,7 @@ function createToast({
     alert.appendChild(btn);
   }
   const close = document.createElement("button");
+  close.type = "button";
   close.className = "btn btn-xs btn-circle btn-ghost absolute top-1 right-1";
   close.setAttribute("title", t("close"));
   close.setAttribute("aria-label", t("close"));
@@ -128,6 +130,7 @@ export function showLowStockToast(
   const span = document.createElement("span");
   span.textContent = t("toast_low_stock");
   const btn = document.createElement("button");
+  btn.type = "button";
   btn.className = "btn btn-sm ml-auto mr-8";
   btn.dataset.action = "shopping";
   btn.textContent = t("toast_go_shopping");
@@ -143,6 +146,7 @@ export function showLowStockToast(
     alert.remove();
   });
   const close = document.createElement("button");
+  close.type = "button";
   close.className = "btn btn-xs btn-circle btn-ghost absolute top-1 right-1";
   close.dataset.action = "close";
   close.setAttribute("title", t("close"));
@@ -204,6 +208,7 @@ export function showTopBanner(message, { actionLabel, onAction } = {}) {
   banner.appendChild(msg);
   if (actionLabel && onAction) {
     const btn = document.createElement("button");
+    btn.type = "button";
     btn.className = "btn btn-sm";
     btn.textContent = actionLabel;
     btn.addEventListener("click", () => {
@@ -213,6 +218,7 @@ export function showTopBanner(message, { actionLabel, onAction } = {}) {
     banner.appendChild(btn);
   }
   const close = document.createElement("button");
+  close.type = "button";
   close.className = "btn btn-xs btn-circle btn-ghost";
   close.innerHTML = '<i class="fa-regular fa-xmark"></i>';
   close.addEventListener("click", () => banner.remove());

--- a/app/static/js/helpers.js
+++ b/app/static/js/helpers.js
@@ -125,6 +125,7 @@ HTMLDialogElement.prototype.showModal = function (...args) {
       this.setAttribute("aria-labelledby", title.id);
     }
   }
+  const prevActive = document.activeElement;
   nativeShowModal.apply(this, args);
   const focusables = this.querySelectorAll(
     'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
@@ -151,9 +152,16 @@ HTMLDialogElement.prototype.showModal = function (...args) {
     }
   };
   this.addEventListener("keydown", trap);
-  this.addEventListener("close", () => {
-    this.removeEventListener("keydown", trap);
-  }, { once: true });
+  this.addEventListener(
+    "close",
+    () => {
+      this.removeEventListener("keydown", trap);
+      if (prevActive && typeof prevActive.focus === "function") {
+        prevActive.focus();
+      }
+    },
+    { once: true }
+  );
   if (primary) {
     if (!primary.getAttribute("aria-label")) {
       primary.setAttribute("aria-label", primary.textContent.trim());


### PR DESCRIPTION
## Summary
- prevent toast actions from behaving like form submits by tagging actions and dismiss buttons with `type="button"`
- guard recipe and product pagers against stray submits by setting `type="button"` on their navigation buttons
- return keyboard focus to the triggering control when closing dialogs

## Testing
- `pytest -q`
- `python3 scripts/validate_data.py`
- `python - <<'PY'
from app.utils import _validate_products_file
print('products', _validate_products_file())
PY` *(fails: ImportError: cannot import name '_validate_products_file')*

------
https://chatgpt.com/codex/tasks/task_e_689db23c95ec832abab492941031a57f