### PR TITLE
Remove mobile-specific layout logic

### DIFF
--- a/app/static/js/components/product-table.js
+++ b/app/static/js/components/product-table.js
@@ -797,8 +797,6 @@ function renderProductsImmediate() {
 
           const header = document.createElement("header");
           header.className = "storage-header flex items-center gap-2";
-          if (state.displayMode === "mobile")
-            header.classList.add("cursor-pointer");
           const nameSpan = document.createElement("span");
           nameSpan.className = "inline-flex items-center text-xl font-semibold";
           nameSpan.textContent = `${STORAGE_ICONS[stor] || ""} ${t(STORAGE_KEYS[stor] || stor)}`;
@@ -837,8 +835,6 @@ function renderProductsImmediate() {
 
                 const catHeader = document.createElement("header");
                 catHeader.className = "category-header flex items-center gap-2";
-                if (state.displayMode === "mobile")
-                  catHeader.classList.add("cursor-pointer");
                 const catSpan = document.createElement("span");
                 catSpan.className = "font-medium";
                 catSpan.textContent = t(cat, "categories");
@@ -994,17 +990,8 @@ function attachCollapses(root) {
 
   const toggleHandler = (e) => {
     if (APP.state && APP.state.editing) return;
-
-    const isMobile = window.matchMedia("(max-width: 768px)").matches;
-    let btn;
-    if (isMobile) {
-      const hdr = e.target.closest(".storage-header, .category-header");
-      if (!hdr) return;
-      btn = hdr.querySelector(".toggle-storage, .toggle-category");
-    } else {
-      btn = e.target.closest(".toggle-storage, .toggle-category");
-      if (!btn) return;
-    }
+    const btn = e.target.closest(".toggle-storage, .toggle-category");
+    if (!btn) return;
 
     e.stopPropagation();
 

--- a/app/static/js/components/recipe-list.js
+++ b/app/static/js/components/recipe-list.js
@@ -190,7 +190,6 @@ export function bindRecipeEvents() {
   const sortField = document.getElementById("recipe-sort-field");
   const sortAsc = document.getElementById("recipe-sort-dir-asc");
   const sortDesc = document.getElementById("recipe-sort-dir-desc");
-  const sortMobile = document.getElementById("recipe-sort-mobile");
   const timeFilter = document.getElementById("recipe-time-filter");
   const portionsFilter = document.getElementById("recipe-portions-filter");
   const favToggle = document.getElementById("recipe-favorites-toggle");
@@ -223,17 +222,6 @@ export function bindRecipeEvents() {
     state.recipePage = 1;
     loadRecipes();
   });
-  sortMobile?.addEventListener(
-    "change",
-    debounce(() => {
-      const [field, dir] = sortMobile.value.split("-");
-      state.recipeSortField = field;
-      state.recipeSortDir = dir;
-      updateSortButtons();
-       state.recipePage = 1;
-      loadRecipes();
-    }, 150),
-  );
 
   timeFilter?.addEventListener(
     "change",
@@ -265,7 +253,6 @@ export function bindRecipeEvents() {
     state.recipePortionsFilter = "";
     state.showFavoritesOnly = false;
     sortField && (sortField.value = "name");
-    sortMobile && (sortMobile.value = "name-asc");
     timeFilter && (timeFilter.value = "");
     portionsFilter && (portionsFilter.value = "");
     favToggle?.classList.remove("btn-primary");

--- a/app/static/js/helpers.js
+++ b/app/static/js/helpers.js
@@ -82,8 +82,6 @@ try {
 }
 
 export const state = {
-  displayMode:
-    document.documentElement.getAttribute("data-layout") || "desktop",
   expandedStorages: {},
   expandedCategories: {},
   shoppingList: storedShopping,
@@ -204,7 +202,6 @@ export function throttle(fn, delay = 200) {
 }
 
 export function loadProductFilters() {
-  if (state.displayMode !== "desktop") return {};
   try {
     return JSON.parse(localStorage.getItem("productFilters") || "{}");
   } catch {
@@ -213,7 +210,6 @@ export function loadProductFilters() {
 }
 
 export function saveProductFilters(filters = {}) {
-  if (state.displayMode !== "desktop") return;
   try {
     localStorage.setItem("productFilters", JSON.stringify(filters));
   } catch {}
@@ -778,7 +774,6 @@ function isFormInput(el) {
 }
 
 document.addEventListener('keydown', (e) => {
-  if (state.displayMode !== 'desktop') return;
   const active = document.activeElement;
   const inInput = isFormInput(active);
   if (e.key === 'Enter' && e.ctrlKey) {

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -1,6 +1,6 @@
 <!doctype html>
 <!-- FIX: Render & responsive boot (2025-08-09) -->
-<html lang="pl" data-layout="desktop">
+<html lang="pl">
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
@@ -641,44 +641,6 @@
             class="flex flex-col sm:flex-row items-start sm:items-center gap-2"
           >
             <span data-i18n="recipe_sort_label">Sortuj według:</span>
-            <div
-              id="recipe-sort-mobile-container"
-              class="w-full"
-              style="display: none"
-            >
-              <select
-                id="recipe-sort-mobile"
-                class="select select-bordered select-sm w-full"
-              >
-                <option value="name-asc" data-i18n="recipe_sort_mobile_name">
-                  Nazwy (A→Z)
-                </option>
-                <option
-                  value="time-asc"
-                  data-i18n="recipe_sort_mobile_time_asc"
-                >
-                  Czasu (rosnąco)
-                </option>
-                <option
-                  value="time-desc"
-                  data-i18n="recipe_sort_mobile_time_desc"
-                >
-                  Czasu (malejąco)
-                </option>
-                <option
-                  value="portions-asc"
-                  data-i18n="recipe_sort_mobile_portions_asc"
-                >
-                  Porcji (rosnąco)
-                </option>
-                <option
-                  value="portions-desc"
-                  data-i18n="recipe_sort_mobile_portions_desc"
-                >
-                  Porcji (malejąco)
-                </option>
-              </select>
-            </div>
             <div
               id="recipe-sort-desktop-container"
               class="flex items-center gap-2"


### PR DESCRIPTION
## Summary
- drop mobile-only branches and state handling in helper utilities
- simplify product table and recipe list components to a single desktop layout
- remove leftover mobile markup from index template

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689e18354d84832a85d9e2b81dbdecb7