### PR TITLE
Ensure product data loads on startup with fallback

### DIFF
--- a/app/static/script.js
+++ b/app/static/script.js
@@ -68,11 +68,12 @@ async function loadProducts() {
     trace("loadProducts:ok");
   } catch (e) {
     console.error(e);
+    APP.state.products = [];
+    ProductTable.renderProducts();
     showTopBanner(t("load_products_failed"), {
       actionLabel: t("retry"),
       onAction: loadProducts,
     });
-    throw e;
   }
 }
 
@@ -748,6 +749,10 @@ async function boot() {
   document.documentElement.setAttribute("lang", state.currentLang);
   await loadFavorites();
   trace("favorites");
+  try {
+    await loadProducts();
+    trace("products");
+  } catch {}
   await loadHistory();
   trace("history");
   initNavigationAndEvents();


### PR DESCRIPTION
## Summary
- Load product data during boot sequence so items are available on initial page load
- Gracefully handle product fetch errors by rendering an empty table and showing a retry banner

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689e22c080d0832ab6d8ef231335e269