### PR TITLE
Add placeholder products for testing

### DIFF
--- a/app/data/products.json
+++ b/app/data/products.json
@@ -11,6 +11,32 @@
         "is_spice": false,
         "tags": []
       }
+    ],
+    "category.canned": [
+      {
+        "name": "product.canned",
+        "quantity": 1.0,
+        "unit": "szt",
+        "threshold": 1.0,
+        "main": true,
+        "level": null,
+        "is_spice": false,
+        "tags": []
+      }
+    ]
+  },
+  "storage.fridge": {
+    "category.dairy-eggs": [
+      {
+        "name": "product.dairy",
+        "quantity": 1.0,
+        "unit": "l",
+        "threshold": 1.0,
+        "main": true,
+        "level": null,
+        "is_spice": false,
+        "tags": []
+      }
     ]
   }
 }


### PR DESCRIPTION
## Summary
- seed sample canned and dairy items across different storages
- enable easier loading tests with multiple product categories

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a265f9f65c832a8a2a9640170414d0