### PR TITLE
Fix uninitialized variable in add-form validation

### DIFF
--- a/app/static/script.js
+++ b/app/static/script.js
@@ -271,6 +271,12 @@ function initAddForm() {
   }
   submitBtn.classList.add("add-submit");
 
+  // Elements required for form validation must be declared before any
+  // validation logic executes. `syncSpiceUI` invokes `validate`, so the
+  // `required` array needs to exist before `syncSpiceUI` runs to avoid
+  // referencing it prior to initialization.
+  const required = [nameInput, qtyInput, unitSel, catSelect, storSelect];
+
   function syncSpiceUI() {
     const isSp = catSelect.value === "spices";
     qtyInput.classList.toggle("hidden", isSp);
@@ -285,8 +291,6 @@ function initAddForm() {
   }
   catSelect.addEventListener("change", syncSpiceUI);
   syncSpiceUI();
-
-  const required = [nameInput, qtyInput, unitSel, catSelect, storSelect];
   function validate() {
     const msg = state.currentLang === "pl" ? "Wymagane" : "Required";
     const isSp = catSelect.value === "spices";


### PR DESCRIPTION
## Summary
- prevent ReferenceError by declaring `required` array before `syncSpiceUI` runs

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689f49d8d1ec832aa96322cb19e1161f