### PR TITLE
Return plain product array from /api/products

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -394,6 +394,12 @@ def products():
     try:
         with open(PRODUCTS_PATH, "r", encoding="utf-8") as f:
             data = json.load(f)
+        products = data["products"] if isinstance(data, dict) else None
+        if not isinstance(products, list):
+            raise KeyError("products list missing or invalid")
+    except (KeyError, TypeError, ValueError) as exc:
+        trace_id = _log_error(exc, context)
+        return error_response("Invalid product data format", 500, trace_id)
     except Exception as exc:
         trace_id = _log_error(exc, context)
         return error_response("Unable to load product data", 500, trace_id)
@@ -420,7 +426,7 @@ def products():
         except (TypeError, ValueError, OverflowError):
             pass
 
-    resp = jsonify(data)
+    resp = jsonify(products)
     resp.headers["ETag"] = etag
     resp.headers["Last-Modified"] = last_modified
     return resp

--- a/tests/test_http_caching.py
+++ b/tests/test_http_caching.py
@@ -20,7 +20,7 @@ def test_products_etag_and_conditional_headers():
     assert resp.status_code == 200
     etag = resp.headers.get("ETag")
     last_mod = resp.headers.get("Last-Modified")
-    first = resp.get_json()["products"]
+    first = resp.get_json()
 
     resp2 = client.get("/api/products", headers={"If-None-Match": etag})
     assert resp2.status_code == 304
@@ -37,7 +37,7 @@ def test_products_etag_and_conditional_headers():
         resp4 = client.get("/api/products")
         assert resp4.status_code == 200
         assert resp4.headers.get("ETag") != etag
-        data4 = resp4.get_json()["products"]
+        data4 = resp4.get_json()
         assert data4 != first
     finally:
         with open(PRODUCTS_PATH, "w", encoding="utf-8") as fh:

--- a/tests/test_minimal_valid.py
+++ b/tests/test_minimal_valid.py
@@ -59,8 +59,7 @@ def test_products_endpoint_returns_data():
     resp = client.get("/api/products")
     assert resp.status_code == 200
     data = resp.get_json()
-    assert "products" in data and isinstance(data["products"], list)
-    assert "categories" in data and isinstance(data["categories"], list)
+    assert isinstance(data, list)
 
 
 def test_recipes_pagination_and_sorting():

--- a/tests/test_products_adapter.py
+++ b/tests/test_products_adapter.py
@@ -13,9 +13,7 @@ def test_products_endpoint_returns_raw_data():
     resp = client.get('/api/products')
     assert resp.status_code == 200
     data = resp.get_json()
-    assert isinstance(data, dict)
-    products = data.get('products', [])
-    assert isinstance(products, list)
-    assert len(products) > 0
-    first = products[0]
+    assert isinstance(data, list)
+    assert len(data) > 0
+    first = data[0]
     assert 'id' in first and 'names' in first


### PR DESCRIPTION
## Summary
- return products array from /api/products instead of nested object
- validate presence of products list and adjust tests

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689f3afc78a8832a8a46bdc274fb81f2