### PR TITLE
Fix sortable product table

### DIFF
--- a/app/static/js/components/product-table.js
+++ b/app/static/js/components/product-table.js
@@ -67,12 +67,12 @@ function updateBulkActions() {
 
 function updateSortIcons() {
   document
-    .querySelectorAll('#product-table thead th[data-sort] i')
+    .querySelectorAll('#product-table thead th[data-sort-by] i')
     .forEach((icon) => {
       icon.className = 'fa-solid fa-sort opacity-50';
     });
   const active = document.querySelector(
-    `#product-table thead th[data-sort="${state.productSortField}"] i`,
+    `#product-table thead th[data-sort-by="${state.productSortField}"] i`,
   );
   if (active) {
     active.className =
@@ -254,18 +254,20 @@ export function bindProductEvents() {
     if (e.target.closest('.qty-dec')) adjustRow(e.target.closest('tr'), -1);
   });
   document
-    .querySelectorAll('#product-table thead th[data-sort]')
+    .querySelectorAll('#product-table thead th[data-sort-by]')
     .forEach((th) => {
-      th.addEventListener('click', () => {
-        const field = th.dataset.sort;
-        if (state.productSortField === field) {
-          state.productSortDir = state.productSortDir === 'asc' ? 'desc' : 'asc';
+      th.addEventListener('click', async () => {
+        const field = th.dataset.sortBy;
+        if (productPager.sort_by === field) {
+          productPager.order = productPager.order === 'asc' ? 'desc' : 'asc';
         } else {
-          state.productSortField = field;
-          state.productSortDir = 'asc';
+          productPager.sort_by = field;
+          productPager.order = 'asc';
         }
-        renderProducts();
+        state.productSortField = productPager.sort_by;
+        state.productSortDir = productPager.order;
         updateSortIcons();
+        await loadProducts();
       });
     });
   updateSortIcons();

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -358,21 +358,21 @@
             <thead>
               <tr>
                 <th id="select-header" style="display: none"></th>
-                <th data-sort="name" class="sortable">
+                <th data-sort-by="name" class="sortable">
                   <span data-i18n="table_header_name">Nazwa</span>
                   <i class="fa-solid fa-sort opacity-50"></i>
                 </th>
                 <th data-i18n="table_header_quantity">Ilość</th>
                 <th data-i18n="table_header_unit">Jednostka</th>
-                <th class="hidden md:table-cell sortable" data-sort="category">
+                <th class="hidden md:table-cell sortable" data-sort-by="category">
                   <span data-i18n="table_header_category">Kategoria</span>
                   <i class="fa-solid fa-sort opacity-50"></i>
                 </th>
-                <th class="hidden md:table-cell sortable" data-sort="storage">
+                <th class="hidden md:table-cell sortable" data-sort-by="storage">
                   <span data-i18n="table_header_storage">Miejsce</span>
                   <i class="fa-solid fa-sort opacity-50"></i>
                 </th>
-                <th class="text-center hidden md:table-cell sortable" data-sort="status">
+                <th class="text-center hidden md:table-cell sortable" data-sort-by="status">
                   <span class="tooltip" data-i18n-tip="stock_legend"
                     ><i class="fa-solid fa-circle-info"></i
                   ></span>


### PR DESCRIPTION
## Summary
- Replace data-sort with data-sort-by in product table headers
- Reload products from the server when clicking a header and toggle ascending/descending icons

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689f568eac1c832aa61c6347d3af9381