### PR TITLE
Align mobile product rows using Tailwind grid

### DIFF
--- a/app/static/js/components/product-table.js
+++ b/app/static/js/components/product-table.js
@@ -391,11 +391,11 @@ function adjustRow(tr, delta) {
 
 function buildQtyCell(p, tr) {
   const td = document.createElement("td");
-  td.className = "qty-cell";
+  td.className = "qty-cell col-span-2 flex items-center";
   td.style.minWidth = "10rem";
   if (isSpice(p)) {
     const wrap = document.createElement("div");
-    wrap.className = "flex gap-2";
+    wrap.className = "flex items-center gap-2";
     ["none", "low", "medium", "high"].forEach((l) => {
       const label = document.createElement("label");
       label.className = "cursor-pointer flex items-center gap-1";
@@ -419,7 +419,7 @@ function buildQtyCell(p, tr) {
     return td;
   }
   const wrap = document.createElement("div");
-  wrap.className = "qty-wrap";
+  wrap.className = "flex items-center gap-2";
   wrap.style.minWidth = "10rem";
   const dec = document.createElement("button");
   dec.type = "button";
@@ -578,9 +578,10 @@ function createFlatRow(p, idx, editable) {
   tr.dataset.index = idx;
   tr.dataset.productId = p.id != null ? p.id : idx;
   if (editable) {
+    tr.className = "grid grid-cols-12 items-center gap-2";
     // checkbox
     const cbTd = document.createElement("td");
-    cbTd.className = "checkbox-cell";
+    cbTd.className = "checkbox-cell col-span-1 flex items-center justify-center";
     const cb = document.createElement("input");
     cb.type = "checkbox";
     cb.className = "checkbox checkbox-sm product-select";
@@ -590,7 +591,7 @@ function createFlatRow(p, idx, editable) {
     tr.appendChild(cbTd);
     // name
     const nameTd = document.createElement("td");
-    nameTd.className = "name-cell";
+    nameTd.className = "name-cell col-span-3 flex items-center truncate";
     nameTd.textContent = t(p.id, "products");
     if (!getProduct(p.id)) nameTd.classList.add("opacity-60");
     tr.appendChild(nameTd);
@@ -599,7 +600,7 @@ function createFlatRow(p, idx, editable) {
     tr.appendChild(qtyTd);
     // unit select
     const unitTd = document.createElement("td");
-    unitTd.className = "unit-cell";
+    unitTd.className = "unit-cell col-span-1";
     if (isSpice(p)) {
       unitTd.textContent = "";
     } else {
@@ -617,7 +618,7 @@ function createFlatRow(p, idx, editable) {
     tr.appendChild(unitTd);
     // category select
     const catTd = document.createElement("td");
-    catTd.className = "category-cell";
+    catTd.className = "category-cell col-span-2";
     const catSel = document.createElement("select");
     catSel.className = "select select-bordered w-full";
     Object.keys(state.domain.categories).forEach((c) => {
@@ -631,7 +632,7 @@ function createFlatRow(p, idx, editable) {
     tr.appendChild(catTd);
     // storage select
     const storTd = document.createElement("td");
-    storTd.className = "storage-cell";
+    storTd.className = "storage-cell col-span-2";
     const storSel = document.createElement("select");
     storSel.className = "select select-bordered w-full";
     Object.keys(STORAGE_KEYS).forEach((s) => {
@@ -645,7 +646,7 @@ function createFlatRow(p, idx, editable) {
     tr.appendChild(storTd);
     // status
     const statusTd = document.createElement("td");
-    statusTd.className = "status-cell text-center";
+    statusTd.className = "status-cell col-span-1 text-center flex items-center justify-center";
     const status = getStatusIcon(p);
     if (status) {
       statusTd.innerHTML = status.html;

--- a/app/static/styles.css
+++ b/app/static/styles.css
@@ -90,20 +90,11 @@ input::placeholder {
   min-height: 2.5rem;
 }
 
-#product-table.edit-mode thead tr,
-#product-table.edit-mode tbody tr {
+#product-table.edit-mode thead tr {
   display: grid;
   grid-template-columns: repeat(12, minmax(0, 1fr));
   align-items: center;
 }
-
-#product-table.edit-mode .checkbox-cell { grid-column: span 1 / span 1; }
-#product-table.edit-mode .name-cell { grid-column: span 3 / span 3; }
-#product-table.edit-mode .qty-cell { grid-column: span 2 / span 2; }
-#product-table.edit-mode .unit-cell { grid-column: span 1 / span 1; }
-#product-table.edit-mode .category-cell { grid-column: span 2 / span 2; }
-#product-table.edit-mode .storage-cell { grid-column: span 2 / span 2; }
-#product-table.edit-mode .status-cell { grid-column: span 1 / span 1; }
 
 
 #product-table.edit-mode select,
@@ -111,13 +102,6 @@ input::placeholder {
   height: 2.5rem;
   border-radius: 0.375rem;
 }
-
-.qty-wrap {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.5rem;
-}
-
 .qty-input {
   width: 7rem;
   text-align: center;

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -357,22 +357,22 @@
             </colgroup>
             <thead>
               <tr>
-                <th id="select-header" style="display: none"></th>
-                <th data-sort-by="name" class="sortable">
+                <th id="select-header" style="display: none" class="col-span-1"></th>
+                <th data-sort-by="name" class="sortable col-span-3">
                   <span data-i18n="table_header_name">Nazwa</span>
                   <i class="fa-solid fa-sort opacity-50"></i>
                 </th>
-                <th data-i18n="table_header_quantity">Ilość</th>
-                <th data-i18n="table_header_unit">Jednostka</th>
-                <th class="hidden md:table-cell sortable" data-sort-by="category">
+                <th data-i18n="table_header_quantity" class="col-span-2">Ilość</th>
+                <th data-i18n="table_header_unit" class="col-span-1">Jednostka</th>
+                <th class="hidden md:table-cell sortable col-span-2" data-sort-by="category">
                   <span data-i18n="table_header_category">Kategoria</span>
                   <i class="fa-solid fa-sort opacity-50"></i>
                 </th>
-                <th class="hidden md:table-cell sortable" data-sort-by="storage">
+                <th class="hidden md:table-cell sortable col-span-2" data-sort-by="storage">
                   <span data-i18n="table_header_storage">Miejsce</span>
                   <i class="fa-solid fa-sort opacity-50"></i>
                 </th>
-                <th class="text-center hidden md:table-cell sortable" data-sort-by="status">
+                <th class="text-center hidden md:table-cell sortable col-span-1" data-sort-by="status">
                   <span class="tooltip" data-i18n-tip="stock_legend"
                     ><i class="fa-solid fa-circle-info"></i
                   ></span>


### PR DESCRIPTION
## Summary
- Use Tailwind grid utilities for editable product rows to align checkboxes, names, quantities, and status icons.
- Update quantity cell wrapper and header columns for consistent spacing and centering.
- Clean up custom CSS.

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a21eb0132c832aa0298d843f550aa0