### PR TITLE
feat: improve product row hover and active states

### DIFF
--- a/app/static/js/components/product-table.js
+++ b/app/static/js/components/product-table.js
@@ -367,6 +367,14 @@ function highlightRow(tr, p) {
     "opacity-60",
     "font-semibold",
   );
+  tr.classList.add(
+    "transition-colors",
+    "cursor-pointer",
+    "hover:bg-neutral-100",
+    "dark:hover:bg-neutral-800",
+    "active:bg-neutral-200",
+    "dark:active:bg-neutral-900",
+  );
   const level = getStockState(p);
   if (p.main) {
     if (level === "zero")


### PR DESCRIPTION
## Summary
- highlight product rows with cursor and hover/active styles for light and dark modes

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a21eb3cd68832a9f55df140ae4c221