### PR TITLE
Add cache headers to domain endpoint

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -14,6 +14,7 @@ from .utils import (
     file_lock,
     file_etag,
     file_mtime_rfc1123,
+    files_cache_metadata,
     load_json,
     load_json_validated,
     normalize_product,
@@ -303,17 +304,49 @@ def domain():
     categories = sorted(
         {p.get("category") for p in products if p.get("category")}
     )
+
+    etag, last_modified, mtime = files_cache_metadata(
+        [PRODUCTS_PATH, UNITS_PATH]
+    )
+    inm = request.headers.get("If-None-Match")
+    ims = request.headers.get("If-Modified-Since")
+    if etag and inm == etag:
+        resp = current_app.response_class(status=304)
+        resp.headers["ETag"] = etag
+        if last_modified:
+            resp.headers["Last-Modified"] = last_modified
+        return resp
+    if ims and mtime:
+        try:
+            since = parsedate_to_datetime(ims)
+            if since >= mtime:
+                resp = current_app.response_class(status=304)
+                if etag:
+                    resp.headers["ETag"] = etag
+                if last_modified:
+                    resp.headers["Last-Modified"] = last_modified
+                return resp
+        except (TypeError, ValueError, OverflowError):
+            pass
+
     first_name = products[0].get("name") if products else None
     logger.info(
-        "domain products=%d units=%d categories=%d first_product=%s",
-        len(products),
-        len(units),
-        len(categories),
-        first_name,
+        {
+            "event": "domain.summary",
+            "products": len(products),
+            "units": len(units),
+            "categories": len(categories),
+            "firstProduct": first_name,
+        }
     )
-    return jsonify(
+    resp = jsonify(
         {"products": products, "units": units, "categories": categories}
     )
+    if etag:
+        resp.headers["ETag"] = etag
+    if last_modified:
+        resp.headers["Last-Modified"] = last_modified
+    return resp
 
 
 @bp.route("/api/search")

--- a/app/utils/__init__.py
+++ b/app/utils/__init__.py
@@ -13,7 +13,7 @@ import threading
 import hashlib
 from datetime import datetime, timezone
 from email.utils import format_datetime
-from typing import Any, Callable, Dict, List, Optional, Tuple
+from typing import Any, Callable, Dict, Iterable, List, Optional, Tuple
 
 import jsonschema
 
@@ -162,6 +162,42 @@ def file_mtime_rfc1123(path: str) -> str:
     ts = os.path.getmtime(path)
     dt = datetime.fromtimestamp(ts, tz=timezone.utc)
     return format_datetime(dt, usegmt=True)
+
+
+def files_cache_metadata(
+    paths: Iterable[str],
+) -> Tuple[Optional[str], Optional[str], Optional[datetime]]:
+    """Return combined cache metadata (ETag, Last-Modified, datetime) for paths.
+
+    Missing files are ignored. If no files exist the tuple of ``(None, None,
+    None)`` is returned. The ``datetime`` entry represents the most recent
+    modification timestamp with microseconds removed to match HTTP semantics.
+    """
+
+    digest = hashlib.sha256()
+    seen_any = False
+    latest_ts: Optional[float] = None
+
+    for path in sorted(set(paths)):
+        try:
+            with open(path, "rb") as fh:
+                digest.update(fh.read())
+            ts = os.path.getmtime(path)
+        except OSError:
+            continue
+
+        seen_any = True
+        if latest_ts is None or ts > latest_ts:
+            latest_ts = ts
+
+    if not seen_any:
+        return None, None, None
+
+    mtime = datetime.fromtimestamp(latest_ts, tz=timezone.utc).replace(
+        microsecond=0
+    )
+    last_modified = format_datetime(mtime, usegmt=True)
+    return digest.hexdigest(), last_modified, mtime
 
 
 def _safe_float(value: Any, default: float = 0.0) -> float:

--- a/tests/test_http_caching.py
+++ b/tests/test_http_caching.py
@@ -88,3 +88,37 @@ def test_recipes_etag_and_conditional_headers():
     finally:
         with open(RECIPES_PATH, "w", encoding="utf-8") as fh:
             fh.write(original)
+
+
+def test_domain_etag_and_conditional_headers():
+    app = create_app()
+    client = app.test_client()
+
+    resp = client.get("/api/domain")
+    assert resp.status_code == 200
+    etag = resp.headers.get("ETag")
+    last_mod = resp.headers.get("Last-Modified")
+    first = resp.get_json()
+
+    assert etag
+    assert last_mod
+
+    resp2 = client.get("/api/domain", headers={"If-None-Match": etag})
+    assert resp2.status_code == 304
+
+    resp3 = client.get("/api/domain", headers={"If-Modified-Since": last_mod})
+    assert resp3.status_code == 304
+
+    def mutate(products):
+        prod = products[0]
+        prod["name"] = prod.get("name", "") + " X"
+
+    original = _modify_file(PRODUCTS_PATH, mutate)
+    try:
+        resp4 = client.get("/api/domain")
+        assert resp4.status_code == 200
+        assert resp4.headers.get("ETag") != etag
+        assert resp4.get_json() != first
+    finally:
+        with open(PRODUCTS_PATH, "w", encoding="utf-8") as fh:
+            fh.write(original)


### PR DESCRIPTION
## Summary
- add combined cache metadata helper for multiple files
- return HTTP caching headers from /api/domain and switch to structured logging
- extend caching tests to cover the domain endpoint

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68d943e26d08832a9bfb2694d643e163