### PR TITLE
Load product table data on startup

### DIFF
--- a/app/static/js/components/product-table.js
+++ b/app/static/js/components/product-table.js
@@ -1059,3 +1059,20 @@ if (window.__domain) {
     { once: true },
   );
 }
+
+// Automatically load product data once the DOM is ready. This ensures that
+// the table is populated on initial page load without requiring any user
+// interaction. The listener is registered with `{ once: true }` so the fetch
+// occurs exactly one time.
+if (document.readyState === "loading") {
+  window.addEventListener(
+    "DOMContentLoaded",
+    () => {
+      refreshProducts();
+    },
+    { once: true },
+  );
+} else {
+  // DOM has already loaded, so we can refresh immediately.
+  refreshProducts();
+}


### PR DESCRIPTION
## Summary
- Automatically refresh product data once the DOM is ready so the product table populates on initial page load.

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689e28f305bc832a98ba4284e444ed96