### PR TITLE
Improve mobile spacing for product lists

### DIFF
--- a/app/static/js/components/shopping-list.js
+++ b/app/static/js/components/shopping-list.js
@@ -65,7 +65,7 @@ function sortShoppingList() {
 function renderShoppingItem(item, idx) {
   const row = document.createElement("div");
   row.className =
-    "shopping-item gap-2 h-11 hover:bg-base-200 transition-colors";
+    "shopping-item gap-x-4 p-2 hover:bg-base-200 transition-colors";
   row.dataset.name = item.name;
   row.tabIndex = 0;
   if (item.inCart) row.classList.add("in-cart");
@@ -80,9 +80,9 @@ function renderShoppingItem(item, idx) {
   }
 
   const nameWrap = document.createElement("div");
-  nameWrap.className = "flex items-center gap-1 overflow-hidden";
+  nameWrap.className = "flex items-center gap-1 break-words";
   const nameEl = document.createElement("span");
-  nameEl.className = "truncate";
+  nameEl.className = "break-words";
   const lbl = t(item.name, "products");
   nameEl.textContent = lbl;
   nameEl.title = lbl;
@@ -286,16 +286,16 @@ export function renderSuggestions() {
   suggestions.forEach((p) => {
     let qty = p.threshold != null ? p.threshold : 1;
     const row = document.createElement("div");
-    row.className =
-      "suggestion-item gap-2 h-11 hover:bg-base-200 transition-colors";
+      row.className =
+        "suggestion-item gap-x-4 p-2 hover:bg-base-200 transition-colors";
     const level = getStockState(p);
     if (level === "low") row.classList.add("product-low");
     if (level === "zero") row.classList.add("product-missing");
 
     const nameWrap = document.createElement("div");
-    nameWrap.className = "flex items-center gap-1 overflow-hidden";
+      nameWrap.className = "flex items-center gap-1 break-words";
     const nameEl = document.createElement("span");
-    nameEl.className = "truncate";
+      nameEl.className = "break-words";
     const lbl = t(p.id, "products");
     nameEl.textContent = lbl;
     nameEl.title = lbl;

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -1041,7 +1041,7 @@
           </div>
           <div
             id="shopping-list"
-            class="border border-base-300 rounded-lg"
+            class="border border-base-300 rounded-lg p-2 space-y-2"
           ></div>
         </div>
         <hr class="border-t border-base-300 mt-6 mb-4" />


### PR DESCRIPTION
## Summary
- add padding and vertical spacing to shopping list container
- use gap-x-4, p-2, and break-words on shopping and suggestion items for better mobile wrapping

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a21ead0190832a98a13e504e7bd57d