### PR TITLE
Ensure product statuses display and checkboxes depend on edit mode

### DIFF
--- a/app/static/js/components/product-table.js
+++ b/app/static/js/components/product-table.js
@@ -645,7 +645,7 @@ function createFlatRow(p, idx, editable) {
     tr.appendChild(storTd);
     // status
     const statusTd = document.createElement("td");
-    statusTd.className = "status-cell text-center";
+    statusTd.className = "status-cell flex justify-center";
     const status = getStatusIcon(p);
     if (status) {
       statusTd.innerHTML = status.html;
@@ -673,7 +673,7 @@ function createFlatRow(p, idx, editable) {
     storTd.textContent = t(STORAGE_KEYS[p.storage] || p.storage);
     tr.appendChild(storTd);
     const statusTd = document.createElement("td");
-    statusTd.className = "text-center hidden md:table-cell";
+    statusTd.className = "status-cell flex justify-center";
     const status = getStatusIcon(p);
     if (status) {
       statusTd.innerHTML = status.html;
@@ -702,6 +702,11 @@ function renderProductsImmediate() {
   if (!table || !list) return;
   const tbody = table.querySelector("tbody");
   list.innerHTML = "";
+
+  const selectHeader = document.getElementById("select-header");
+  const selectCol = document.getElementById("select-col");
+  selectHeader?.classList.toggle("hidden", !editing);
+  selectCol?.classList.toggle("hidden", !editing);
 
   function renderFallback(message) {
     table.style.display = "";
@@ -985,6 +990,7 @@ function renderProductsImmediate() {
                     u.textContent = t(p.unit, "units");
                     tr.appendChild(u);
                     const s = document.createElement("td");
+                    s.className = "status-cell flex justify-center";
                     const ic = getStatusIcon(p);
                     if (ic) {
                       s.innerHTML = ic.html;
@@ -1000,6 +1006,7 @@ function renderProductsImmediate() {
                     const u = document.createElement("td");
                     u.textContent = t(p.unit, "units");
                     const s = document.createElement("td");
+                    s.className = "status-cell flex justify-center";
                     const ic = getStatusIcon(p);
                     if (ic) {
                       s.innerHTML = ic.html;

--- a/app/static/js/helpers.js
+++ b/app/static/js/helpers.js
@@ -396,13 +396,13 @@ export function getStatusIcon(p) {
   const level = getStockState(p);
   if (level === "zero") {
     return {
-      html: '<i class="fa-regular fa-circle-exclamation text-red-600"></i>',
+      html: '<i class="fa-regular fa-circle-exclamation text-red-600 text-xl"></i>',
       title: t("status_missing"),
     };
   }
   if (level === "low") {
     return {
-      html: '<i class="fa-regular fa-triangle-exclamation text-yellow-500"></i>',
+      html: '<i class="fa-regular fa-triangle-exclamation text-yellow-500 text-xl"></i>',
       title: t("status_low"),
     };
   }

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -347,17 +347,17 @@
             class="table table-zebra table-fixed w-full text-sm"
           >
             <colgroup>
-              <col class="w-[6%]" />
+              <col id="select-col" class="w-[6%] hidden" />
               <col class="w-[24%]" />
               <col class="w-[12%]" />
               <col class="w-[12%]" />
               <col class="w-[17%] hidden md:table-column" />
               <col class="w-[17%] hidden md:table-column" />
-              <col class="w-[12%] hidden md:table-column" />
+              <col class="w-[12%]" />
             </colgroup>
             <thead>
               <tr>
-                <th id="select-header" style="display: none"></th>
+                <th id="select-header" class="hidden"></th>
                 <th data-sort-by="name" class="sortable">
                   <span data-i18n="table_header_name">Nazwa</span>
                   <i class="fa-solid fa-sort opacity-50"></i>
@@ -372,13 +372,13 @@
                   <span data-i18n="table_header_storage">Miejsce</span>
                   <i class="fa-solid fa-sort opacity-50"></i>
                 </th>
-                <th class="text-center hidden md:table-cell sortable" data-sort-by="status">
-                  <span class="tooltip" data-i18n-tip="stock_legend"
-                    ><i class="fa-solid fa-circle-info"></i
-                  ></span>
-                  <span class="status-label" data-i18n="table_header_status"
-                    >Status</span
-                  >
+                <th class="text-center sortable" data-sort-by="status">
+                  <span class="tooltip" data-i18n-tip="stock_legend">
+                    <i class="fa-solid fa-circle-info"></i>
+                  </span>
+                  <span class="status-label hidden md:inline" data-i18n="table_header_status">
+                    Status
+                  </span>
                   <i class="fa-solid fa-sort opacity-50"></i>
                 </th>
               </tr>


### PR DESCRIPTION
## Summary
- Always render status icons and hide selection columns unless edit mode is active
- Make status icons larger and more distinct
- Enable responsive table headers and columns for status and checkbox columns

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a21eb8e4ac832a993da7fe7a96235e