### PR TITLE
Load products from static JSON with logging and fallback

### DIFF
--- a/app/static/products.json
+++ b/app/static/products.json
@@ -1,0 +1,994 @@
+{
+  "categories": [
+    {
+      "id": "category.bread",
+      "names": {
+        "en": "Bread",
+        "pl": "Pieczywo"
+      }
+    },
+    {
+      "id": "category.dairy-eggs",
+      "names": {
+        "en": "Dairy & eggs",
+        "pl": "Nabiał i jajka"
+      }
+    },
+    {
+      "id": "category.dried-legumes",
+      "names": {
+        "en": "Dried legumes",
+        "pl": "Strączki suche"
+      }
+    },
+    {
+      "id": "category.dry-veg",
+      "names": {
+        "en": "Long-lasting vegetables",
+        "pl": "Warzywa trwałe"
+      }
+    },
+    {
+      "id": "category.fresh-veg",
+      "names": {
+        "en": "Fresh vegetables",
+        "pl": "Warzywa świeże"
+      }
+    },
+    {
+      "id": "category.frozen-meals",
+      "names": {
+        "en": "Frozen meals",
+        "pl": "Dania mrożone"
+      }
+    },
+    {
+      "id": "category.grains",
+      "names": {
+        "en": "Grains & groats",
+        "pl": "Zboża i kasze"
+      }
+    },
+    {
+      "id": "category.mushrooms",
+      "names": {
+        "en": "Mushrooms",
+        "pl": "Grzyby"
+      }
+    },
+    {
+      "id": "category.oils",
+      "names": {
+        "en": "Oils",
+        "pl": "Oleje"
+      }
+    },
+    {
+      "id": "category.opened-preserves",
+      "names": {
+        "en": "Opened preserves",
+        "pl": "Otwarte przetwory"
+      }
+    },
+    {
+      "id": "category.pasta",
+      "names": {
+        "en": "Pasta",
+        "pl": "Makaron"
+      }
+    },
+    {
+      "id": "category.ready-sauces",
+      "names": {
+        "en": "Ready sauces",
+        "pl": "Gotowe sosy"
+      }
+    },
+    {
+      "id": "category.spices",
+      "names": {
+        "en": "Spices",
+        "pl": "Przyprawy"
+      }
+    },
+    {
+      "id": "category.spreads",
+      "names": {
+        "en": "Spreads & pastes",
+        "pl": "Smary i pasty"
+      }
+    }
+  ],
+  "products": [
+    {
+      "aliases": ["product.allspice"],
+      "categoryId": "category.spices",
+      "id": "prod.allspice",
+      "names": {
+        "en": "Allspice",
+        "pl": "Ziele angielskie"
+      },
+      "unitId": "unit.lvl"
+    },
+    {
+      "aliases": ["product.barley"],
+      "categoryId": "category.grains",
+      "id": "prod.barley",
+      "names": {
+        "en": "Pearl barley",
+        "pl": "Kasza pęczak"
+      },
+      "unitId": "unit.szt"
+    },
+    {
+      "aliases": ["product.basil"],
+      "categoryId": "category.spices",
+      "id": "prod.basil",
+      "names": {
+        "en": "Basil",
+        "pl": "Bazylia"
+      },
+      "unitId": "unit.lvl"
+    },
+    {
+      "aliases": ["product.bay_leaves"],
+      "categoryId": "category.spices",
+      "id": "prod.bay-leaves",
+      "names": {
+        "en": "Bay leaves",
+        "pl": "Liście laurowe"
+      },
+      "unitId": "unit.lvl"
+    },
+    {
+      "aliases": ["product.beans_piekny_jas"],
+      "categoryId": "category.dried-legumes",
+      "id": "prod.beans-piekny-jas",
+      "names": {
+        "en": "Piękny Jaś beans",
+        "pl": "Fasola Piękny Jaś"
+      },
+      "unitId": "unit.g"
+    },
+    {
+      "aliases": ["product.bell_peppers"],
+      "categoryId": "category.fresh-veg",
+      "id": "prod.bell-peppers",
+      "names": {
+        "en": "Bell peppers",
+        "pl": "Papryki"
+      },
+      "unitId": "unit.szt"
+    },
+    {
+      "aliases": ["product.borscht"],
+      "categoryId": "category.frozen-meals",
+      "id": "prod.borscht",
+      "names": {
+        "en": "Borscht",
+        "pl": "Barszcz"
+      },
+      "unitId": "unit.sloik"
+    },
+    {
+      "aliases": ["product.bouillon_cubes"],
+      "categoryId": "category.spices",
+      "id": "prod.bouillon-cubes",
+      "names": {
+        "en": "Bouillon cubes",
+        "pl": "Kostki bulionowe"
+      },
+      "unitId": "unit.lvl"
+    },
+    {
+      "aliases": ["product.breaded_schnitzel"],
+      "categoryId": "category.frozen-meals",
+      "id": "prod.breaded-schnitzel",
+      "names": {
+        "en": "Breaded schnitzel",
+        "pl": "Sznycel w chrupiącej panierce"
+      },
+      "unitId": "unit.szt"
+    },
+    {
+      "aliases": ["product.breaded_tofu_hot_spicy"],
+      "categoryId": "category.dairy-eggs",
+      "id": "prod.breaded-tofu-hot-spicy",
+      "names": {
+        "en": "Hot & Spicy breaded tofu",
+        "pl": "Tofu panierowane Hot & Spicy"
+      },
+      "unitId": "unit.szt"
+    },
+    {
+      "aliases": ["product.buckwheat"],
+      "categoryId": "category.grains",
+      "id": "prod.buckwheat",
+      "names": {
+        "en": "Buckwheat groats",
+        "pl": "Kasza gryczana"
+      },
+      "unitId": "unit.szt"
+    },
+    {
+      "aliases": ["product.bulgur"],
+      "categoryId": "category.grains",
+      "id": "prod.bulgur",
+      "names": {
+        "en": "Bulgur",
+        "pl": "Kasza bulgur"
+      },
+      "unitId": "unit.szt"
+    },
+    {
+      "aliases": ["product.cardamom"],
+      "categoryId": "category.spices",
+      "id": "prod.cardamom",
+      "names": {
+        "en": "Cardamom",
+        "pl": "Kardamon"
+      },
+      "unitId": "unit.lvl"
+    },
+    {
+      "aliases": ["product.carrot"],
+      "categoryId": "category.fresh-veg",
+      "id": "prod.carrot",
+      "names": {
+        "en": "Carrot",
+        "pl": "Marchew"
+      },
+      "unitId": "unit.g"
+    },
+    {
+      "aliases": ["product.cashew_nuts"],
+      "categoryId": "category.spreads",
+      "id": "prod.cashew-nuts",
+      "names": {
+        "en": "Cashew nuts",
+        "pl": "Orzechy nerkowca"
+      },
+      "unitId": "unit.g"
+    },
+    {
+      "aliases": ["product.cauliflower_soup"],
+      "categoryId": "category.frozen-meals",
+      "id": "prod.cauliflower-soup",
+      "names": {
+        "en": "Cauliflower soup",
+        "pl": "Zupa kalafiorowa"
+      },
+      "unitId": "unit.szt"
+    },
+    {
+      "aliases": ["product.cayenne_chilli"],
+      "categoryId": "category.spices",
+      "id": "prod.cayenne-chilli",
+      "names": {
+        "en": "Cayenne chili",
+        "pl": "Chili cayenne"
+      },
+      "unitId": "unit.lvl"
+    },
+    {
+      "aliases": ["product.champignons"],
+      "categoryId": "category.mushrooms",
+      "id": "prod.champignons",
+      "names": {
+        "en": "Champignons",
+        "pl": "Pieczarki"
+      },
+      "unitId": "unit.g"
+    },
+    {
+      "aliases": ["product.cheese_slices"],
+      "categoryId": "category.dairy-eggs",
+      "id": "prod.cheese-slices",
+      "names": {
+        "en": "Cheese slices",
+        "pl": "Ser w plastrach"
+      },
+      "unitId": "unit.szt"
+    },
+    {
+      "aliases": ["product.chickpeas"],
+      "categoryId": "category.opened-preserves",
+      "id": "prod.chickpeas",
+      "names": {
+        "en": "Chickpeas",
+        "pl": "Ciecierzyca"
+      },
+      "unitId": "unit.szt"
+    },
+    {
+      "aliases": ["product.chinese_cabbage"],
+      "categoryId": "category.fresh-veg",
+      "id": "prod.chinese-cabbage",
+      "names": {
+        "en": "Chinese cabbage",
+        "pl": "Kapusta pekińska"
+      },
+      "unitId": "unit.szt"
+    },
+    {
+      "aliases": ["product.chinese_sauce"],
+      "categoryId": "category.frozen-meals",
+      "id": "prod.chinese-sauce",
+      "names": {
+        "en": "Chinese-style sauce",
+        "pl": "Sos do chińszczyzny"
+      },
+      "unitId": "unit.szt"
+    },
+    {
+      "aliases": ["product.cloves"],
+      "categoryId": "category.spices",
+      "id": "prod.cloves",
+      "names": {
+        "en": "Cloves",
+        "pl": "Goździki"
+      },
+      "unitId": "unit.lvl"
+    },
+    {
+      "aliases": ["product.coriander_leaves"],
+      "categoryId": "category.spices",
+      "id": "prod.coriander-leaves",
+      "names": {
+        "en": "Coriander leaves",
+        "pl": "Kolendra (liście)"
+      },
+      "unitId": "unit.lvl"
+    },
+    {
+      "aliases": ["product.corn"],
+      "categoryId": "category.opened-preserves",
+      "id": "prod.corn",
+      "names": {
+        "en": "Corn",
+        "pl": "Kukurydza"
+      },
+      "unitId": "unit.szt"
+    },
+    {
+      "aliases": ["product.curry_powder"],
+      "categoryId": "category.spices",
+      "id": "prod.curry-powder",
+      "names": {
+        "en": "Curry powder",
+        "pl": "Przyprawa curry"
+      },
+      "unitId": "unit.lvl"
+    },
+    {
+      "aliases": ["product.dark_gravy_sauce"],
+      "categoryId": "category.spices",
+      "id": "prod.dark-gravy-sauce",
+      "names": {
+        "en": "Dark gravy sauce",
+        "pl": "Sos pieczeniowy ciemny"
+      },
+      "unitId": "unit.lvl"
+    },
+    {
+      "aliases": ["product.dijon_mustard"],
+      "categoryId": "category.opened-preserves",
+      "id": "prod.dijon-mustard",
+      "names": {
+        "en": "Dijon mustard",
+        "pl": "Musztarda dijon"
+      },
+      "unitId": "unit.szt"
+    },
+    {
+      "aliases": ["product.ditalini_rigati_pasta"],
+      "categoryId": "category.pasta",
+      "id": "prod.ditalini-rigati-pasta",
+      "names": {
+        "en": "Ditalini rigati pasta",
+        "pl": "Makaron ditalini rigati"
+      },
+      "unitId": "unit.g"
+    },
+    {
+      "aliases": ["product.eggplant"],
+      "categoryId": "category.fresh-veg",
+      "id": "prod.eggplant",
+      "names": {
+        "en": "Eggplant",
+        "pl": "Bakłażan"
+      },
+      "unitId": "unit.szt"
+    },
+    {
+      "aliases": ["product.eggs"],
+      "categoryId": "category.dairy-eggs",
+      "id": "prod.eggs",
+      "names": {
+        "en": "Eggs",
+        "pl": "Jajka"
+      },
+      "unitId": "unit.szt"
+    },
+    {
+      "aliases": ["product.french_mustard"],
+      "categoryId": "category.opened-preserves",
+      "id": "prod.french-mustard",
+      "names": {
+        "en": "French mustard",
+        "pl": "Musztarda francuska"
+      },
+      "unitId": "unit.szt"
+    },
+    {
+      "aliases": ["product.fries"],
+      "categoryId": "category.fresh-veg",
+      "id": "prod.fries",
+      "names": {
+        "en": "Fries",
+        "pl": "Frytki"
+      },
+      "unitId": "unit.szt"
+    },
+    {
+      "aliases": ["product.garlic"],
+      "categoryId": "category.dry-veg",
+      "id": "prod.garlic",
+      "names": {
+        "en": "Garlic",
+        "pl": "Czosnek"
+      },
+      "unitId": "unit.szt"
+    },
+    {
+      "aliases": ["product.garlic_in_oil"],
+      "categoryId": "category.opened-preserves",
+      "id": "prod.garlic-in-oil",
+      "names": {
+        "en": "Garlic in oil",
+        "pl": "Czosnek w oleju"
+      },
+      "unitId": "unit.szt"
+    },
+    {
+      "aliases": ["product.garlic_powder"],
+      "categoryId": "category.spices",
+      "id": "prod.garlic-powder",
+      "names": {
+        "en": "Garlic powder",
+        "pl": "Czosnek w proszku"
+      },
+      "unitId": "unit.lvl"
+    },
+    {
+      "aliases": ["product.gravy"],
+      "categoryId": "category.frozen-meals",
+      "id": "prod.gravy",
+      "names": {
+        "en": "Gravy",
+        "pl": "Sos pieczeniowy"
+      },
+      "unitId": "unit.szt"
+    },
+    {
+      "aliases": ["product.green_beans"],
+      "categoryId": "category.fresh-veg",
+      "id": "prod.green-beans",
+      "names": {
+        "en": "Green beans",
+        "pl": "Fasolka szparagowa"
+      },
+      "unitId": "unit.g"
+    },
+    {
+      "aliases": ["product.green_peas"],
+      "categoryId": "category.opened-preserves",
+      "id": "prod.green-peas",
+      "names": {
+        "en": "Green peas",
+        "pl": "Zielony groszek"
+      },
+      "unitId": "unit.szt"
+    },
+    {
+      "aliases": ["product.herbes_de_provence_duo"],
+      "categoryId": "category.spices",
+      "id": "prod.herbes-de-provence-duo",
+      "names": {
+        "en": "Herbes de Provence",
+        "pl": "Zioła prowansalskie"
+      },
+      "unitId": "unit.lvl"
+    },
+    {
+      "aliases": ["product.hot_paprika"],
+      "categoryId": "category.spices",
+      "id": "prod.hot-paprika",
+      "names": {
+        "en": "Hot paprika",
+        "pl": "Papryka ostra"
+      },
+      "unitId": "unit.lvl"
+    },
+    {
+      "aliases": ["product.large_green_olives"],
+      "categoryId": "category.opened-preserves",
+      "id": "prod.large-green-olives",
+      "names": {
+        "en": "Large green olives",
+        "pl": "Zielone oliwki duże"
+      },
+      "unitId": "unit.g"
+    },
+    {
+      "aliases": ["product.lemon"],
+      "categoryId": "category.dry-veg",
+      "id": "prod.lemon",
+      "names": {
+        "en": "Lemon",
+        "pl": "Cytryna"
+      },
+      "unitId": "unit.szt"
+    },
+    {
+      "aliases": ["product.lemon_pepper"],
+      "categoryId": "category.spices",
+      "id": "prod.lemon-pepper",
+      "names": {
+        "en": "Lemon pepper",
+        "pl": "Pieprz cytrynowy"
+      },
+      "unitId": "unit.lvl"
+    },
+    {
+      "aliases": ["product.lentils_green"],
+      "categoryId": "category.dried-legumes",
+      "id": "prod.lentils-green",
+      "names": {
+        "en": "Green lentils",
+        "pl": "Soczewica zielona"
+      },
+      "unitId": "unit.opak-350g"
+    },
+    {
+      "aliases": ["product.lentils_red"],
+      "categoryId": "category.dried-legumes",
+      "id": "prod.lentils-red",
+      "names": {
+        "en": "Red lentils",
+        "pl": "Soczewica czerwona"
+      },
+      "unitId": "unit.opak-350g"
+    },
+    {
+      "aliases": ["product.lime"],
+      "categoryId": "category.dry-veg",
+      "id": "prod.lime",
+      "names": {
+        "en": "Lime",
+        "pl": "Limonka"
+      },
+      "unitId": "unit.szt"
+    },
+    {
+      "aliases": ["product.lovage"],
+      "categoryId": "category.spices",
+      "id": "prod.lovage",
+      "names": {
+        "en": "Lovage",
+        "pl": "Lubczyk"
+      },
+      "unitId": "unit.lvl"
+    },
+    {
+      "aliases": ["product.natural_tofu"],
+      "categoryId": "category.dairy-eggs",
+      "id": "prod.natural-tofu",
+      "names": {
+        "en": "Natural tofu",
+        "pl": "Tofu naturalne"
+      },
+      "unitId": "unit.szt"
+    },
+    {
+      "aliases": ["product.new_potatoes"],
+      "categoryId": "category.fresh-veg",
+      "id": "prod.new-potatoes",
+      "names": {
+        "en": "New potatoes",
+        "pl": "Ziemniaki młode"
+      },
+      "unitId": "unit.g"
+    },
+    {
+      "aliases": ["product.nutmeg"],
+      "categoryId": "category.spices",
+      "id": "prod.nutmeg",
+      "names": {
+        "en": "Nutmeg",
+        "pl": "Gałka muszkatołowa"
+      },
+      "unitId": "unit.lvl"
+    },
+    {
+      "aliases": ["product.oregano"],
+      "categoryId": "category.spices",
+      "id": "prod.oregano",
+      "names": {
+        "en": "Oregano",
+        "pl": "Oregano"
+      },
+      "unitId": "unit.lvl"
+    },
+    {
+      "aliases": ["product.oyster_mushrooms"],
+      "categoryId": "category.mushrooms",
+      "id": "prod.oyster-mushrooms",
+      "names": {
+        "en": "Oyster mushrooms",
+        "pl": "Boczniaki"
+      },
+      "unitId": "unit.g"
+    },
+    {
+      "aliases": ["product.parsley"],
+      "categoryId": "category.fresh-veg",
+      "id": "prod.parsley",
+      "names": {
+        "en": "Parsley",
+        "pl": "Natka pietruszki"
+      },
+      "unitId": "unit.szt"
+    },
+    {
+      "aliases": ["product.peanut_butter"],
+      "categoryId": "category.spreads",
+      "id": "prod.peanut-butter",
+      "names": {
+        "en": "Peanut butter",
+        "pl": "Masło orzechowe"
+      },
+      "unitId": "unit.szt"
+    },
+    {
+      "aliases": ["product.penne_pasta"],
+      "categoryId": "category.pasta",
+      "id": "prod.penne-pasta",
+      "names": {
+        "en": "Penne pasta",
+        "pl": "Makaron penne"
+      },
+      "unitId": "unit.g"
+    },
+    {
+      "aliases": ["product.pickled_pearl_onions"],
+      "categoryId": "category.opened-preserves",
+      "id": "prod.pickled-pearl-onions",
+      "names": {
+        "en": "Pickled pearl onions",
+        "pl": "Marynowana cebula perłowa"
+      },
+      "unitId": "unit.szt"
+    },
+    {
+      "aliases": ["product.pink_tomatoes"],
+      "categoryId": "category.fresh-veg",
+      "id": "prod.pink-tomatoes",
+      "names": {
+        "en": "Pink tomatoes",
+        "pl": "Pomidory malinowe"
+      },
+      "unitId": "unit.szt"
+    },
+    {
+      "aliases": ["product.pistachio_cream"],
+      "categoryId": "category.spreads",
+      "id": "prod.pistachio-cream",
+      "names": {
+        "en": "Pistachio cream",
+        "pl": "Krem pistacjowy"
+      },
+      "unitId": "unit.szt"
+    },
+    {
+      "aliases": ["product.plant_fat"],
+      "categoryId": "category.oils",
+      "id": "prod.plant-fat",
+      "names": {
+        "en": "Plant fat",
+        "pl": "Tłuszcz roślinny"
+      },
+      "unitId": "unit.szt"
+    },
+    {
+      "aliases": ["product.radish"],
+      "categoryId": "category.fresh-veg",
+      "id": "prod.radish",
+      "names": {
+        "en": "Radish",
+        "pl": "Rzodkiewka"
+      },
+      "unitId": "unit.szt"
+    },
+    {
+      "aliases": ["product.red_beans"],
+      "categoryId": "category.opened-preserves",
+      "id": "prod.red-beans",
+      "names": {
+        "en": "Red beans",
+        "pl": "Fasola czerwona"
+      },
+      "unitId": "unit.szt"
+    },
+    {
+      "aliases": ["product.red_onion"],
+      "categoryId": "category.dry-veg",
+      "id": "prod.red-onion",
+      "names": {
+        "en": "Red onion",
+        "pl": "Czerwona cebula"
+      },
+      "unitId": "unit.g"
+    },
+    {
+      "aliases": ["product.rice_arborio"],
+      "categoryId": "category.grains",
+      "id": "prod.rice-arborio",
+      "names": {
+        "en": "Arborio rice",
+        "pl": "Ryż arborio"
+      },
+      "unitId": "unit.g"
+    },
+    {
+      "aliases": ["product.rice_basmati"],
+      "categoryId": "category.grains",
+      "id": "prod.rice-basmati",
+      "names": {
+        "en": "Basmati rice",
+        "pl": "Ryż basmati"
+      },
+      "unitId": "unit.szt"
+    },
+    {
+      "aliases": ["product.rice_jasmine"],
+      "categoryId": "category.grains",
+      "id": "prod.rice-jasmine",
+      "names": {
+        "en": "Jasmine rice",
+        "pl": "Ryż jaśminowy"
+      },
+      "unitId": "unit.szt"
+    },
+    {
+      "aliases": ["product.rosemary"],
+      "categoryId": "category.spices",
+      "id": "prod.rosemary",
+      "names": {
+        "en": "Rosemary",
+        "pl": "Rozmaryn"
+      },
+      "unitId": "unit.lvl"
+    },
+    {
+      "aliases": ["product.sauce_alla_norma"],
+      "categoryId": "category.ready-sauces",
+      "id": "prod.sauce-alla-norma",
+      "names": {
+        "en": "Alla Norma sauce",
+        "pl": "Sos alla norma"
+      },
+      "unitId": "unit.g"
+    },
+    {
+      "aliases": ["product.sauce_alla_puttanesca"],
+      "categoryId": "category.ready-sauces",
+      "id": "prod.sauce-alla-puttanesca",
+      "names": {
+        "en": "Puttanesca sauce",
+        "pl": "Sos alla puttanesca"
+      },
+      "unitId": "unit.g"
+    },
+    {
+      "aliases": ["product.sauce_basilico"],
+      "categoryId": "category.ready-sauces",
+      "id": "prod.sauce-basilico",
+      "names": {
+        "en": "Basilico sauce",
+        "pl": "Sos basilico"
+      },
+      "unitId": "unit.g"
+    },
+    {
+      "aliases": ["product.sauce_bearnaise"],
+      "categoryId": "category.ready-sauces",
+      "id": "prod.sauce-bearnaise",
+      "names": {
+        "en": "Béarnaise sauce",
+        "pl": "Sos berneński"
+      },
+      "unitId": "unit.g"
+    },
+    {
+      "aliases": ["product.sauce_cacio_e_pepe"],
+      "categoryId": "category.ready-sauces",
+      "id": "prod.sauce-cacio-e-pepe",
+      "names": {
+        "en": "Cacio e pepe sauce",
+        "pl": "Sos cacio e pepe"
+      },
+      "unitId": "unit.g"
+    },
+    {
+      "aliases": ["product.sauce_napoletana"],
+      "categoryId": "category.ready-sauces",
+      "id": "prod.sauce-napoletana",
+      "names": {
+        "en": "Napoletana sauce",
+        "pl": "Sos napoletana"
+      },
+      "unitId": "unit.g"
+    },
+    {
+      "aliases": ["product.sciatelli_al_limone_pasta"],
+      "categoryId": "category.pasta",
+      "id": "prod.sciatelli-al-limone-pasta",
+      "names": {
+        "en": "Sciatelli al limone pasta",
+        "pl": "Makaron sciatelli al limone"
+      },
+      "unitId": "unit.g"
+    },
+    {
+      "aliases": ["product.sesame_oil"],
+      "categoryId": "category.oils",
+      "id": "prod.sesame-oil",
+      "names": {
+        "en": "Sesame oil",
+        "pl": "Olej sezamowy"
+      },
+      "unitId": "unit.butelka"
+    },
+    {
+      "aliases": ["product.smoked_paprika"],
+      "categoryId": "category.spices",
+      "id": "prod.smoked-paprika",
+      "names": {
+        "en": "Smoked paprika",
+        "pl": "Papryka wędzona"
+      },
+      "unitId": "unit.lvl"
+    },
+    {
+      "aliases": ["product.soup_veg"],
+      "categoryId": "category.fresh-veg",
+      "id": "prod.soup-veg",
+      "names": {
+        "en": "Soup vegetables",
+        "pl": "Włoszczyzna"
+      },
+      "unitId": "unit.szt"
+    },
+    {
+      "aliases": ["product.sour_cream_18"],
+      "categoryId": "category.dairy-eggs",
+      "id": "prod.sour-cream-18",
+      "names": {
+        "en": "Sour cream 18%",
+        "pl": "Śmietana 18%"
+      },
+      "unitId": "unit.250g"
+    },
+    {
+      "aliases": ["product.spinach"],
+      "categoryId": "category.frozen-meals",
+      "id": "prod.spinach",
+      "names": {
+        "en": "Spinach",
+        "pl": "Szpinak"
+      },
+      "unitId": "unit.szt"
+    },
+    {
+      "aliases": ["product.spring_onion"],
+      "categoryId": "category.dry-veg",
+      "id": "prod.spring-onion",
+      "names": {
+        "en": "Spring onion",
+        "pl": "Cebula dymka"
+      },
+      "unitId": "unit.szt"
+    },
+    {
+      "aliases": ["product.stir_fry_vegetables"],
+      "categoryId": "category.frozen-meals",
+      "id": "prod.stir-fry-vegetables",
+      "names": {
+        "en": "Stir-fry vegetables",
+        "pl": "Warzywa na patelnię"
+      },
+      "unitId": "unit.szt"
+    },
+    {
+      "aliases": ["product.sun_dried_tomatoes"],
+      "categoryId": "category.oils",
+      "id": "prod.sun-dried-tomatoes",
+      "names": {
+        "en": "Sun-dried tomatoes in oil",
+        "pl": "Suszone pomidory w oleju"
+      },
+      "unitId": "unit.x270g"
+    },
+    {
+      "aliases": ["product.thai_spice_mix"],
+      "categoryId": "category.spreads",
+      "id": "prod.thai-spice-mix",
+      "names": {
+        "en": "Thai spice mix",
+        "pl": "Mieszanka przypraw tajska"
+      },
+      "unitId": "unit.g"
+    },
+    {
+      "aliases": ["product.thyme"],
+      "categoryId": "category.spices",
+      "id": "prod.thyme",
+      "names": {
+        "en": "Thyme",
+        "pl": "Tymianek"
+      },
+      "unitId": "unit.lvl"
+    },
+    {
+      "aliases": ["product.toast_bread"],
+      "categoryId": "category.bread",
+      "id": "prod.toast-bread",
+      "names": {
+        "en": "Toast bread",
+        "pl": "Pieczywo tostowe"
+      },
+      "unitId": "unit.szt"
+    },
+    {
+      "aliases": ["product.tomato_garlic_basil_mix"],
+      "categoryId": "category.spices",
+      "id": "prod.tomato-garlic-basil-mix",
+      "names": {
+        "en": "Mix: tomato, garlic, basil",
+        "pl": "Mieszanka: pomidor, czosnek, bazylia"
+      },
+      "unitId": "unit.lvl"
+    },
+    {
+      "aliases": ["product.tomato_puree"],
+      "categoryId": "category.fresh-veg",
+      "id": "prod.tomato-puree",
+      "names": {
+        "en": "Tomato purée",
+        "pl": "Przecier pomidorowy"
+      },
+      "unitId": "unit.g"
+    },
+    {
+      "aliases": ["product.turmeric"],
+      "categoryId": "category.spices",
+      "id": "prod.turmeric",
+      "names": {
+        "en": "Turmeric",
+        "pl": "Kurkuma"
+      },
+      "unitId": "unit.lvl"
+    },
+    {
+      "aliases": ["product.zucchini"],
+      "categoryId": "category.fresh-veg",
+      "id": "prod.zucchini",
+      "names": {
+        "en": "Zucchini",
+        "pl": "Cukinia"
+      },
+      "unitId": "unit.szt"
+    }
+  ]
+}

--- a/app/static/script.js
+++ b/app/static/script.js
@@ -6,7 +6,6 @@ import {
   loadDomain,
   loadFavorites,
   state,
-  normalizeProduct,
   applyTranslations,
   isSpice,
   debounce,
@@ -51,9 +50,7 @@ APP.searches = APP.searches || {
 async function loadProducts() {
   trace("loadProducts:enter");
   try {
-    const data = await fetchJson("/api/products");
-    APP.state.products = Array.isArray(data) ? data.map(normalizeProduct) : [];
-    ProductTable.renderProducts();
+    await ProductTable.loadProducts();
     Shopping.renderSuggestions();
     checkLowStockToast(
       APP.state.products,
@@ -68,8 +65,6 @@ async function loadProducts() {
     trace("loadProducts:ok");
   } catch (e) {
     console.error(e);
-    APP.state.products = [];
-    ProductTable.renderProducts();
     showTopBanner(t("load_products_failed"), {
       actionLabel: t("retry"),
       onAction: loadProducts,


### PR DESCRIPTION
## Summary
- fetch product data from `/products.json` with console logging and empty-data handling
- show "Brak danych / No data available" row when product data fails to load
- use new loader in script and add `products.json` to static assets

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689e2a20b718832ab66453d53af90f81