### PR TITLE
Enable default console logging when APP_JSON_LOGS is unset

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -40,8 +40,11 @@ def _configure_logging() -> logging.Logger:
         handler.setFormatter(JSONFormatter())
         root_logger.setLevel(logging.INFO)
         root_logger.addHandler(handler)
-    else:  # pragma: no cover - no-op configuration
-        root_logger.addHandler(logging.NullHandler())
+    else:  # pragma: no cover - console logging for development
+        handler = logging.StreamHandler()
+        handler.setFormatter(logging.Formatter("%(levelname)s: %(message)s"))
+        root_logger.setLevel(logging.INFO)
+        root_logger.addHandler(handler)
     return root_logger
 
 


### PR DESCRIPTION
## Summary
- Enable console logging when `APP_JSON_LOGS` is not set, using a `StreamHandler` and INFO level

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689e117d5778832aa835435c08c4035e