### PR TITLE
Ensure status icons visible and checkboxes only in edit

### DIFF
--- a/app/static/js/components/product-table.js
+++ b/app/static/js/components/product-table.js
@@ -682,7 +682,7 @@ function createFlatRow(p, idx, editable) {
     storTd.textContent = t(STORAGE_KEYS[p.storage] || p.storage);
     tr.appendChild(storTd);
     const statusTd = document.createElement("td");
-    statusTd.className = "text-center hidden md:table-cell";
+    statusTd.className = "status-cell text-center flex items-center justify-center md:table-cell";
     const status = getStatusIcon(p);
     if (status) {
       statusTd.innerHTML = status.html;
@@ -976,7 +976,7 @@ function renderProductsImmediate() {
                   tr.dataset.productId = p.id != null ? p.id : idx;
                   if (editing) {
                     const cbTd = document.createElement("td");
-                    cbTd.className = "checkbox-cell";
+                    cbTd.className = "checkbox-cell flex items-center justify-center";
                     const cb = document.createElement("input");
                     cb.type = "checkbox";
                     cb.className = "checkbox checkbox-sm product-select";
@@ -994,6 +994,7 @@ function renderProductsImmediate() {
                     u.textContent = t(p.unit, "units");
                     tr.appendChild(u);
                     const s = document.createElement("td");
+                    s.className = "status-cell text-center flex items-center justify-center md:table-cell";
                     const ic = getStatusIcon(p);
                     if (ic) {
                       s.innerHTML = ic.html;
@@ -1009,6 +1010,7 @@ function renderProductsImmediate() {
                     const u = document.createElement("td");
                     u.textContent = t(p.unit, "units");
                     const s = document.createElement("td");
+                    s.className = "status-cell text-center flex items-center justify-center md:table-cell";
                     const ic = getStatusIcon(p);
                     if (ic) {
                       s.innerHTML = ic.html;

--- a/app/static/js/helpers.js
+++ b/app/static/js/helpers.js
@@ -396,13 +396,13 @@ export function getStatusIcon(p) {
   const level = getStockState(p);
   if (level === "zero") {
     return {
-      html: '<i class="fa-regular fa-circle-exclamation text-red-600"></i>',
+      html: '<i class="status-icon fa-regular fa-circle-exclamation text-red-600 fa-lg pointer-events-none"></i>',
       title: t("status_missing"),
     };
   }
   if (level === "low") {
     return {
-      html: '<i class="fa-regular fa-triangle-exclamation text-yellow-500"></i>',
+      html: '<i class="status-icon fa-regular fa-triangle-exclamation text-yellow-500 fa-lg pointer-events-none"></i>',
       title: t("status_low"),
     };
   }

--- a/app/static/script.js
+++ b/app/static/script.js
@@ -594,7 +594,7 @@ function initNavigationAndEvents() {
     deleteBtn.style.display = "";
     deleteBtn.disabled = true;
     deleteBtn.textContent = t("delete_selected_button");
-    selectHeader.style.display = "";
+    selectHeader.classList.remove("hidden");
     if (addSection) addSection.style.display = "";
     filterSel?.setAttribute("disabled", "true");
     searchInput?.setAttribute("disabled", "true");
@@ -613,7 +613,7 @@ function initNavigationAndEvents() {
     deleteBtn.style.display = "none";
     deleteBtn.disabled = true;
     deleteBtn.textContent = t("delete_selected_button");
-    selectHeader.style.display = "none";
+    selectHeader.classList.add("hidden");
     if (addSection) addSection.style.display = "none";
     filterSel?.removeAttribute("disabled");
     searchInput?.removeAttribute("disabled");

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -357,7 +357,7 @@
             </colgroup>
             <thead>
               <tr>
-                <th id="select-header" style="display: none" class="col-span-1"></th>
+                <th id="select-header" class="col-span-1 hidden"></th>
                 <th data-sort-by="name" class="sortable col-span-3">
                   <span data-i18n="table_header_name">Nazwa</span>
                   <i class="fa-solid fa-sort opacity-50"></i>
@@ -372,7 +372,7 @@
                   <span data-i18n="table_header_storage">Miejsce</span>
                   <i class="fa-solid fa-sort opacity-50"></i>
                 </th>
-                <th class="text-center hidden md:table-cell sortable col-span-1" data-sort-by="status">
+                <th class="text-center sortable col-span-1 flex items-center justify-center" data-sort-by="status">
                   <span class="tooltip" data-i18n-tip="stock_legend"
                     ><i class="fa-solid fa-circle-info"></i
                   ></span>


### PR DESCRIPTION
## Summary
- Show product status icons on both mobile and desktop layouts
- Hide checkbox column unless in edit mode
- Style status icons for clear distinction from interactive controls

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a2214d4ccc832aa04ed0da8398a181