### PR TITLE
Refactor backend for nested product structure

### DIFF
--- a/app/utils/product_io.py
+++ b/app/utils/product_io.py
@@ -1,0 +1,64 @@
+import os
+import json
+from collections import defaultdict
+from typing import Any, Dict, List
+
+from . import load_json, save_json
+
+# Path to the product schema relative to this module
+_SCHEMA_PATH = os.path.join(os.path.dirname(__file__), "..", "schemas", "product.schema.json")
+
+
+def load_products_nested(path: str) -> List[Dict[str, Any]]:
+    """Load products from ``path`` in nested form and flatten them.
+
+    The JSON file is expected to be structured as ``storage -> category ->
+    [products]``. Each returned product dict contains the original fields
+    plus ``storage`` and ``category`` keys preserved from the nesting.
+    Invalid or missing files return an empty list.
+    """
+    data = load_json(path, {}, _SCHEMA_PATH)
+    if not isinstance(data, dict):
+        return []
+
+    flat: List[Dict[str, Any]] = []
+    for storage, categories in data.items():
+        if not isinstance(categories, dict):
+            continue
+        for category, items in categories.items():
+            if not isinstance(items, list):
+                continue
+            for item in items:
+                if not isinstance(item, dict):
+                    continue
+                obj = dict(item)
+                obj["storage"] = storage
+                obj["category"] = category
+                flat.append(obj)
+    return flat
+
+
+def save_products_nested(path: str, products: List[Dict[str, Any]]) -> None:
+    """Persist ``products`` to ``path`` using the nested structure.
+
+    ``products`` is a flat list where every item contains ``storage`` and
+    ``category`` keys. The function groups items by these keys and writes the
+    nested representation to disk validating against the product schema.
+    """
+    nested: Dict[str, Dict[str, List[Dict[str, Any]]]] = defaultdict(lambda: defaultdict(list))
+    for prod in products:
+        storage = prod.get("storage")
+        category = prod.get("category")
+        if not storage or not category:
+            continue
+        item = dict(prod)
+        item.pop("storage", None)
+        item.pop("category", None)
+        nested[storage][category].append(item)
+
+    # Convert defaultdicts to regular dicts for serialization
+    data: Dict[str, Dict[str, List[Dict[str, Any]]]] = {
+        storage: {cat: items for cat, items in categories.items()}
+        for storage, categories in nested.items()
+    }
+    save_json(path, data, _SCHEMA_PATH)

--- a/app/validators.py
+++ b/app/validators.py
@@ -1,0 +1,28 @@
+import os
+from typing import Dict, List
+
+from .utils import _validate
+
+# Schema path for nested products structure
+PRODUCTS_SCHEMA = os.path.join(os.path.dirname(__file__), "schemas", "product.schema.json")
+
+
+def validate_products(products: List[Dict[str, Any]]) -> List[str]:
+    """Validate flattened products against the nested schema.
+
+    The function groups the flat list by ``storage`` and ``category`` and then
+    validates the nested representation using the JSON schema. It returns a
+    list of validation error messages. An empty list indicates the dataset is
+    valid.
+    """
+    grouped: Dict[str, Dict[str, List[Dict[str, Any]]]] = {}
+    for prod in products:
+        storage = prod.get("storage")
+        category = prod.get("category")
+        if not storage or not category:
+            continue
+        grouped.setdefault(storage, {}).setdefault(category, []).append(
+            {k: v for k, v in prod.items() if k not in ("storage", "category")}
+        )
+    _, errors = _validate(grouped, PRODUCTS_SCHEMA)
+    return errors

--- a/tests/test_products.py
+++ b/tests/test_products.py
@@ -1,0 +1,70 @@
+import os
+import sys
+import json
+from pathlib import Path
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from app.utils.product_io import load_products_nested, save_products_nested
+
+
+def _sample_data():
+    return {
+        "storage.fridge": {
+            "category.dairy-eggs": [
+                {
+                    "name": "milk",
+                    "quantity": 1,
+                    "unit": "l",
+                    "threshold": 1,
+                    "main": True,
+                    "level": None,
+                    "is_spice": False,
+                    "tags": [],
+                }
+            ]
+        },
+        "storage.pantry": {
+            "category.spices": [
+                {
+                    "name": "pepper",
+                    "quantity": 2,
+                    "unit": "g",
+                    "threshold": 1,
+                    "main": True,
+                    "level": "medium",
+                    "is_spice": True,
+                    "tags": [],
+                }
+            ]
+        },
+    }
+
+
+def test_roundtrip_conversion(tmp_path: Path):
+    path = tmp_path / "products.json"
+    data = _sample_data()
+    path.write_text(json.dumps(data, indent=2))
+
+    flat = load_products_nested(str(path))
+    assert any(
+        p["name"] == "milk" and p["storage"] == "storage.fridge" for p in flat
+    )
+    assert any(p["name"] == "pepper" and p["category"] == "category.spices" for p in flat)
+
+    save_products_nested(str(path), flat)
+    reloaded = json.loads(path.read_text())
+    assert reloaded == data
+
+
+def test_modify_and_save(tmp_path: Path):
+    path = tmp_path / "products.json"
+    path.write_text(json.dumps(_sample_data(), indent=2))
+
+    products = load_products_nested(str(path))
+    pepper = next(p for p in products if p["name"] == "pepper")
+    pepper["quantity"] = 5
+    save_products_nested(str(path), products)
+
+    products2 = load_products_nested(str(path))
+    assert any(p["name"] == "pepper" and p["quantity"] == 5 for p in products2)


### PR DESCRIPTION
## Summary
- Add utilities to load and save products grouped by storage and category
- Update routes and search to use flattened products from nested JSON
- Provide validators and tests for roundtrip persistence

## Testing
- `pytest tests/test_products.py -q`

------
https://chatgpt.com/codex/tasks/task_e_689f71a58640832a8a34b89d9ed2e99b