### PR TITLE
Remove mobile navigation and layout toggle from index.html

### DIFF
--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -198,17 +198,6 @@
           >
             <li>
               <button
-                id="layout-toggle"
-                aria-label="Toggle layout"
-                title="Toggle layout"
-                class="text-xl p-2 bg-transparent border-0"
-                type="button"
-              >
-                <i id="layout-icon" class="fa-solid fa-mobile-screen-button"></i>
-              </button>
-            </li>
-            <li>
-              <button
                 id="lang-toggle"
                 aria-label="Toggle language"
                 title="Toggle language"
@@ -1312,43 +1301,6 @@
       </div>
     </main>
 
-    <nav class="fixed bottom-0 left-0 w-full z-50 bg-base-100 flex border-t border-base-300 bottom-nav">
-      <a
-        class="tab tab-active font-bold flex flex-col items-center justify-center flex-1 py-3 px-2 border-r border-base-300 min-h-11 text-center"
-        aria-controls="tab-products" data-tab-target="tab-products"
-      >
-        <i class="fa-solid fa-box text-xl"></i>
-        <span class="text-xs" data-i18n="tab_products">Products</span>
-      </a>
-      <a
-        class="tab flex flex-col items-center justify-center flex-1 py-3 px-2 border-r border-base-300 min-h-11 text-center"
-        aria-controls="tab-recipes" data-tab-target="tab-recipes"
-      >
-        <i class="fa-solid fa-utensils text-xl"></i>
-        <span class="text-xs" data-i18n="tab_recipes">Recipes</span>
-      </a>
-      <a
-        class="tab flex flex-col items-center justify-center flex-1 py-3 px-2 border-r border-base-300 min-h-11 text-center"
-        aria-controls="tab-shopping" data-tab-target="tab-shopping"
-      >
-        <i class="fa-solid fa-cart-shopping text-xl"></i>
-        <span class="text-xs" data-i18n="tab_shopping">Shopping</span>
-      </a>
-      <a
-        class="tab flex flex-col items-center justify-center flex-1 py-3 px-2 border-r border-base-300 min-h-11 text-center"
-        aria-controls="tab-history" data-tab-target="tab-history"
-      >
-        <i class="fa-solid fa-clock-rotate-left text-xl"></i>
-        <span class="text-xs" data-i18n="tab_history">History</span>
-      </a>
-      <a
-        class="tab flex flex-col items-center justify-center flex-1 py-3 px-2 min-h-11 text-center"
-        aria-controls="tab-settings" data-tab-target="tab-settings"
-      >
-        <i class="fa-solid fa-gear text-xl"></i>
-        <span class="text-xs" data-i18n="tab_settings">Settings</span>
-      </a>
-    </nav>
     <script>
       window.APP_VERSION = {{ app_version|tojson }};
     </script>


### PR DESCRIPTION
## Summary
- remove bottom mobile navigation tabs
- drop layout toggle for mobile/desktop switch

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689e1465708c832abec6980ff8252cd6